### PR TITLE
Governance: New-Hope + Slash-Topics alignment gate

### DIFF
--- a/governance/CANONICAL_SOURCES.yaml
+++ b/governance/CANONICAL_SOURCES.yaml
@@ -1,0 +1,7 @@
+# sociosphere workspace controller: canonical ownership registry
+namespaces:
+  caps/slash-topics: { canonical_repo: slash-topics }
+  caps/new-hope: { canonical_repo: new-hope }
+  caps/semantic-search-bi: { canonical_repo: prophet-platform }
+hygiene:
+  forbid: [".DS_Store", "__MACOSX"]

--- a/tools/validate_nh_slash_alignment.sh
+++ b/tools/validate_nh_slash_alignment.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NH="${NEW_HOPE_REPO:?set NEW_HOPE_REPO}"
+ST="${SLASH_TOPICS_REPO:?set SLASH_TOPICS_REPO}"
+PACK="${NH_ST_PACK:-}"
+
+for d in "$NH" "$ST"; do
+  test -d "$d" || { echo "[fail] missing dir: $d"; exit 2; }
+  test -f "$d/LICENSE" || { echo "[fail] missing LICENSE in $d"; exit 2; }
+  find "$d" -name '.DS_Store' -print -quit | grep -q . && { echo "[fail] .DS_Store in $d"; exit 2; } || true
+  find "$d" -type d -name '__MACOSX' -print -quit | grep -q . && { echo "[fail] __MACOSX in $d"; exit 2; } || true
+done
+
+if [[ -n "$PACK" && -f "$PACK/tools/validate_newhope_slash_topics.py" ]]; then
+  python3 -m venv .venv-nh-st >/dev/null 2>&1 || true
+  source .venv-nh-st/bin/activate
+  python -m pip install -U pip >/dev/null
+  pip install -q jsonschema
+  python "$PACK/tools/validate_newhope_slash_topics.py" "$PACK" "$NH" "$ST"
+  echo "[ok] nh/slash schema validation passed"
+else
+  echo "[warn] pack validator not found; only hygiene/license validated"
+fi


### PR DESCRIPTION
Add canonical sources registry + validator gate in sociosphere (workspace controller). Validates New-Hope + Slash-Topics sources restored under ~/dev/_staging_restore.