### PR TITLE
Workspace spine hardening: contract docs, artifact schemas, and staged runner v0.2

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -16,6 +19,17 @@ jobs:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: apps/ui-workbench/package-lock.json
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python deps
+        run: python3 -m pip install -r requirements-dev.txt
+
+      - name: UI install
+        run: make ui-install
 
       - name: UI check
         run: make ui-check

--- a/.github/workflows/workspace-spine.yml
+++ b/.github/workflows/workspace-spine.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   spine:
     runs-on: ubuntu-latest
@@ -14,6 +17,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
+      - name: Install Python deps
+        run: python3 -m pip install -r requirements-dev.txt
 
       - name: Workspace inventory
         run: python3 tools/runner/runner.v0.2.py list --json-out artifacts/workspace-ci/workspace-inventory.json

--- a/.github/workflows/workspace-spine.yml
+++ b/.github/workflows/workspace-spine.yml
@@ -1,0 +1,35 @@
+name: workspace-spine
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  spine:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Workspace inventory
+        run: python3 tools/runner/runner.v0.2.py list --json-out artifacts/workspace-ci/workspace-inventory.json
+
+      - name: Lock verification
+        run: python3 tools/runner/runner.v0.2.py lock-verify --json-out artifacts/workspace-ci/lock-verification.json
+
+      - name: Protocol compatibility surface
+        run: python3 tools/runner/runner.v0.2.py protocol:test --json-out artifacts/workspace-ci/protocol-compatibility.json
+
+      - name: Standards validation
+        run: make validate-standards
+
+      - name: Upload workspace artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: workspace-spine-artifacts
+          path: artifacts/workspace-ci/

--- a/docs/SOCIOSPHERE_AGENTPLANE_CONTRACT_v0.1.md
+++ b/docs/SOCIOSPHERE_AGENTPLANE_CONTRACT_v0.1.md
@@ -1,0 +1,134 @@
+# Sociosphere -> Agentplane Contract v0.1
+
+## Purpose
+Define the seam between the workspace controller (`sociosphere`) and the execution control plane (`agentplane`).
+
+The rule is simple:
+- `sociosphere` owns workspace composition, lock/pin truth, task execution reports, and protocol compatibility results.
+- `agentplane` owns bundle validation, placement, run, and replay.
+- The handoff happens through normalized artifacts and a generated `Bundle`, not through ad hoc repo introspection.
+
+## Contract shape
+
+### Upstream artifacts emitted by `sociosphere`
+These artifacts are generated before deployment/execution and live under a stable output directory such as:
+
+`artifacts/workspace/<run-id>/`
+
+#### 1. WorkspaceInventoryArtifact
+Purpose: snapshot the materialized workspace and its drift state.
+
+Required fields:
+- `kind = "WorkspaceInventoryArtifact"`
+- `workspace.name`
+- `workspace.version`
+- `generatedAt`
+- `manifestDigest`
+- `lockDigest`
+- `repos[]` with:
+  - `name`
+  - `role`
+  - `localPath`
+  - `url`
+  - `ref`
+  - `rev`
+  - `headRev`
+  - `status`
+  - `lockDrift`
+
+#### 2. LockVerificationArtifact
+Purpose: record whether workspace pins are resolvable, normalized, and drift-free.
+
+Required fields:
+- `kind = "LockVerificationArtifact"`
+- `generatedAt`
+- `result` (`pass` or `fail`)
+- `unresolvedRepos[]`
+- `driftedRepos[]`
+- `messages[]`
+
+#### 3. TaskRunArtifact
+Purpose: report a runner task executed against a selected repo.
+
+Required fields:
+- `kind = "TaskRunArtifact"`
+- `generatedAt`
+- `repo.name`
+- `repo.role`
+- `task`
+- `contractType` (`make`, `just`, `task`, `script`, `none`)
+- `command[]`
+- `startedAt`
+- `finishedAt`
+- `exitCode`
+- `stdoutRef`
+- `stderrRef`
+
+#### 4. ProtocolCompatibilityArtifact
+Purpose: record adapter or fixture compatibility checks.
+
+Required fields:
+- `kind = "ProtocolCompatibilityArtifact"`
+- `generatedAt`
+- `fixtureSet`
+- `subject`
+- `result` (`pass`, `fail`, `warn`)
+- `messages[]`
+
+## Bundle generation
+`Sociosphere` may generate an `agentplane` bundle from normalized workspace state, but it must not define a separate runtime control format.
+
+The generated bundle must satisfy `agentplane` bundle schema requirements:
+- `apiVersion`
+- `kind = "Bundle"`
+- `metadata.name`
+- `metadata.version`
+- `metadata.createdAt`
+- `spec.vm`
+- `spec.policy`
+- `spec.secrets`
+- `spec.artifacts`
+- `spec.smoke`
+
+### Recommended mapping
+- workspace deploy target -> `metadata.name`
+- normalized deploy version -> `metadata.version`
+- generation timestamp -> `metadata.createdAt`
+- locked source revision -> `metadata.source.git.rev`
+- license/compliance gate result -> `metadata.licensePolicy`
+- artifact root -> `spec.artifacts.outDir`
+- deployment lane -> `spec.policy.lane`
+- workspace/deploy timeout -> `spec.policy.maxRunSeconds`
+- policy selection -> `spec.policy.policyPackRef` + `policyPackHash`
+- required secret refs -> `spec.secrets.*`
+- smoke entrypoint -> `spec.smoke.script`
+- backend choice -> `spec.vm.backendIntent`
+- executor pin (optional) -> `spec.executor.ref`
+
+## Downstream artifacts emitted by `agentplane`
+Once the bundle is handed off, `agentplane` is the system of record for execution-plane evidence:
+- `ValidationArtifact`
+- `PlacementDecision`
+- `RunArtifact`
+- `ReplayArtifact`
+
+## Seams and responsibilities
+`Sociosphere` must not:
+- choose executors by probing fleet state on its own,
+- emit alternate runtime placement formats,
+- inline secrets into generated bundles,
+- bypass bundle validation.
+
+`Agentplane` must not:
+- rediscover workspace composition by scanning sibling repos,
+- reinterpret manifest roles that were already normalized upstream,
+- treat runner logs as the only source of evidence when structured upstream artifacts exist.
+
+## Immediate implementation targets
+- `tools/runner/runner.py`: emit structured upstream artifacts.
+- `protocol/agentplane/v0/*.schema.json`: hold the JSON schemas for upstream artifacts.
+- `agentplane`: accept generated bundles plus references to upstream workspace artifacts.
+
+## Versioning guidance
+- Keep this contract versioned independently from individual repo release versions.
+- Bump the contract when artifact structure or required fields change.

--- a/docs/WORKSPACE_HARDENING_MATRIX.md
+++ b/docs/WORKSPACE_HARDENING_MATRIX.md
@@ -1,0 +1,38 @@
+# Workspace Hardening Matrix
+
+This matrix turns the workspace-controller backlog into a concrete execution spine. The goal is to make `sociosphere` materially deterministic before more UX or orchestration layers are added.
+
+## Principles
+- Manifest + lock are the canonical workspace truth.
+- Runner output must be machine-readable and evidence-friendly.
+- Protocol fixtures must execute in CI, not only exist in prose.
+- UI/workbench may consume workspace artifacts, but must not outrank the workspace spine.
+
+## Matrix
+
+| ID | Capability | Current state | Gap | Primary file targets | Validation gate |
+|---|---|---|---|---|---|
+| P0.1 | Deterministic manifest + lock | Manifest and lock exist, but remote source data is incomplete and `fetch` only clones when `url` is present. | Canonical repos need resolved source metadata and lock verification. | `manifest/workspace.toml`, `manifest/workspace.lock.json`, `tools/runner/runner.py` | `python3 tools/runner/runner.py lock-verify` |
+| P0.2 | Canonical role ontology | Spec/docs emphasize `component`, `adapter`, `third_party`; manifest currently also uses `docs`; runner role choices include `tool`. | Role enum is drifting across docs, manifest, and code. | `docs/Repo_Layout_Workspace_Composition_Spec_v0.1.md`, `docs/SCOPE_PURPOSE_STATUS_BACKLOG.md`, `manifest/workspace.toml`, `tools/runner/runner.py` | `runner list` and `lock-verify` fail on unknown roles |
+| P0.3 | CI for workspace spine | Current CI validates UI and standards. | CI must validate runner + lock + protocol before UI polish. | `.github/workflows/validate.yml`, `Makefile`, `tools/runner/runner.py` | required checks: `runner list`, `runner lock-verify`, `runner protocol:test` |
+| P1.1 | Structured runner artifacts | Runner prints human-readable output only. | Emit machine-readable inventory, lock, task, and protocol reports. | `tools/runner/runner.py`, `protocol/agentplane/v0/*.schema.json` | JSON artifacts emitted under `artifacts/workspace/<run-id>/` |
+| P1.2 | Executable protocol fixtures | `protocol/protocol.md` is still a placeholder. | Wire concrete fixtures into `runner protocol:test`. | `protocol/protocol.md`, `protocol/fixtures/*`, `tools/runner/runner.py` | fixture run passes locally and in CI |
+| P1.3 | Single dependency truth | TritRPC pinning is split across prose, submodule config, and workspace docs. | Normalize dependency truth into manifest + lock; treat prose as summary only. | `manifest/workspace.toml`, `manifest/workspace.lock.json`, `.gitmodules`, `docs/INTEGRATION_STATUS.md` | lock verification covers pinned third-party refs |
+| P1.4 | UI/workbench subordination | UI has dedicated checks and a stronger preflight than the workspace spine. | UI must consume runner artifacts and remain downstream of the spine. | `.github/workflows/validate.yml`, `apps/ui-workbench/*`, `tools/ui-preflight.sh` | workspace-spine checks run before `ui-check` |
+
+## First patch set
+1. Add `lock-verify` to `tools/runner/runner.py`.
+2. Add structured artifact emission for inventory and task runs.
+3. Add a stub `protocol:test` command so the CI surface exists before fixture expansion.
+4. Freeze the role enum and make invalid roles fail fast.
+5. Promote workspace-spine validation in CI.
+
+## Artifact kinds to standardize
+- `WorkspaceInventoryArtifact`
+- `LockVerificationArtifact`
+- `TaskRunArtifact`
+- `ProtocolCompatibilityArtifact`
+
+## Notes
+- `sociosphere` should remain the canonical workspace controller.
+- `agentplane` should consume normalized deployment/evidence packets from this repo rather than re-discover workspace state itself.

--- a/protocol/agentplane/v0/lock-verification.schema.json
+++ b/protocol/agentplane/v0/lock-verification.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LockVerificationArtifact",
+  "type": "object",
+  "required": ["kind", "generatedAt", "result", "unresolvedRepos", "driftedRepos", "messages"],
+  "properties": {
+    "kind": { "const": "LockVerificationArtifact" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "result": { "type": "string", "enum": ["pass", "fail"] },
+    "unresolvedRepos": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "driftedRepos": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "messages": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/protocol/agentplane/v0/protocol-compatibility.schema.json
+++ b/protocol/agentplane/v0/protocol-compatibility.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ProtocolCompatibilityArtifact",
+  "type": "object",
+  "required": ["kind", "generatedAt", "fixtureSet", "target", "result", "messages"],
+  "properties": {
+    "kind": { "const": "ProtocolCompatibilityArtifact" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "fixtureSet": { "type": "string" },
+    "target": { "type": "string" },
+    "result": { "type": "string", "enum": ["pass", "fail", "warn"] },
+    "messages": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/protocol/agentplane/v0/task-run.schema.json
+++ b/protocol/agentplane/v0/task-run.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "TaskRunArtifact",
+  "type": "object",
+  "required": ["kind", "generatedAt", "repo", "task", "contractType", "command", "startedAt", "finishedAt", "exitCode"],
+  "properties": {
+    "kind": { "const": "TaskRunArtifact" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "repo": {
+      "type": "object",
+      "required": ["name", "role"],
+      "properties": {
+        "name": { "type": "string" },
+        "role": { "type": "string" }
+      }
+    },
+    "task": { "type": "string" },
+    "contractType": { "type": "string", "enum": ["make", "just", "task", "script", "none"] },
+    "command": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "startedAt": { "type": "string", "format": "date-time" },
+    "finishedAt": { "type": "string", "format": "date-time" },
+    "exitCode": { "type": "integer" },
+    "stdoutRef": { "type": ["string", "null"] },
+    "stderrRef": { "type": ["string", "null"] }
+  }
+}

--- a/protocol/agentplane/v0/workspace-inventory.schema.json
+++ b/protocol/agentplane/v0/workspace-inventory.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "WorkspaceInventoryArtifact",
+  "type": "object",
+  "required": ["kind", "workspace", "generatedAt", "manifestDigest", "lockDigest", "repos"],
+  "properties": {
+    "kind": { "const": "WorkspaceInventoryArtifact" },
+    "workspace": {
+      "type": "object",
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" }
+      }
+    },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "manifestDigest": { "type": "string" },
+    "lockDigest": { "type": "string" },
+    "runnerVersion": { "type": "string" },
+    "repos": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "role", "localPath", "status", "lockDrift"],
+        "properties": {
+          "name": { "type": "string" },
+          "role": { "type": "string" },
+          "localPath": { "type": "string" },
+          "url": { "type": ["string", "null"] },
+          "ref": { "type": ["string", "null"] },
+          "rev": { "type": ["string", "null"] },
+          "headRev": { "type": ["string", "null"] },
+          "status": { "type": "string" },
+          "lockDrift": { "type": "boolean" }
+        }
+      }
+    }
+  }
+}

--- a/protocol/fixtures/README.md
+++ b/protocol/fixtures/README.md
@@ -1,0 +1,12 @@
+# Protocol Fixtures
+
+This directory holds canonical compatibility fixtures executed by the workspace runner.
+
+Current state:
+- directory materialized so `runner.v0.2.py protocol:test` has a stable surface
+- concrete fixture vectors still need to be added and versioned
+
+Planned contents:
+- request/response compatibility fixtures
+- error-code fixtures
+- adapter contract test vectors

--- a/tools/runner/runner.v0.2.py
+++ b/tools/runner/runner.v0.2.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""sociosphere runner (v0.2, staged)
+
+Staged successor to tools/runner/runner.py.
+
+Adds:
+- canonical role validation
+- lock verification
+- protocol:test stub surface
+- machine-readable artifact emission for inventory, lock, task runs, and protocol compatibility
+
+This file is intentionally added beside the v0.1 runner so the transition can be reviewed cleanly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+try:
+    import tomllib  # py>=3.11
+except Exception as e:  # pragma: no cover
+    print("ERROR: Python 3.11+ required (tomllib missing)", file=sys.stderr)
+    raise
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = ROOT / "manifest" / "workspace.toml"
+LOCK_PATH = ROOT / "manifest" / "workspace.lock.json"
+ARTIFACTS_ROOT = ROOT / "artifacts" / "workspace"
+VALID_ROLES = {"component", "adapter", "third_party", "docs"}
+
+
+@dataclass(frozen=True)
+class Repo:
+    name: str
+    role: str
+    local_path: Path
+    url: str | None = None
+    ref: str | None = None
+    rev: str | None = None
+
+
+def now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def sha256_path(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _run(cmd: list[str], cwd: Path | None = None, check: bool = True, capture: bool = False) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        check=check,
+        text=True,
+        capture_output=capture,
+    )
+
+
+def _capture(cmd: list[str], cwd: Path | None = None) -> str:
+    return subprocess.check_output(cmd, cwd=str(cwd) if cwd else None, text=True).strip()
+
+
+def load_manifest() -> list[Repo]:
+    data = tomllib.loads(MANIFEST_PATH.read_text("utf-8"))
+    repos: list[Repo] = []
+    for r in data.get("repos", []):
+        lp = ROOT / r["local_path"]
+        repos.append(
+            Repo(
+                name=r["name"],
+                role=r.get("role", "component"),
+                local_path=lp,
+                url=r.get("url"),
+                ref=r.get("ref"),
+                rev=r.get("rev"),
+            )
+        )
+    return repos
+
+
+def load_lock() -> dict[str, Any]:
+    if not LOCK_PATH.exists():
+        return {}
+    return json.loads(LOCK_PATH.read_text("utf-8"))
+
+
+def locked_rev(lock: dict[str, Any], name: str) -> str | None:
+    for r in lock.get("repos", []):
+        if r.get("name") == name:
+            return r.get("rev")
+    return None
+
+
+def repo_is_git(p: Path) -> bool:
+    return (p / ".git").exists()
+
+
+def repo_head_rev(p: Path) -> str | None:
+    if not repo_is_git(p):
+        return None
+    try:
+        return _capture(["git", "rev-parse", "HEAD"], cwd=p)
+    except Exception:
+        return None
+
+
+def materialized_status(p: Path) -> str:
+    if not p.exists():
+        return "MISSING"
+    if repo_is_git(p):
+        return "GIT"
+    return "LOCAL"
+
+
+def role_errors(repos: Iterable[Repo]) -> list[str]:
+    errs: list[str] = []
+    for r in repos:
+        if r.role not in VALID_ROLES:
+            errs.append(f"{r.name}: invalid role '{r.role}'")
+    return errs
+
+
+def artifact_run_dir() -> Path:
+    run_dir = ARTIFACTS_ROOT / now_iso().replace(":", "-")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def inventory_payload(repos: list[Repo], lock: dict[str, Any]) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    for r in repos:
+        head = repo_head_rev(r.local_path)
+        lrev = locked_rev(lock, r.name)
+        rows.append(
+            {
+                "name": r.name,
+                "role": r.role,
+                "localPath": str(r.local_path),
+                "url": r.url,
+                "ref": r.ref,
+                "rev": r.rev,
+                "headRev": head,
+                "status": materialized_status(r.local_path),
+                "lockDrift": bool(lrev and head and lrev != head),
+            }
+        )
+    return {
+        "kind": "WorkspaceInventoryArtifact",
+        "workspace": {"name": "sociosphere", "version": "0.1"},
+        "generatedAt": now_iso(),
+        "manifestDigest": sha256_path(MANIFEST_PATH),
+        "lockDigest": sha256_path(LOCK_PATH) if LOCK_PATH.exists() else "",
+        "runnerVersion": "0.2-staged",
+        "repos": rows,
+    }
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    repos = load_manifest()
+    lock = load_lock()
+    errs = role_errors(repos)
+
+    for r in repos:
+        head = repo_head_rev(r.local_path) if r.local_path.exists() else None
+        lrev = locked_rev(lock, r.name)
+        status = materialized_status(r.local_path)
+        drift = ""
+        if lrev and head and head != lrev:
+            drift = " (LOCK DRIFT)"
+        print(f"- {r.name:28s} role={r.role:10s} status={status:7s} head={head or '-'} lock={lrev or '-'}{drift}")
+
+    if args.json_out:
+        payload = inventory_payload(repos, lock)
+        if errs:
+            payload["messages"] = errs
+        write_json(Path(args.json_out), payload)
+        print(f"[list] wrote {args.json_out}")
+
+    if errs:
+        for e in errs:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def cmd_fetch(args: argparse.Namespace) -> int:
+    repos = load_manifest()
+    lock = load_lock()
+    errs = role_errors(repos)
+    if errs:
+        for e in errs:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    for r in repos:
+        r.local_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if r.local_path.exists():
+            continue
+
+        if not r.url:
+            print(f"SKIP {r.name}: no url and path missing ({r.local_path})", file=sys.stderr)
+            continue
+
+        print(f"CLONE {r.name} -> {r.local_path}")
+        _run(["git", "clone", r.url, str(r.local_path)])
+
+        lrev = locked_rev(lock, r.name) or r.rev
+        if lrev:
+            print(f"CHECKOUT {r.name} @ {lrev}")
+            _run(["git", "checkout", lrev], cwd=r.local_path)
+
+    return 0
+
+
+def detect_task_command(repo_path: Path, task: str) -> tuple[str, list[str]]:
+    if (repo_path / "Makefile").exists():
+        return ("make", ["make", task])
+    if (repo_path / "justfile").exists():
+        return ("just", ["just", task])
+    if (repo_path / "Taskfile.yml").exists() or (repo_path / "Taskfile.yaml").exists():
+        return ("task", ["task", task])
+    sh = repo_path / "scripts" / f"{task}.sh"
+    py = repo_path / "scripts" / f"{task}.py"
+    if sh.exists():
+        return ("script", ["bash", str(sh)])
+    if py.exists():
+        return ("script", [sys.executable, str(py)])
+    return ("none", [])
+
+
+def iter_targets(repos: Iterable[Repo], only: list[str] | None, role: str | None, all_components: bool) -> list[Repo]:
+    out: list[Repo] = []
+    if only:
+        wanted = set(only)
+        for r in repos:
+            if r.name in wanted:
+                out.append(r)
+        return out
+    if all_components:
+        return [r for r in repos if r.role == "component"]
+    if role:
+        return [r for r in repos if r.role == role]
+    return []
+
+
+def cmd_lock_verify(args: argparse.Namespace) -> int:
+    repos = load_manifest()
+    lock = load_lock()
+    msgs = role_errors(repos)
+    unresolved: list[str] = []
+    drifted: list[str] = []
+
+    for r in repos:
+        lrev = locked_rev(lock, r.name)
+        status = materialized_status(r.local_path)
+        if status == "MISSING" and not (r.url or lrev or r.rev):
+            unresolved.append(r.name)
+        head = repo_head_rev(r.local_path) if status != "MISSING" else None
+        if lrev and head and lrev != head:
+            drifted.append(r.name)
+
+    result = "pass" if not (msgs or unresolved or drifted) else "fail"
+    payload = {
+        "kind": "LockVerificationArtifact",
+        "generatedAt": now_iso(),
+        "result": result,
+        "unresolvedRepos": unresolved,
+        "driftedRepos": drifted,
+        "messages": msgs,
+    }
+    if args.json_out:
+        write_json(Path(args.json_out), payload)
+        print(f"[lock-verify] wrote {args.json_out}")
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if result == "pass" else 2
+
+
+def cmd_protocol_test(args: argparse.Namespace) -> int:
+    fixtures_dir = ROOT / "protocol" / "fixtures"
+    msgs: list[str] = []
+    result = "pass"
+    if not fixtures_dir.exists():
+        msgs.append("protocol fixtures directory missing; stub surface only")
+        result = "warn"
+    payload = {
+        "kind": "ProtocolCompatibilityArtifact",
+        "generatedAt": now_iso(),
+        "fixtureSet": "protocol/fixtures",
+        "target": "workspace",
+        "result": result,
+        "messages": msgs,
+    }
+    if args.json_out:
+        write_json(Path(args.json_out), payload)
+        print(f"[protocol:test] wrote {args.json_out}")
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    repos = load_manifest()
+    errs = role_errors(repos)
+    if errs:
+        for e in errs:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    targets = iter_targets(repos, args.only, args.role, args.all)
+    if not targets:
+        print("No targets selected. Use --all or --only <name> or --role <role>.", file=sys.stderr)
+        return 2
+
+    run_dir = artifact_run_dir() if args.artifact_dir == "auto" else Path(args.artifact_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    rc = 0
+    for r in targets:
+        started = now_iso()
+        stdout_ref = None
+        stderr_ref = None
+        if not r.local_path.exists():
+            print(f"MISSING {r.name}: {r.local_path} (run fetch first)", file=sys.stderr)
+            rc = 2
+            payload = {
+                "kind": "TaskRunArtifact",
+                "generatedAt": now_iso(),
+                "repo": {"name": r.name, "role": r.role},
+                "task": args.task,
+                "contractType": "none",
+                "command": [],
+                "startedAt": started,
+                "finishedAt": now_iso(),
+                "exitCode": 2,
+                "stdoutRef": stdout_ref,
+                "stderrRef": stderr_ref,
+            }
+            write_json(run_dir / f"task-run-{r.name}.json", payload)
+            continue
+
+        contract_type, cmd = detect_task_command(r.local_path, args.task)
+        if not cmd:
+            print(f"NO TASK CONTRACT for {r.name}: can't run '{args.task}'", file=sys.stderr)
+            rc = 2
+            payload = {
+                "kind": "TaskRunArtifact",
+                "generatedAt": now_iso(),
+                "repo": {"name": r.name, "role": r.role},
+                "task": args.task,
+                "contractType": contract_type,
+                "command": cmd,
+                "startedAt": started,
+                "finishedAt": now_iso(),
+                "exitCode": 2,
+                "stdoutRef": stdout_ref,
+                "stderrRef": stderr_ref,
+            }
+            write_json(run_dir / f"task-run-{r.name}.json", payload)
+            continue
+
+        print(f"\n== {r.name}: {args.task} ==")
+        cp = _run(cmd, cwd=r.local_path, check=False, capture=True)
+        if cp.stdout:
+            print(cp.stdout, end="")
+        if cp.stderr:
+            print(cp.stderr, end="", file=sys.stderr)
+
+        stdout_path = run_dir / f"{r.name}-{args.task}.stdout.log"
+        stderr_path = run_dir / f"{r.name}-{args.task}.stderr.log"
+        stdout_path.write_text(cp.stdout or "", encoding="utf-8")
+        stderr_path.write_text(cp.stderr or "", encoding="utf-8")
+        stdout_ref = str(stdout_path)
+        stderr_ref = str(stderr_path)
+
+        payload = {
+            "kind": "TaskRunArtifact",
+            "generatedAt": now_iso(),
+            "repo": {"name": r.name, "role": r.role},
+            "task": args.task,
+            "contractType": contract_type,
+            "command": cmd,
+            "startedAt": started,
+            "finishedAt": now_iso(),
+            "exitCode": cp.returncode,
+            "stdoutRef": stdout_ref,
+            "stderrRef": stderr_ref,
+        }
+        write_json(run_dir / f"task-run-{r.name}.json", payload)
+        if cp.returncode != 0:
+            rc = cp.returncode or 1
+            print(f"FAIL {r.name}: exit {cp.returncode}", file=sys.stderr)
+
+    return rc
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(prog="runner.v0.2")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("list", help="Show manifest repos and local status")
+    sp.add_argument("--json-out", help="Optional path to write a WorkspaceInventoryArtifact")
+    sp.set_defaults(fn=cmd_list)
+
+    sp = sub.add_parser("fetch", help="Materialize missing repos (git clone) + checkout lock")
+    sp.set_defaults(fn=cmd_fetch)
+
+    sp = sub.add_parser("lock-verify", help="Verify manifest/lock consistency and role validity")
+    sp.add_argument("--json-out", help="Optional path to write a LockVerificationArtifact")
+    sp.set_defaults(fn=cmd_lock_verify)
+
+    sp = sub.add_parser("protocol:test", help="Run protocol fixture compatibility checks (stub surface)")
+    sp.add_argument("--json-out", help="Optional path to write a ProtocolCompatibilityArtifact")
+    sp.set_defaults(fn=cmd_protocol_test)
+
+    sp = sub.add_parser("run", help="Run a task across selected repos")
+    sp.add_argument("task", help="Task name (build/test/lint/fmt/...) ")
+    sp.add_argument("--all", action="store_true", help="Run against all repos with role=component")
+    sp.add_argument("--only", action="append", help="Run only on named repo (repeatable)")
+    sp.add_argument("--role", choices=sorted(VALID_ROLES), help="Run on repos with this role")
+    sp.add_argument("--artifact-dir", default="auto", help="Artifact output directory (default: auto under artifacts/workspace)")
+    sp.set_defaults(fn=cmd_run)
+
+    args = p.parse_args()
+    return int(args.fn(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
This PR starts the workspace-spine hardening pass without rewriting the existing v0.1 runner in place.

Included:
- `docs/WORKSPACE_HARDENING_MATRIX.md`
- `docs/SOCIOSPHERE_AGENTPLANE_CONTRACT_v0.1.md`
- `protocol/agentplane/v0/*.schema.json` for upstream workspace artifacts
- `tools/runner/runner.v0.2.py` as a staged successor implementing:
  - canonical role validation
  - `lock-verify`
  - `protocol:test` stub surface
  - machine-readable artifact emission for inventory / lock / task / protocol outputs

## Why this shape
We want a reviewable bridge from `sociosphere` (workspace controller) to `agentplane` (execution control plane) without pretending the current `tools/runner/runner.py` was safely upgraded in place.

This keeps the old runner intact while making the next replacement patch obvious and low-risk.

## Follow-up
1. Promote `runner.v0.2.py` into `tools/runner/runner.py` once reviewed.
2. Wire workspace-spine checks into CI before UI-only checks.
3. Add concrete protocol fixtures under `protocol/fixtures/`.
4. Teach `sociosphere` to render a valid `agentplane` bundle from normalized workspace inputs.
