### PR TITLE
Fix standards validation when PyYAML is unavailable

### DIFF
--- a/standards/qes/tools/validate_qes_contracts.py
+++ b/standards/qes/tools/validate_qes_contracts.py
@@ -1,24 +1,61 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-from pathlib import Path
 import json
+import re
 import sys
+from pathlib import Path
 
 try:
     import yaml  # type: ignore
 except Exception:
-    print("ERR: PyYAML not installed. Install with: python3 -m pip install pyyaml", file=sys.stderr)
-    raise
+    yaml = None
 
 ROOT = Path(__file__).resolve().parents[1]  # standards/qes
 CAT = ROOT / "schemas/topics/topic-catalog.v1.yaml"
+
+
+def _parse_topic_catalog_without_yaml(raw: str) -> list[dict[str, str]]:
+    """
+    Fallback parser for the limited structure of topic-catalog.v1.yaml.
+
+    This intentionally supports only the subset we validate here:
+    - topics:
+      - name: ...
+        schema: ...
+    """
+    topics: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        topic_start = re.match(r"-\s+name:\s*(.+)", stripped)
+        if topic_start:
+            if current:
+                topics.append(current)
+            current = {"name": topic_start.group(1).strip()}
+            continue
+        schema = re.match(r"schema:\s*(.+)", stripped)
+        if schema and current is not None:
+            current["schema"] = schema.group(1).strip()
+    if current:
+        topics.append(current)
+    return topics
 
 def main() -> int:
     if not CAT.exists():
         print(f"ERR: missing topic catalog: {CAT}", file=sys.stderr)
         return 2
-    doc = yaml.safe_load(CAT.read_text())
-    topics = doc.get("topics", [])
+    raw_catalog = CAT.read_text()
+    if yaml is None:
+        print(
+            "WARN: PyYAML not installed; using fallback parser for topic-catalog.v1.yaml",
+            file=sys.stderr,
+        )
+        topics = _parse_topic_catalog_without_yaml(raw_catalog)
+    else:
+        doc = yaml.safe_load(raw_catalog)
+        topics = doc.get("topics", [])
     errs = 0
     for t in topics:
         schema_rel = t.get("schema")


### PR DESCRIPTION
### Motivation
- `make validate` failed in environments without `PyYAML`, preventing repository validation even though the `topic-catalog.v1.yaml` structure is simple. 
- Allow validation to run in lean environments (CI or minimal containers) without requiring `PyYAML` to be installed.

### Description
- Stop crashing at import time by falling back to `yaml = None` when `import yaml` fails in `standards/qes/tools/validate_qes_contracts.py`.
- Add a lightweight fallback parser `_parse_topic_catalog_without_yaml` that extracts `topics` entries and their `name` and `schema` fields using regex for the limited structure the validator needs. 
- Use the fallback parser with a warning when `PyYAML` is not available, and preserve existing `yaml.safe_load` behavior when it is present.
- No other functional changes to schema existence or JSON parsing checks were made.

### Testing
- Ran `make validate`, which completed successfully and printed the fallback warning when `PyYAML` was absent. 
- Ran `python3 standards/qes/tools/validate_qes_contracts.py`, which completed successfully and reported `OK: topic catalog schemas exist and JSON parses`. 
- The validator exercised both fallback and normal paths as appropriate during testing and returned success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa29de9088323a71052e163f95857)