### PR TITLE
Add MAIPJ live-receipt workspace manifest extensions v0.1

### DIFF
--- a/spec/workspace/manifest_extensions.yaml
+++ b/spec/workspace/manifest_extensions.yaml
@@ -1,0 +1,34 @@
+# SocioSphere workspace manifest extensions for live MAIPJ receipt integration
+version: 0.1
+workspace:
+  id: workspace://gakw/hybrid-warm-answer
+  manifest_digest: sha256:manifest-example
+  lock_digest: sha256:lock-example
+benchmark:
+  family: assistive_knowledge_work
+  case_id: gakw_hybrid_warm_answer
+  utility_rubric_version: gakw-utility-v0.1
+  receipt_schema_version: maipj-run-receipt-v0.1
+execution:
+  planner_version: agentplane-0.1.0
+  replay_required: true
+  accounting_boundary: device+host+allocated-network+storage+cooling
+context:
+  packs:
+    - id: topicpack://slash-topics/community-health@1
+      digest: sha256:pack01
+      locality_preference: warm-local
+    - id: topicpack://slash-topics/governance@1
+      digest: sha256:pack03
+      locality_preference: warm-local
+policy:
+  bundle_id: hdt-policy-2026-04
+  approval_mode: human-when-high-risk
+  risk_class: high
+transport:
+  protocol: tritrpc
+  deterministic_envelope: true
+telemetry:
+  emit_raw_events: true
+  emit_receipt: true
+  evidence_required: true


### PR DESCRIPTION
## Summary

This PR adds the first workspace-manifest extension example for MAIPJ live receipt integration.

## Why

SocioSphere is the workspace/filesystem authority in the AI+HW+State stack. The live receipt path needs a place to bind:

- benchmark family + case
- receipt schema version
- replay requirement
- policy bundle reference
- context pack references
- telemetry emission requirements

This YAML example is the first concrete workspace-side binding for the GAKW hybrid warm-answer path.

## File added

- `spec/workspace/manifest_extensions.yaml`

## Review focus

1. Whether this belongs under `spec/workspace/`.
2. Whether the vocabulary is right for benchmark binding.
3. Whether additional workspace/lock provenance fields are needed immediately.

## Follow-ons

- workspace event schema
- lock/manifest vocabulary freeze
- binding to real workspace identifiers in a live trace