### PR TITLE
Add workspace event schema for live receipt paths v0.1

### DIFF
--- a/schemas/events/workspace-events.schema.json
+++ b/schemas/events/workspace-events.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.local/sociosphere/schemas/events/workspace-events.schema.json",
+  "title": "SocioSphere Workspace Event",
+  "type": "object",
+  "required": [
+    "event_id",
+    "trace_id",
+    "span_id",
+    "event_type",
+    "ts",
+    "producer",
+    "payload"
+  ],
+  "properties": {
+    "event_id": { "type": "string" },
+    "trace_id": { "type": "string" },
+    "span_id": { "type": "string" },
+    "parent_span_id": { "type": "string" },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "workspace.resolved",
+        "workspace.locked",
+        "workspace.materialized"
+      ]
+    },
+    "ts": { "type": "string", "format": "date-time" },
+    "producer": { "type": "string", "const": "sociosphere" },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "workspace_manifest_id": { "type": "string" },
+        "workspace_lock_digest": { "type": "string" },
+        "benchmark_family": { "type": "string" },
+        "case_id": { "type": "string" },
+        "mission_weight": { "type": "number" },
+        "utility_rubric_version": { "type": "string" },
+        "latency_slo_ms": { "type": "number" },
+        "risk_class": { "type": "string" },
+        "materialization_root": { "type": "string" },
+        "component_count": { "type": "integer" }
+      },
+      "required": ["workspace_manifest_id"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the first normalized workspace event schema for live receipt paths in `sociosphere`.

## Why

The prior PR added a manifest extension example. This PR adds the event schema needed for real workspace-side emission so `workspace.resolved`, `workspace.locked`, and `workspace.materialized` can participate in receipt assembly without inventing ad hoc payloads per workflow.

## File added

- `schemas/events/workspace-events.schema.json`

## Review focus

1. Whether the event names are right.
2. Whether the payload fields are the correct minimum set for the first live path.
3. Whether schema placement is appropriate inside `sociosphere`.

## Follow-ons

- emit live workspace events from actual resolution/materialization paths
- bind schema references into benchmarked workspace runs