### PR TITLE
Add wave-cycle intent audit artifact and link as authoritative closeout

### DIFF
--- a/status/ecosystem-status.yaml
+++ b/status/ecosystem-status.yaml
@@ -9,6 +9,7 @@ metadata:
   total_repos_tracked: 53
   total_open_prs: 81
   last_analysis_by: "research-socioprophet-ecosystem (2026-04-06)"
+  authoritative_closeout_artifact: "status/intent-audit-2026-04-06.md"
 
 # ── Phase 0: Standards & Foundational ────────────────────────────────────────
 phase_0:

--- a/status/intent-audit-2026-04-06.md
+++ b/status/intent-audit-2026-04-06.md
@@ -1,0 +1,51 @@
+# Intent Audit — 2026-04-06
+
+- **Wave cycle:** Baseline closeout sweep (generated at wave-cycle end on 2026-04-06)
+- **Scope:** Merged PRs detected since prior in-repo audit artifact (none existed before this file)
+- **Authoritative closeout artifact:** `status/intent-audit-2026-04-06.md`
+
+## Merged PR audit records
+
+### 1) sociosphere#9 — Clarify ontology integration state
+
+- **PR identifier:** `#9`
+- **Repository:** `sociosphere`
+- **Title:** `Clarify ontology integration state`
+- **Merge commit SHA:** `e69cbafbc575d165b2997e50bdf85681eccf09ee`
+
+#### Extracted intent claims (`intent_checklist`)
+
+> No explicit `intent_checklist` artifact was found for this merged PR in the repository snapshot. Claims below are reconstructed from merge metadata and landing content.
+
+- Clarify current ontology integration state in Sociosphere documentation.
+- Make scope/current-state/backlog boundaries explicit.
+- Ensure top-level README points operators to the authoritative scope/backlog document.
+
+#### Implementation evidence (exact paths + changed identifiers)
+
+- **Path:** `docs/SCOPE_PURPOSE_STATUS_BACKLOG.md`
+  - **Identifiers:**
+    - `## Ontology integration (broader repos)`
+    - `### Functional state (what exists today)`
+    - `### Self-describing state (what should be encoded in metadata)`
+    - `### Integration and reasoning model`
+- **Path:** `README.md`
+  - **Identifiers:**
+    - `## Scope and backlog`
+    - Link target `docs/SCOPE_PURPOSE_STATUS_BACKLOG.md`
+
+#### Verification result
+
+| Intent claim | Result | Notes |
+|---|---|---|
+| Clarify ontology integration state | satisfied | Dedicated ontology integration section and structured sub-sections are present. |
+| Clarify scope/current-state/backlog boundaries | satisfied | Purpose, scope, current state, and backlog sections are explicitly present. |
+| Provide top-level navigation to scope/backlog doc | satisfied | README contains a dedicated section that points to the scope/backlog doc. |
+| Preserve explicit PR-scoped `intent_checklist` traceability | missed | No explicit `intent_checklist` block found for this merged PR. |
+
+## Follow-up backlog entries created for partial/missed items
+
+Added to `workbench/backlog/INTEGRATED_BACKLOG.md`:
+
+1. Add a standardized `intent_checklist` block to every PR and persist it in-repo for auditability.
+2. Add a lightweight validator/check to fail CI when merged PR closeout data lacks `intent_checklist` provenance links.

--- a/workbench/backlog/INTEGRATED_BACKLOG.md
+++ b/workbench/backlog/INTEGRATED_BACKLOG.md
@@ -14,3 +14,7 @@
 
 ## P3 SourceOS integration
 - [ ] integration spec + bootstrap script + systemd units (SourceOS)
+
+## Intent audit follow-ups (2026-04-06)
+- [ ] Require explicit `intent_checklist` content for each PR and persist it in-repo as part of closeout artifacts (`status/intent-audit-YYYY-MM-DD.md`).
+- [ ] Add CI validation that blocks closeout completion when a merged PR lacks intent provenance (`intent_checklist` source reference + verification status).


### PR DESCRIPTION
### Motivation
- Provide a repeatable end-of-wave closeout artifact that captures merged-PR intent, implementation evidence, and verification results for auditability.
- Ensure the ecosystem status metadata points to a canonical closeout document so downstream workflows can reference a single authoritative audit.
- Capture follow-up work for any partial/missed verification items so the backlog includes required remediation tasks.

### Description
- Add `status/intent-audit-2026-04-06.md` containing an audit record for the merged PR `sociosphere#9` with PR id/repo/title, merge commit SHA, reconstructed `intent_checklist` claims, exact implementation evidence (file paths and changed identifiers), verification results, and follow-up items.
- Update `status/ecosystem-status.yaml` to include `authoritative_closeout_artifact: "status/intent-audit-2026-04-06.md"` in the metadata so the status snapshot references the closeout artifact.
- Append two follow-up tasks to `workbench/backlog/INTEGRATED_BACKLOG.md` to require explicit `intent_checklist` persistence and CI validation for intent provenance.

### Testing
- Ran `git diff --check` which produced no whitespace or index errors and therefore succeeded.
- Verified presence of the new audit file with `test -f status/intent-audit-2026-04-06.md` which succeeded.
- Attempted to run the reporter with `python engines/status_reporter.py report --format json` which failed due to the environment missing the `PyYAML` dependency (`ModuleNotFoundError: No module named 'yaml'`).
- Validated YAML parsing of updated status files was not possible here because `PyYAML` is not installed, so runtime report generation should be re-run in CI or a dev environment with `PyYAML` available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32fb6f7bc832393d11e4c0b485964)