### PR TITLE
Wave 3: Add Chain Validation for FIPS PR chain and persist status

### DIFF
--- a/governance/MERGE-ORDER.md
+++ b/governance/MERGE-ORDER.md
@@ -66,6 +66,29 @@ Also in wave 3:
 - `socioprophet-standards-storage` #5 (ADR-040 twin economy) — standalone, merge after #14
 - `socioprophet-standards-storage` #13 (shared schemas) — prerequisite for Wave 4
 
+### Chain Validation
+
+Validation scope: `socioprophet-standards-storage` PRs #14, #15, #16, #18, #19, #17, #20, #21, #22, #23.
+
+| PR | Expected base | Validation result |
+|----|---------------|-------------------|
+| #14 | `main` | ✅ pass (root of chain) |
+| #15 | `#14` branch | ❌ fail (currently targets `main`) |
+| #16 | `#15` branch | ❌ fail (currently targets `main`) |
+| #18 | `#16` branch | ❌ fail (currently targets `main`) |
+| #19 | `#18` branch | ❌ fail (currently targets `main`) |
+| #17 | `#19` branch | ❌ fail (currently targets `main`) |
+| #20 | `#17` branch | ❌ fail (currently targets `main`) |
+| #21 | `#20` branch | ❌ fail (currently targets `main`) |
+| #22 | `#21` branch | ❌ fail (currently targets `main`) |
+| #23 | `#22` branch | ❌ fail (currently targets `main`) |
+
+Incremental diff-scope validation relative to immediate predecessor is **blocked** until the base-branch chain is corrected for all 10 PRs.
+
+**Recomputed merge order status**: **not recomputed**. Per policy, recomputation can only occur after all 10 base relationships pass.
+
+**Merge blocker**: Any FIPS PR in this chain targeting `main` directly (other than #14) is blocked from merge until rebased to the immediate predecessor branch in the documented chain.
+
 ---
 
 ## Wave 4 — Slice work (depends on Wave 3 #13)

--- a/status/pr-register.yaml
+++ b/status/pr-register.yaml
@@ -137,6 +137,52 @@ promote_and_review:
 # ── Priority 3: FIPS cluster — triage and chain ──────────────────────────────
 fips_triage:
   description: "10 FIPS PRs in socioprophet-standards-storage must be chained before merge. All currently target main independently."
+  chain_validation:
+    validated_on: "2026-04-06"
+    chain_validated: false
+    merge_order_recomputed: false
+    merge_blocker: "PRs #15, #16, #18, #19, #17, #20, #21, #22, and #23 incorrectly target main; only #14 may target main as the chain root."
+    checks:
+      - pr: 14
+        expected_base: main
+        base_valid: true
+        incremental_diff_valid: true
+      - pr: 15
+        expected_base: 14
+        base_valid: false
+        incremental_diff_valid: false
+      - pr: 16
+        expected_base: 15
+        base_valid: false
+        incremental_diff_valid: false
+      - pr: 18
+        expected_base: 16
+        base_valid: false
+        incremental_diff_valid: false
+      - pr: 19
+        expected_base: 18
+        base_valid: false
+        incremental_diff_valid: false
+      - pr: 17
+        expected_base: 19
+        base_valid: false
+        incremental_diff_valid: false
+      - pr: 20
+        expected_base: 17
+        base_valid: false
+        incremental_diff_valid: false
+      - pr: 21
+        expected_base: 20
+        base_valid: false
+        incremental_diff_valid: false
+      - pr: 22
+        expected_base: 21
+        base_valid: false
+        incremental_diff_valid: false
+      - pr: 23
+        expected_base: 22
+        base_valid: false
+        incremental_diff_valid: false
   recommended_merge_order:
     - pr: 14
       title: "FIPS authority docs"


### PR DESCRIPTION
### Motivation
- Ensure the Wave 3 FIPS cluster (`socioprophet-standards-storage` PRs #14→#23) is explicitly chain-gated so merge sequencing is only recomputed after the base-branch chain is correct. 
- Make base-branch and incremental diff-scope checks explicit and surface a merge-blocker when PRs incorrectly target `main`. 
- Persist the validation outcomes in repository status so automation and reviewers can act on a single source of truth.

### Description
- Add a `Chain Validation` subsection to `governance/MERGE-ORDER.md` documenting expected base relationships for PRs `#14, #15, #16, #18, #19, #17, #20, #21, #22, #23` and marking current validation results and gating rules. 
- Add `fips_triage.chain_validation` to `status/pr-register.yaml` with `validated_on`, `chain_validated: false`, `merge_order_recomputed: false`, a `merge_blocker` message, and per-PR `checks` entries containing `expected_base`, `base_valid`, and `incremental_diff_valid`. 
- Explicitly block incremental diff-scope validation and recomputation of merge order until all 10 base relationships pass, and mark any non-root PR targeting `main` as a merge blocker.

### Testing
- Validated `status/pr-register.yaml` syntax with Ruby using `ruby -e "require 'yaml'; YAML.load_file('status/pr-register.yaml'); puts 'YAML OK'"`, which succeeded. 
- Attempted YAML validation via Python (`yaml.safe_load`) which failed due to a missing `PyYAML` module in the environment, indicating the file is syntactically fine but the test runner lacked the dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32fb3e8248323a5b6539fea612c8f)