### PR TITLE
Add companion PR group and companion-PR merge policy for sociosphere#19 & socioprophet#257

### DIFF
--- a/governance/MERGE-ORDER.md
+++ b/governance/MERGE-ORDER.md
@@ -9,6 +9,17 @@
 2. **Schemas before consumers** — Shared schema definitions before anything that reads/writes them.
 3. **Specs before fixtures** — Protocol specs before reference fixtures.
 4. **No cascading conflicts** — Each PR in a cluster must target the previous one's merged result, not `main`.
+5. **Companion PR lockstep** — Companion PR pairs must complete review and merge in the same wave window.
+
+### Companion PR Policy (Required)
+
+For companion PR pair `sociosphere#19` and `socioprophet#257`:
+
+1. **Joint review sign-off is required on both PRs before either PR merges.**
+2. **Each PR must include an explicit compatibility note confirming terminology alignment** (for example, boundary/doctrine term alignment).
+3. **If one companion PR changes materially, re-request review on the paired PR before merge.**
+4. **Merge both within the same wave window, or defer both.**
+5. **After merge, record the final merged commit SHAs for both PRs in `status/ecosystem-status.yaml`.**
 
 ---
 

--- a/status/ecosystem-status.yaml
+++ b/status/ecosystem-status.yaml
@@ -10,17 +10,17 @@ metadata:
   total_open_prs: 81
   last_analysis_by: "research-socioprophet-ecosystem (2026-04-06)"
 
-companion_pr_groups:
-  - id: workspace-os-boundary-liberty-doctrine
-    prs:
-      - repo: sociosphere
-        pr: 19
-        merged_sha: pending
-      - repo: socioprophet
-        pr: 257
-        merged_sha: pending
-    merge_wave: pending
-    notes: "Record final merged SHAs once both companion PRs merge in the same wave window."
+companion_pr_group:
+  id: workspace-os-boundary-liberty-doctrine
+  prs:
+    - repo: sociosphere
+      pr: 19
+      final_merged_sha: null
+    - repo: socioprophet
+      pr: 257
+      final_merged_sha: null
+  merge_wave: null
+  notes: "Populate final merged SHAs for both PRs once the paired merge is completed."
 
 # ── Phase 0: Standards & Foundational ────────────────────────────────────────
 phase_0:

--- a/status/ecosystem-status.yaml
+++ b/status/ecosystem-status.yaml
@@ -10,6 +10,18 @@ metadata:
   total_open_prs: 81
   last_analysis_by: "research-socioprophet-ecosystem (2026-04-06)"
 
+companion_pr_groups:
+  - id: workspace-os-boundary-liberty-doctrine
+    prs:
+      - repo: sociosphere
+        pr: 19
+        merged_sha: pending
+      - repo: socioprophet
+        pr: 257
+        merged_sha: pending
+    merge_wave: pending
+    notes: "Record final merged SHAs once both companion PRs merge in the same wave window."
+
 # ── Phase 0: Standards & Foundational ────────────────────────────────────────
 phase_0:
   description: "Standards and governance foundations — must land first."

--- a/status/pr-register.yaml
+++ b/status/pr-register.yaml
@@ -11,23 +11,23 @@ metadata:
   needs_triage: 17
   draft_active: 44
 
-companion_groups:
-  - id: workspace-os-boundary-liberty-doctrine
-    description: "Paired documentation PRs that must be reviewed and merged together."
-    prs:
-      - repo: sociosphere
-        pr: 19
-      - repo: socioprophet
-        pr: 257
-    policy:
-      joint_review_required: true
-      compatibility_note_required: true
-      rereview_on_material_change: true
-      same_wave_merge_required: true
-    status:
-      review_state: pending_joint_signoff
-      compatibility_note: pending
-      merge_wave: pending
+companion_group:
+  id: workspace-os-boundary-liberty-doctrine
+  description: "Paired documentation PRs that must be reviewed and merged together."
+  prs:
+    - repo: sociosphere
+      pr: 19
+    - repo: socioprophet
+      pr: 257
+  policy:
+    joint_review_signoff_required: true
+    explicit_compatibility_note_required: true
+    rereview_on_material_change_required: true
+    same_wave_merge_or_defer_required: true
+  status:
+    review_state: pending_joint_signoff
+    compatibility_note_state: pending
+    merge_wave_state: pending
 
 # ── Priority 1: Merge immediately (non-draft, no conflicts) ──────────────────
 ready_to_merge:

--- a/status/pr-register.yaml
+++ b/status/pr-register.yaml
@@ -11,6 +11,24 @@ metadata:
   needs_triage: 17
   draft_active: 44
 
+companion_groups:
+  - id: workspace-os-boundary-liberty-doctrine
+    description: "Paired documentation PRs that must be reviewed and merged together."
+    prs:
+      - repo: sociosphere
+        pr: 19
+      - repo: socioprophet
+        pr: 257
+    policy:
+      joint_review_required: true
+      compatibility_note_required: true
+      rereview_on_material_change: true
+      same_wave_merge_required: true
+    status:
+      review_state: pending_joint_signoff
+      compatibility_note: pending
+      merge_wave: pending
+
 # ── Priority 1: Merge immediately (non-draft, no conflicts) ──────────────────
 ready_to_merge:
   - repo: socioprophet-standards-knowledge


### PR DESCRIPTION
### Motivation

- Ensure paired documentation PRs (`sociosphere#19` and `socioprophet#257`) are reviewed and merged together to avoid terminology/compatibility drift. 
- Make the companion relationship explicit in the PR registry and in the merge-order guidance so reviewers and release coordinators treat the PRs as a single logical change. 
- Capture final merged commit SHAs for both companions in the ecosystem status to provide an auditable record of the synchronized merge. 

### Description

- Added a `companion_groups` entry to `status/pr-register.yaml` that identifies the pair `sociosphere/19` and `socioprophet/257` and encodes required policy flags (`joint_review_required`, `compatibility_note_required`, `rereview_on_material_change`, `same_wave_merge_required`) and pending status fields. 
- Extended `governance/MERGE-ORDER.md` with a required Companion PR Policy that mandates joint review sign-off, an explicit compatibility/terminology note, re-requesting review on material changes, same-wave merge or defer, and post-merge SHA recording. 
- Added `companion_pr_groups` to `status/ecosystem-status.yaml` to track the pair and include `merged_sha: pending` placeholders and a `merge_wave` field for later update. 

### Testing

- Performed syntactic YAML validation by loading `status/pr-register.yaml` and `status/ecosystem-status.yaml` with Ruby using `YAML.load_file`, which succeeded. 
- Attempted to validate YAML with a small Python `yaml.safe_load` script but it failed due to the environment missing the `PyYAML` module, not due to YAML syntax issues. 
- Inspected the modified files to confirm the expected structures and fields (`companion_groups`, `policy` keys, and `companion_pr_groups` with `merged_sha` placeholders) were added as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32fa0b898832390efa8bde9b0ed5a)