### PR TITLE
chore(ui-workbench): bump picomatch to 4.0.4 in lockfile

### DIFF
--- a/README.edge-caps.md
+++ b/README.edge-caps.md
@@ -1,0 +1,15 @@
+# Edge Capabilities (Draft v0.1)
+
+This directory introduces two mesh-edge capabilities designed to be wrapped by TriTRPC and logged as Cairn receipts.
+
+## cap.edge.fingerprint@0.1 (cdncheck)
+- Purpose: Identify CDN / Cloud / WAF properties for IP/DNS inputs.
+- Output: JSONL records; one record per input; also emits a `cairn.edge.fingerprint@0.1` receipt.
+
+## cap.edge.share@0.1 (airshare)
+- Purpose: Local network sharing (files + clipboard) with mDNS discovery.
+- Output: Emits `cairn.edge.share.transfer@0.1` receipts for send/receive.
+
+## Next
+- Add shim CLIs in `caps/edge-fingerprint/` and `caps/edge-share/` that normalize outputs and collect evidence hashes.
+- Add TriTRPC handshake envelope and TOFU+receipt flow.

--- a/apps/ui-workbench/package-lock.json
+++ b/apps/ui-workbench/package-lock.json
@@ -1062,9 +1062,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/caps/edge-fingerprint/edge_fingerprint.sh
+++ b/caps/edge-fingerprint/edge_fingerprint.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# cap.edge.fingerprint@0.1 shim
+# Depends on: cdncheck in PATH
+# Emits: jsonl results to stdout, and a Cairn receipt to ./out/cairn.edge.fingerprint.json
+
+OUTDIR="${OUTDIR:-./out}"
+MODE="${MODE:-any}" # any|cdn|cloud|waf
+mkdir -p "$OUTDIR"
+
+if ! command -v cdncheck >/dev/null 2>&1; then
+  echo "error: cdncheck not found in PATH" >&2
+  exit 127
+fi
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <target> [target...]" >&2
+  exit 2
+fi
+
+# Build args
+ARGS=()
+case "$MODE" in
+  any) ;;
+  cdn) ARGS+=("-cdn") ;;
+  cloud) ARGS+=("-cloud") ;;
+  waf) ARGS+=("-waf") ;;
+  *) echo "error: MODE must be one of any|cdn|cloud|waf" >&2; exit 2 ;;
+esac
+
+# Run cdncheck in jsonl mode.
+# Note: cdncheck's -jsonl writes json(line) format. We keep it as our stable wire format.
+cdncheck -i "$@" -jsonl "${ARGS[@]}" | tee "$OUTDIR/results.jsonl" >/dev/null
+
+# Evidence: attempt to capture tool version; sources hash is best-effort (unknown unless we can locate sources_data.json).
+TOOL_VERSION="$(cdncheck -version 2>/dev/null | tr -d '\r' | head -n1 | sed 's/^[^0-9]*//')"
+[ -z "$TOOL_VERSION" ] && TOOL_VERSION="unknown"
+
+# sources_hash: we can’t reliably locate provider index from installed binary without conventions.
+# We keep placeholder "unknown" until we implement a deterministic build/install lane.
+SOURCES_HASH="unknown"
+
+python3 - <<'PY'
+import json, os, hashlib, datetime
+outdir = os.environ.get("OUTDIR","./out")
+tool_version = os.environ.get("TOOL_VERSION","unknown")
+sources_hash = os.environ.get("SOURCES_HASH","unknown")
+targets = os.environ.get("TARGETS","").splitlines()
+results_path = os.path.join(outdir, "results.jsonl")
+
+def sha256_file(p):
+    h = hashlib.sha256()
+    with open(p, "rb") as f:
+        for b in iter(lambda: f.read(1024*1024), b""):
+            h.update(b)
+    return h.hexdigest()
+
+# We do minimal parsing: store raw jsonl hash and leave detailed extraction to later.
+receipt = {
+  "cairn_type": "cairn.edge.fingerprint",
+  "version": "0.1",
+  "event_time": datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+  "input": {"targets": targets},
+  "results": [],
+  "evidence": {
+    "tool": "cdncheck",
+    "tool_version": tool_version,
+    "sources_hash": sources_hash,
+    "results_jsonl_sha256": sha256_file(results_path) if os.path.exists(results_path) else None
+  }
+}
+
+with open(os.path.join(outdir, "cairn.edge.fingerprint.json"), "w", encoding="utf-8") as f:
+    json.dump(receipt, f, indent=2, sort_keys=True)
+PY

--- a/caps/edge-share/edge_share.sh
+++ b/caps/edge-share/edge_share.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# cap.edge.share@0.1 shim
+# Depends on: airshare in PATH
+# Emits: a Cairn receipt to ./out/cairn.edge.share.transfer.json (per invocation)
+
+OUTDIR="${OUTDIR:-./out}"
+DIRECTION="${DIRECTION:-send}" # send|receive
+PEER="${PEER:-}"
+SAVE_DIR="${SAVE_DIR:-}"
+CLIPBOARD_SEND="${CLIPBOARD_SEND:-}" # if set, send as clipboard text
+CLIPBOARD_COPY="${CLIPBOARD_COPY:-false}" # true to copy received clipboard when compatible
+mkdir -p "$OUTDIR"
+
+if ! command -v airshare >/dev/null 2>&1; then
+  echo "error: airshare not found in PATH" >&2
+  exit 127
+fi
+
+if [ -z "$PEER" ]; then
+  echo "error: PEER is required (Airshare username/handle)" >&2
+  exit 2
+fi
+
+TOOL_VERSION="$(airshare -h 2>/dev/null | head -n1 | tr -d '\r')"
+[ -z "$TOOL_VERSION" ] && TOOL_VERSION="unknown"
+
+if [ "$DIRECTION" = "send" ]; then
+  if [ -n "$CLIPBOARD_SEND" ]; then
+    # Send clipboard text
+    airshare -cs "$PEER" <<<"$CLIPBOARD_SEND"
+    CLIP_SHA="$(printf '%s' "$CLIPBOARD_SEND" | shasum -a 256 | awk '{print $1}')"
+    python3 - <<PY
+import json, os, datetime
+outdir=os.environ.get("OUTDIR","./out")
+peer=os.environ["PEER"]
+tool_version=os.environ.get("TOOL_VERSION","unknown")
+clip_sha=os.environ.get("CLIP_SHA","")
+receipt={
+ "cairn_type":"cairn.edge.share.transfer",
+ "version":"0.1",
+ "event_time": datetime.datetime.utcnow().replace(microsecond=0).isoformat()+"Z",
+ "direction":"send",
+ "peer": peer,
+ "payload":{"clipboard_text_sha256": clip_sha},
+ "evidence":{"tool":"airshare","tool_version":tool_version,"discovery":{"method":"mdns","service":"unknown"}}
+}
+with open(os.path.join(outdir,"cairn.edge.share.transfer.json"),"w",encoding="utf-8") as f:
+  json.dump(receipt,f,indent=2,sort_keys=True)
+PY
+  else
+    if [ "$#" -lt 1 ]; then
+      echo "usage: PEER=<peer> DIRECTION=send $0 <path> [path...]" >&2
+      exit 2
+    fi
+    # Send files/paths
+    airshare -u "$PEER" "$@"
+    python3 - <<PY
+import json, os, datetime
+outdir=os.environ.get("OUTDIR","./out")
+peer=os.environ["PEER"]
+tool_version=os.environ.get("TOOL_VERSION","unknown")
+paths=os.environ.get("PATHS","").splitlines()
+receipt={
+ "cairn_type":"cairn.edge.share.transfer",
+ "version":"0.1",
+ "event_time": datetime.datetime.utcnow().replace(microsecond=0).isoformat()+"Z",
+ "direction":"send",
+ "peer": peer,
+ "payload":{"paths": paths},
+ "evidence":{"tool":"airshare","tool_version":tool_version,"discovery":{"method":"mdns","service":"unknown"}}
+}
+with open(os.path.join(outdir,"cairn.edge.share.transfer.json"),"w",encoding="utf-8") as f:
+  json.dump(receipt,f,indent=2,sort_keys=True)
+PY
+  fi
+elif [ "$DIRECTION" = "receive" ]; then
+  # Receive: Airshare UX is interactive; we log receipt stub now and tighten later.
+  # If SAVE_DIR set, user should run in that dir; for now we just invoke base receive mode (no flags).
+  if [ "$CLIPBOARD_COPY" = "true" ]; then
+    airshare -cr "$PEER"
+  else
+    airshare "$PEER"
+  fi
+  python3 - <<PY
+import json, os, datetime
+outdir=os.environ.get("OUTDIR","./out")
+peer=os.environ["PEER"]
+tool_version=os.environ.get("TOOL_VERSION","unknown")
+receipt={
+ "cairn_type":"cairn.edge.share.transfer",
+ "version":"0.1",
+ "event_time": datetime.datetime.utcnow().replace(microsecond=0).isoformat()+"Z",
+ "direction":"receive",
+ "peer": peer,
+ "payload":{},
+ "evidence":{"tool":"airshare","tool_version":tool_version,"discovery":{"method":"mdns","service":"unknown"}}
+}
+with open(os.path.join(outdir,"cairn.edge.share.transfer.json"),"w",encoding="utf-8") as f:
+  json.dump(receipt,f,indent=2,sort_keys=True)
+PY
+else
+  echo "error: DIRECTION must be send|receive" >&2
+  exit 2
+fi

--- a/schema/cairn/cairn.edge.fingerprint.v0.1.json
+++ b/schema/cairn/cairn.edge.fingerprint.v0.1.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cairn.edge.fingerprint@0.1",
+  "type": "object",
+  "required": ["cairn_type", "version", "event_time", "input", "results", "evidence"],
+  "properties": {
+    "cairn_type": { "const": "cairn.edge.fingerprint" },
+    "version": { "const": "0.1" },
+    "event_time": { "type": "string", "description": "RFC3339 timestamp" },
+    "input": {
+      "type": "object",
+      "required": ["targets"],
+      "properties": { "targets": { "type": "array", "items": { "type": "string" } } }
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["target", "resolved_ips", "detections"],
+        "properties": {
+          "target": { "type": "string" },
+          "resolved_ips": { "type": "array", "items": { "type": "string" } },
+          "detections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["kind", "provider"],
+              "properties": {
+                "kind": { "type": "string", "enum": ["cdn", "cloud", "waf"] },
+                "provider": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["tool", "tool_version", "sources_hash"],
+      "properties": {
+        "tool": { "const": "cdncheck" },
+        "tool_version": { "type": "string" },
+        "sources_hash": { "type": "string", "description": "Hash of provider index/sources_data.json when available." }
+      }
+    }
+  }
+}

--- a/schema/cairn/cairn.edge.share.transfer.v0.1.json
+++ b/schema/cairn/cairn.edge.share.transfer.v0.1.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cairn.edge.share.transfer@0.1",
+  "type": "object",
+  "required": ["cairn_type", "version", "event_time", "direction", "peer", "payload", "evidence"],
+  "properties": {
+    "cairn_type": { "const": "cairn.edge.share.transfer" },
+    "version": { "const": "0.1" },
+    "event_time": { "type": "string" },
+    "direction": { "type": "string", "enum": ["send", "receive"] },
+    "peer": { "type": "string" },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "paths": { "type": "array", "items": { "type": "string" } },
+        "clipboard_text_sha256": { "type": "string" },
+        "bytes_sent": { "type": "integer" },
+        "bytes_received": { "type": "integer" }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["tool", "tool_version", "discovery"],
+      "properties": {
+        "tool": { "const": "airshare" },
+        "tool_version": { "type": "string" },
+        "discovery": {
+          "type": "object",
+          "required": ["method"],
+          "properties": {
+            "method": { "type": "string", "enum": ["mdns"] },
+            "service": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/capability/cap.edge.fingerprint.v0.1.json
+++ b/schema/capability/cap.edge.fingerprint.v0.1.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cap.edge.fingerprint@0.1",
+  "type": "object",
+  "required": ["capability", "version", "inputs", "outputs"],
+  "properties": {
+    "capability": { "const": "cap.edge.fingerprint" },
+    "version": { "const": "0.1" },
+    "inputs": {
+      "type": "object",
+      "required": ["targets"],
+      "properties": {
+        "targets": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "List of IPs or DNS names."
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["any", "cdn", "cloud", "waf"],
+          "default": "any"
+        },
+        "output": {
+          "type": "string",
+          "enum": ["jsonl"],
+          "default": "jsonl"
+        }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "required": ["jsonl_record_schema"],
+      "properties": {
+        "jsonl_record_schema": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schema/capability/cap.edge.share.v0.1.json
+++ b/schema/capability/cap.edge.share.v0.1.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cap.edge.share@0.1",
+  "type": "object",
+  "required": ["capability", "version", "inputs", "outputs"],
+  "properties": {
+    "capability": { "const": "cap.edge.share" },
+    "version": { "const": "0.1" },
+    "inputs": {
+      "type": "object",
+      "required": ["peer"],
+      "properties": {
+        "peer": { "type": "string", "description": "Airshare peer username/handle." },
+        "send": {
+          "type": "object",
+          "properties": {
+            "paths": { "type": "array", "items": { "type": "string" } },
+            "clipboard_text": { "type": "string" }
+          }
+        },
+        "receive": {
+          "type": "object",
+          "properties": {
+            "save_dir": { "type": "string" },
+            "clipboard_copy": { "type": "boolean", "default": false }
+          }
+        }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "required": ["receipt_schema"],
+      "properties": { "receipt_schema": { "type": "string" } }
+    }
+  }
+}

--- a/tools/bootstrap/linux-edge-caps.sh
+++ b/tools/bootstrap/linux-edge-caps.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Linux bootstrap for edge capabilities:
+# - cdncheck (Go binary)
+# - airshare (Python packaged as PEX-like single artifact placeholder)
+#
+# This script is DEV-LANE. For SourceOS base, CI should build artifacts, sign them, and publish.
+#
+# Outputs:
+#   tools/bootstrap/edge-caps.lock
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOCK="$ROOT/tools/bootstrap/edge-caps.lock"
+BIN_DIR="${BIN_DIR:-$ROOT/caps/bin}"
+mkdir -p "$BIN_DIR"
+
+echo "# edge caps lock (dev lane)" > "$LOCK"
+date -u +"# generated: %Y-%m-%dT%H:%M:%SZ" >> "$LOCK"
+
+# ---- cdncheck ----
+if ! command -v cdncheck >/dev/null 2>&1; then
+  if command -v go >/dev/null 2>&1; then
+    echo "[+] installing cdncheck via go install (dev lane)"
+    GOBIN="$BIN_DIR" go install -v github.com/projectdiscovery/cdncheck/cmd/cdncheck@latest
+  else
+    echo "error: go not found; install Go or provide cdncheck binary" >&2
+    exit 127
+  fi
+else
+  echo "[=] cdncheck already present at $(command -v cdncheck)"
+fi
+
+CDNCHK_VER="$( ( "$BIN_DIR/cdncheck" -version 2>/dev/null || cdncheck -version 2>/dev/null ) | head -n1 | tr -d '\r' )"
+echo "cdncheck.version=$CDNCHK_VER" >> "$LOCK"
+
+# ---- airshare ----
+# We install from upstream repo and create a venv-backed wrapper in BIN_DIR.
+# For SourceOS base lane, replace this with CI-built PEX/zipapp.
+AIRSHARE_DIR="$ROOT/third_party/Airshare"
+if [ ! -d "$AIRSHARE_DIR/.git" ]; then
+  echo "[+] cloning KuroLabs/Airshare"
+  mkdir -p "$(dirname "$AIRSHARE_DIR")"
+  git clone https://github.com/KuroLabs/Airshare.git "$AIRSHARE_DIR"
+fi
+
+# Optional: pin commit here once chosen.
+AIRSHARE_COMMIT="$(git -C "$AIRSHARE_DIR" rev-parse HEAD)"
+echo "airshare.commit=$AIRSHARE_COMMIT" >> "$LOCK"
+
+python3 -m venv "$AIRSHARE_DIR/.venv"
+# shellcheck disable=SC1091
+source "$AIRSHARE_DIR/.venv/bin/activate"
+pip install -U pip wheel >/dev/null
+if [ -f "$AIRSHARE_DIR/requirements.txt" ]; then
+  pip install -r "$AIRSHARE_DIR/requirements.txt" >/dev/null
+fi
+
+ENTRY="$(ls -1 "$AIRSHARE_DIR"/*.py 2>/dev/null | head -n1)"
+if [ -z "$ENTRY" ]; then
+  echo "error: could not locate Airshare entrypoint (*.py) in $AIRSHARE_DIR" >&2
+  exit 2
+fi
+
+cat > "$BIN_DIR/airshare" <<EOF
+#!/usr/bin/env bash
+exec "$AIRSHARE_DIR/.venv/bin/python" "$ENTRY" "\$@"
+EOF
+chmod +x "$BIN_DIR/airshare"
+
+AIRSHARE_HELP="$("$BIN_DIR/airshare" -h 2>/dev/null | head -n1 | tr -d '\r' || true)"
+echo "airshare.help_head=$AIRSHARE_HELP" >> "$LOCK"
+
+echo "[ok] installed to: $BIN_DIR"
+echo "[ok] lock written: $LOCK"


### PR DESCRIPTION
Lockfile-only remediation for the transitive picomatch advisory in apps/ui-workbench.

Validation:
- isolated worktree branch
- npm ping and tarball reachability succeeded
- npm ci succeeded
- npm audit reported 0 vulnerabilities

Scope:
- package-lock only
- no package.json change
- dev-toolchain dependency path