### PR TITLE
Seed local-hybrid smoke runner across sibling repo checkouts

### DIFF
--- a/docs/local_hybrid_full_smoke_v1.md
+++ b/docs/local_hybrid_full_smoke_v1.md
@@ -1,0 +1,32 @@
+# Local-Hybrid Full Smoke v1
+
+## Purpose
+
+This note documents the full seven-step smoke-path runner for the first local-hybrid slice.
+
+It extends the earlier smoke runner by adding the last two execution steps:
+
+- `evidence.v1.Event/Append`
+- `replay.v1.Cairn/Materialize`
+
+## What the runner now does
+
+1. Resolve a capability binding.
+2. Build a tenant dispatch payload from fixture examples.
+3. Build and execute a worker request.
+4. Build an evidence append request from the worker result.
+5. Append the evidence via the deterministic evidence stub.
+6. Build a replay/cairn materialization request from the journal offset.
+7. Materialize the cairn via the deterministic replay stub.
+
+## Default command
+
+```bash
+python3 tools/smoke/run_local_hybrid_full_smoke.py
+```
+
+## Scope limits
+
+- still uses fixture outputs instead of a live policy engine
+- still uses JSON-level example artifacts instead of packed TriTRPC vectors
+- still uses deterministic stubs rather than production worker/runtime services

--- a/docs/local_hybrid_smoke_v0.md
+++ b/docs/local_hybrid_smoke_v0.md
@@ -1,0 +1,45 @@
+# Local-Hybrid Smoke v0
+
+## Purpose
+
+This note documents the thin smoke-path runner for the first local-hybrid slice.
+
+The runner is intentionally small. It is not a full supervisor. It is a workspace-level demonstration that the current example artifacts and tenant-side stubs can be driven in sequence from a local checkout.
+
+## Expected workspace layout
+
+By default the runner assumes sibling clones under a common workspace root:
+
+- `sociosphere`
+- `agentplane`
+- `TriTRPC`
+
+## What the runner does
+
+1. Resolve a capability binding from the `agentplane` capability example.
+2. Build a dispatch payload from the `TriTRPC` task and policy fixture examples.
+3. Build a worker request with side effects and network egress disabled.
+4. Execute the deterministic worker stub.
+5. Print a combined JSON bundle containing binding, dispatch, worker request, and worker result.
+
+## Default command
+
+```bash
+python3 tools/smoke/run_local_hybrid_smoke.py
+```
+
+## Override examples
+
+```bash
+python3 tools/smoke/run_local_hybrid_smoke.py --workspace-root ~/dev
+```
+
+```bash
+python3 tools/smoke/run_local_hybrid_smoke.py --lane tenant
+```
+
+## Scope limits
+
+- no policy engine invocation yet; it consumes fixture outputs
+- no evidence append or cairn materialization yet; those remain the next executable follow-on
+- no packed TriTRPC vector generation yet; it consumes JSON-level fixture files

--- a/tools/smoke/run_local_hybrid_full_smoke.py
+++ b/tools/smoke/run_local_hybrid_full_smoke.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Run the first full seven-step local-hybrid smoke path across sibling repo checkouts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_workspace_root() -> Path:
+    return repo_root().parent
+
+
+def run_python_json(script: Path, args: list[str]) -> dict[str, Any]:
+    proc = subprocess.run(
+        ["python3", str(script), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace-root", type=Path, default=default_workspace_root())
+    parser.add_argument("--lane", default="tenant")
+    args = parser.parse_args()
+
+    workspace_root = args.workspace_root.resolve()
+    agentplane_root = workspace_root / "agentplane"
+    tritrpc_root = workspace_root / "TriTRPC"
+
+    resolver_script = agentplane_root / "capability-registry" / "resolve_binding_stub.py"
+    dispatch_script = agentplane_root / "gateway" / "dispatch_stub.py"
+    worker_script = agentplane_root / "worker-runtime" / "execute_stub.py"
+    evidence_script = agentplane_root / "evidence" / "append_event_stub.py"
+    replay_script = agentplane_root / "replay" / "materialize_cairn_stub.py"
+    capability_descriptor = agentplane_root / "capability-registry" / "examples" / "summarize.abstractive.v1.json"
+    fixture_dir = tritrpc_root / "spec" / "slices" / "local_hybrid_v0" / "fixtures" / "remote_allowed_redacted"
+    task_plan = fixture_dir / "task-plan.output.example.json"
+    policy_decision = fixture_dir / "policy-decision.output.example.json"
+
+    binding = run_python_json(resolver_script, [str(capability_descriptor), "--lane", args.lane])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        binding_path = tmp / "binding.json"
+        binding_path.write_text(json.dumps(binding, indent=2), encoding="utf-8")
+
+        dispatch = run_python_json(dispatch_script, [str(task_plan), str(policy_decision), str(binding_path)])
+
+        worker_request = {
+            "taskId": dispatch["taskId"],
+            "capabilityInstanceId": dispatch["capabilityInstanceId"],
+            "input": dispatch["input"],
+            "executionPolicy": {
+                "sideEffectsAllowed": False,
+                "networkEgressAllowed": False,
+            },
+        }
+        worker_request_path = tmp / "worker-request.json"
+        worker_request_path.write_text(json.dumps(worker_request, indent=2), encoding="utf-8")
+
+        worker_result = run_python_json(worker_script, [str(worker_request_path)])
+
+        evidence_request = {
+            "event": {
+                "eventId": "urn:uuid:stub-event-01",
+                "parentEventId": "urn:uuid:stub-parent-00",
+                "sessionId": "sess_01",
+                "taskId": worker_result["taskId"],
+                "actor": {"kind": "human", "id": "user:local"},
+                "capability": "summarize.abstractive.v1",
+                "policyHash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                "executionLane": binding["binding"]["executionLane"],
+                "workerId": worker_result["provenance"]["workerId"],
+                "modelId": worker_result["provenance"]["modelId"],
+                "toolchain": worker_result["provenance"]["toolchain"],
+                "zoneCrossings": ["device->tenant", "tenant->device"],
+                "inputDigest": worker_result["provenance"]["inputDigest"],
+                "outputDigest": worker_result["provenance"]["outputDigest"],
+                "artifactRefs": [],
+                "startedAt": "2026-04-06T00:00:01Z",
+                "finishedAt": "2026-04-06T00:00:03Z",
+                "journalOffset": None,
+                "cairnId": None
+            }
+        }
+        evidence_request_path = tmp / "evidence-request.json"
+        evidence_request_path.write_text(json.dumps(evidence_request, indent=2), encoding="utf-8")
+        evidence_result = run_python_json(evidence_script, [str(evidence_request_path)])
+
+        replay_request = {
+            "taskId": worker_result["taskId"],
+            "journalOffset": evidence_result["journalOffset"],
+            "materializeArtifacts": True
+        }
+        replay_request_path = tmp / "replay-request.json"
+        replay_request_path.write_text(json.dumps(replay_request, indent=2), encoding="utf-8")
+        replay_result = run_python_json(replay_script, [str(replay_request_path)])
+
+    result = {
+        "binding": binding,
+        "dispatch": dispatch,
+        "workerRequest": worker_request,
+        "workerResult": worker_result,
+        "evidenceRequest": evidence_request,
+        "evidenceResult": evidence_result,
+        "replayRequest": replay_request,
+        "replayResult": replay_result,
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/smoke/run_local_hybrid_smoke.py
+++ b/tools/smoke/run_local_hybrid_smoke.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Run the first local-hybrid smoke path across sibling repo checkouts.
+
+Expected workspace layout by default:
+
+<workspace-root>/sociosphere
+<workspace-root>/agentplane
+<workspace-root>/TriTRPC
+
+The script may also be pointed at explicit file paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_workspace_root() -> Path:
+    return repo_root().parent
+
+
+def run_python_json(script: Path, args: list[str]) -> dict[str, Any]:
+    proc = subprocess.run(
+        ["python3", str(script), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace-root", type=Path, default=default_workspace_root())
+    parser.add_argument("--lane", default="tenant")
+    parser.add_argument("--resolver-script", type=Path, default=None)
+    parser.add_argument("--dispatch-script", type=Path, default=None)
+    parser.add_argument("--worker-script", type=Path, default=None)
+    parser.add_argument("--capability-descriptor", type=Path, default=None)
+    parser.add_argument("--task-plan", type=Path, default=None)
+    parser.add_argument("--policy-decision", type=Path, default=None)
+    args = parser.parse_args()
+
+    workspace_root = args.workspace_root.resolve()
+    agentplane_root = workspace_root / "agentplane"
+    tritrpc_root = workspace_root / "TriTRPC"
+
+    resolver_script = args.resolver_script or agentplane_root / "capability-registry" / "resolve_binding_stub.py"
+    dispatch_script = args.dispatch_script or agentplane_root / "gateway" / "dispatch_stub.py"
+    worker_script = args.worker_script or agentplane_root / "worker-runtime" / "execute_stub.py"
+    capability_descriptor = args.capability_descriptor or agentplane_root / "capability-registry" / "examples" / "summarize.abstractive.v1.json"
+    fixture_dir = tritrpc_root / "spec" / "slices" / "local_hybrid_v0" / "fixtures" / "remote_allowed_redacted"
+    task_plan = args.task_plan or fixture_dir / "task-plan.output.example.json"
+    policy_decision = args.policy_decision or fixture_dir / "policy-decision.output.example.json"
+
+    binding = run_python_json(resolver_script, [str(capability_descriptor), "--lane", args.lane])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        binding_path = tmp / "binding.json"
+        binding_path.write_text(json.dumps(binding, indent=2), encoding="utf-8")
+
+        dispatch = run_python_json(dispatch_script, [str(task_plan), str(policy_decision), str(binding_path)])
+
+        worker_request = {
+            "taskId": dispatch["taskId"],
+            "capabilityInstanceId": dispatch["capabilityInstanceId"],
+            "input": dispatch["input"],
+            "executionPolicy": {
+                "sideEffectsAllowed": False,
+                "networkEgressAllowed": False
+            }
+        }
+        worker_request_path = tmp / "worker-request.json"
+        worker_request_path.write_text(json.dumps(worker_request, indent=2), encoding="utf-8")
+
+        worker_result = run_python_json(worker_script, [str(worker_request_path)])
+
+    result = {
+        "binding": binding,
+        "dispatch": dispatch,
+        "workerRequest": worker_request,
+        "workerResult": worker_result,
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a thin workspace-level smoke runner for the first local-hybrid slice.

This PR adds:

- `tools/smoke/run_local_hybrid_smoke.py`
- `docs/local_hybrid_smoke_v0.md`

## Why

We already have:

- tenant-side execution stubs in `agentplane`
- transport-facing slice and fixture examples in `TriTRPC`
- shared slice schemas in `socioprophet-standards-storage`

The missing piece was a local workspace runner that can drive those artifacts in sequence from a local checkout.

## What the runner does

1. Resolve a capability binding using the `agentplane` example and resolver stub.
2. Build a tenant dispatch payload using the `TriTRPC` task and policy fixture examples.
3. Build a worker request with side effects and network egress disabled.
4. Execute the deterministic worker stub.
5. Print a combined JSON bundle of the intermediate and final artifacts.

## Scope limits

- no real policy engine invocation yet
- no evidence append or cairn materialization yet
- no packed TriTRPC vector generation yet

## Related work

- `agentplane` draft PR #12
- `TriTRPC` draft PR #20
- `socioprophet-standards-storage` draft PR #13

## Note

An earlier scratch branch was discarded conceptually after a syntax defect was found before PR creation. This PR is cut from a fresh branch with the corrected runner.
