### PR TITLE
Make `ui-install` deterministic by using `npm ci`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ui-preflight:
 	./tools/ui-preflight.sh
 
 ui-install:
-	cd $(UI_DIR) && npm install && npm install -D vue-tsc typescript
+	cd $(UI_DIR) && npm ci
 
 ui-build:
 	cd $(UI_DIR) && npm run build
@@ -76,4 +76,3 @@ merge-order:
 
 workspace-check: validate registry-validate compliance-check
 	@echo "OK: workspace-check passed"
-


### PR DESCRIPTION
### Motivation
- The CI `validate` workflow was intermittently failing because the UI install performed ad-hoc dependency resolution in CI, which is fragile in constrained/proxied environments; using the lockfile for installs reduces network variability and merge failures.

### Description
- Update the `ui-install` Make target to run `cd apps/ui-workbench && npm ci` instead of running `npm install` followed by a separate dev-dependency install.

### Testing
- Ran `make ui-install` (passed), `make ui-check` (passed), and `make validate-standards` (passed), and attempted `make registry-validate` which was blocked by an environment network/proxy restriction preventing installation of `pyyaml` (this failure is external to the Makefile change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69666c1bc8323b67ea275ae040d65)