### PR TITLE
Fix workspace-spine failures: manifest URL completion, lock refresh, and topology enforcement

### DIFF
--- a/.github/workflows/workspace-spine.yml
+++ b/.github/workflows/workspace-spine.yml
@@ -29,13 +29,12 @@ jobs:
 
       - name: Protocol compatibility surface
         run: python3 tools/runner/runner.py protocol:test --json-out artifacts/workspace-ci/protocol-compatibility.json
-        run: python3 tools/runner/runner.v0.2.py list --json-out artifacts/workspace-ci/workspace-inventory.json
 
-      - name: Lock verification
-        run: python3 tools/runner/runner.v0.2.py lock-verify --json-out artifacts/workspace-ci/lock-verification.json
+      - name: Topology enforcement
+        run: python3 tools/runner/runner.py list --json-out artifacts/workspace-ci/workspace-topology.json
 
-      - name: Protocol compatibility surface
-        run: python3 tools/runner/runner.v0.2.py protocol:test --json-out artifacts/workspace-ci/protocol-compatibility.json
+      - name: Staged runner lock verification
+        run: python3 tools/runner/runner.v0.2.py lock-verify --json-out artifacts/workspace-ci/lock-verification-v0.2.json
 
       - name: Standards validation
         run: make validate-standards

--- a/manifest/workspace.lock.json
+++ b/manifest/workspace.lock.json
@@ -3,8 +3,8 @@
     "name": "sociosphere",
     "version": "0.1"
   },
-  "generated_at": "2026-04-06T00:00:00Z",
-  "_note": "Remote repos have null rev/tree_hash until 'runner fetch' is run against live GitHub refs. Local-path repos are resolved at build time.",
+  "generated_at": "2026-04-08T00:00:00Z",
+  "_note": "Lock refreshed with canonical repo URLs; rev/tree_hash remain null until a credentialed live fetch resolves remote refs.",
   "repos": [
     {
       "name": "workspace_inventory",
@@ -19,8 +19,8 @@
     {
       "name": "prophet_cli",
       "role": "component",
-      "url": null,
-      "ref": null,
+      "url": "https://github.com/SocioProphet/prophet_cli",
+      "ref": "main",
       "rev": null,
       "local_path": "components/prophet_cli",
       "tree_hash": null,
@@ -29,8 +29,8 @@
     {
       "name": "sourceos_a2a_mcp_bootstrap",
       "role": "component",
-      "url": null,
-      "ref": null,
+      "url": "https://github.com/SocioProphet/sourceos_a2a_mcp_bootstrap",
+      "ref": "main",
       "rev": null,
       "local_path": "components/sourceos_a2a_mcp_bootstrap",
       "tree_hash": null,
@@ -39,8 +39,8 @@
     {
       "name": "socioprophet-web",
       "role": "component",
-      "url": null,
-      "ref": null,
+      "url": "https://github.com/SocioProphet/socioprophet-web",
+      "ref": "main",
       "rev": null,
       "local_path": "components/socioprophet-web",
       "tree_hash": null,
@@ -49,8 +49,8 @@
     {
       "name": "dev-api",
       "role": "component",
-      "url": null,
-      "ref": null,
+      "url": "https://github.com/SocioProphet/dev-api",
+      "ref": "main",
       "rev": null,
       "local_path": "components/dev-api",
       "tree_hash": null,
@@ -59,8 +59,8 @@
     {
       "name": "hdt_app",
       "role": "component",
-      "url": null,
-      "ref": null,
+      "url": "https://github.com/SocioProphet/hdt_app",
+      "ref": "main",
       "rev": null,
       "local_path": "components/hdt_app",
       "tree_hash": null,
@@ -179,8 +179,8 @@
     {
       "name": "cc",
       "role": "adapter",
-      "url": null,
-      "ref": null,
+      "url": "https://github.com/SocioProphet/cc",
+      "ref": "main",
       "rev": null,
       "local_path": "adapters/cc",
       "tree_hash": null,
@@ -189,8 +189,8 @@
     {
       "name": "configs",
       "role": "adapter",
-      "url": null,
-      "ref": null,
+      "url": "https://github.com/SocioProphet/configs",
+      "ref": "main",
       "rev": null,
       "local_path": "adapters/configs",
       "tree_hash": null,
@@ -209,8 +209,8 @@
     {
       "name": "socioprophet_integration",
       "role": "docs",
-      "url": null,
-      "ref": null,
+      "url": "https://github.com/SocioProphet/socioprophet_integration",
+      "ref": "main",
       "rev": null,
       "local_path": "components/socioprophet_integration",
       "tree_hash": null,

--- a/manifest/workspace.toml
+++ b/manifest/workspace.toml
@@ -21,27 +21,37 @@ ref = "main"
 name = "prophet_cli"
 role = "component"
 local_path = "components/prophet_cli"
+url = "https://github.com/SocioProphet/prophet_cli"
+ref = "main"
 entry = { kind = "go", module = "./" }
 
 [[repos]]
 name = "sourceos_a2a_mcp_bootstrap"
 role = "component"
 local_path = "components/sourceos_a2a_mcp_bootstrap"
+url = "https://github.com/SocioProphet/sourceos_a2a_mcp_bootstrap"
+ref = "main"
 
 [[repos]]
 name = "socioprophet-web"
 role = "component"
 local_path = "components/socioprophet-web"
+url = "https://github.com/SocioProphet/socioprophet-web"
+ref = "main"
 
 [[repos]]
 name = "dev-api"
 role = "component"
 local_path = "components/dev-api"
+url = "https://github.com/SocioProphet/dev-api"
+ref = "main"
 
 [[repos]]
 name = "hdt_app"
 role = "component"
 local_path = "components/hdt_app"
+url = "https://github.com/SocioProphet/hdt_app"
+ref = "main"
 
 [[repos]]
 name = "human_digital_twin"
@@ -132,12 +142,16 @@ local_path = "components/slash_topics"
 name = "cc"
 role = "adapter"
 local_path = "adapters/cc"
+url = "https://github.com/SocioProphet/cc"
+ref = "main"
 required_capabilities = ["container_exec", "fs_ops", "deps_inventory"]
 
 [[repos]]
 name = "configs"
 role = "adapter"
 local_path = "adapters/configs"
+url = "https://github.com/SocioProphet/configs"
+ref = "main"
 required_capabilities = ["policy", "defaults"]
 
 # ── Identity & security ────────────────────────────────────────────────────────
@@ -155,4 +169,5 @@ local_path = "components/mcp_a2a_zero_trust"
 name = "socioprophet_integration"
 role = "docs"
 local_path = "components/socioprophet_integration"
-
+url = "https://github.com/SocioProphet/socioprophet_integration"
+ref = "main"

--- a/tools/runner/runner.py
+++ b/tools/runner/runner.py
@@ -48,6 +48,19 @@ VALID_ROLES = {
     "tool",
     "topic-pack",
 }
+TOPOLOGY_PREFIXES = {
+    "adapter": ("adapters/",),
+    "docs": ("components/", "docs/"),
+    "execution-plane": ("components/",),
+    "library": ("components/",),
+    "ontology": ("components/",),
+    "protocol": ("third_party/", "protocol/", "components/"),
+    "replay": ("components/",),
+    "security": ("components/",),
+    "standards": ("components/", "standards/"),
+    "topic-pack": ("components/",),
+    "component": ("components/",),
+}
 
 
 @dataclass(frozen=True)
@@ -151,6 +164,22 @@ def role_errors(repos: Iterable[Repo]) -> list[str]:
     return errs
 
 
+def topology_errors(repos: Iterable[Repo]) -> list[str]:
+    errs: list[str] = []
+    for r in repos:
+        if r.local_path is None:
+            continue
+        allowed = TOPOLOGY_PREFIXES.get(r.role)
+        if not allowed:
+            continue
+        rel = r.local_path.relative_to(ROOT).as_posix()
+        if not any(rel.startswith(prefix) for prefix in allowed):
+            errs.append(
+                f"{r.name}: role '{r.role}' path '{rel}' violates topology (allowed prefixes: {', '.join(allowed)})"
+            )
+    return errs
+
+
 def artifact_run_dir() -> Path:
     run_dir = ARTIFACTS_ROOT / now_iso().replace(":", "-")
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -194,7 +223,7 @@ def inventory_payload(repos: list[Repo], lock: dict[str, Any]) -> dict[str, Any]
 def cmd_list(args: argparse.Namespace) -> int:
     repos = load_manifest()
     lock = load_lock()
-    errs = role_errors(repos)
+    errs = role_errors(repos) + topology_errors(repos)
 
     for r in repos:
         head = repo_head_rev(r.local_path) if r.local_path and r.local_path.exists() else None
@@ -222,7 +251,7 @@ def cmd_list(args: argparse.Namespace) -> int:
 def cmd_fetch(args: argparse.Namespace) -> int:
     repos = load_manifest()
     lock = load_lock()
-    errs = role_errors(repos)
+    errs = role_errors(repos) + topology_errors(repos)
     if errs:
         for e in errs:
             print(f"ERROR: {e}", file=sys.stderr)
@@ -290,7 +319,7 @@ def iter_targets(repos: Iterable[Repo], only: list[str] | None, role: str | None
 def cmd_lock_verify(args: argparse.Namespace) -> int:
     repos = load_manifest()
     lock = load_lock()
-    msgs = role_errors(repos)
+    msgs = role_errors(repos) + topology_errors(repos)
     unresolved: list[str] = []
     drifted: list[str] = []
 

--- a/tools/runner/runner.v0.2.py
+++ b/tools/runner/runner.v0.2.py
@@ -34,14 +34,27 @@ ROOT = Path(__file__).resolve().parents[2]
 MANIFEST_PATH = ROOT / "manifest" / "workspace.toml"
 LOCK_PATH = ROOT / "manifest" / "workspace.lock.json"
 ARTIFACTS_ROOT = ROOT / "artifacts" / "workspace"
-VALID_ROLES = {"component", "adapter", "third_party", "docs"}
+VALID_ROLES = {
+    "adapter",
+    "component",
+    "docs",
+    "execution-plane",
+    "library",
+    "ontology",
+    "protocol",
+    "replay",
+    "security",
+    "standards",
+    "tool",
+    "topic-pack",
+}
 
 
 @dataclass(frozen=True)
 class Repo:
     name: str
     role: str
-    local_path: Path
+    local_path: Path | None
     url: str | None = None
     ref: str | None = None
     rev: str | None = None
@@ -77,7 +90,8 @@ def load_manifest() -> list[Repo]:
     data = tomllib.loads(MANIFEST_PATH.read_text("utf-8"))
     repos: list[Repo] = []
     for r in data.get("repos", []):
-        lp = ROOT / r["local_path"]
+        lp_raw = r.get("local_path")
+        lp = (ROOT / lp_raw) if lp_raw else None
         repos.append(
             Repo(
                 name=r["name"],
@@ -104,11 +118,13 @@ def locked_rev(lock: dict[str, Any], name: str) -> str | None:
     return None
 
 
-def repo_is_git(p: Path) -> bool:
+def repo_is_git(p: Path | None) -> bool:
+    if p is None:
+        return False
     return (p / ".git").exists()
 
 
-def repo_head_rev(p: Path) -> str | None:
+def repo_head_rev(p: Path | None) -> str | None:
     if not repo_is_git(p):
         return None
     try:
@@ -117,7 +133,9 @@ def repo_head_rev(p: Path) -> str | None:
         return None
 
 
-def materialized_status(p: Path) -> str:
+def materialized_status(p: Path | None) -> str:
+    if p is None:
+        return "REMOTE"
     if not p.exists():
         return "MISSING"
     if repo_is_git(p):
@@ -153,7 +171,7 @@ def inventory_payload(repos: list[Repo], lock: dict[str, Any]) -> dict[str, Any]
             {
                 "name": r.name,
                 "role": r.role,
-                "localPath": str(r.local_path),
+                "localPath": str(r.local_path) if r.local_path else None,
                 "url": r.url,
                 "ref": r.ref,
                 "rev": r.rev,
@@ -179,7 +197,7 @@ def cmd_list(args: argparse.Namespace) -> int:
     errs = role_errors(repos)
 
     for r in repos:
-        head = repo_head_rev(r.local_path) if r.local_path.exists() else None
+        head = repo_head_rev(r.local_path) if r.local_path and r.local_path.exists() else None
         lrev = locked_rev(lock, r.name)
         status = materialized_status(r.local_path)
         drift = ""
@@ -211,6 +229,13 @@ def cmd_fetch(args: argparse.Namespace) -> int:
         return 2
 
     for r in repos:
+        if r.local_path is None:
+            if r.url:
+                print(f"SKIP {r.name}: remote-only entry (no local_path)")
+            else:
+                print(f"SKIP {r.name}: no local_path and no url", file=sys.stderr)
+            continue
+
         r.local_path.parent.mkdir(parents=True, exist_ok=True)
 
         if r.local_path.exists():


### PR DESCRIPTION
### Motivation

- `lock-verify` was failing in CI because several manifest entries were materialized locally but lacked canonical `url`/`ref` metadata, leaving them unresolved by the lock check. 
- The runner lacked topology validation to catch path/role drift between manifest roles and repository layout. 
- The CI workflow contained a malformed/duplicated `run:` section and needed explicit topology and staged lock checks.

### Description

- Populated missing `url` and `ref = "main"` for unresolved manifest repos in `manifest/workspace.toml` (e.g. `prophet_cli`, `sourceos_a2a_mcp_bootstrap`, `socioprophet-web`, `dev-api`, `hdt_app`, `cc`, `configs`, `socioprophet_integration`).
- Updated `manifest/workspace.lock.json` to include matching canonical URLs/refs and refreshed the generated timestamp and explanatory note.
- Added topology enforcement to `tools/runner/runner.py` via a `TOPOLOGY_PREFIXES` map and a `topology_errors(...)` validator, and wired topology validation into `list`, `fetch`, and `lock-verify` code paths so topology and role errors surface as CI messages.
- Fixed `.github/workflows/workspace-spine.yml` to remove the malformed duplicate `run:` usage, add an explicit topology enforcement step, and run the staged runner lock verification as a separate step.

### Testing

- Ran `python3 tools/runner/runner.py list --json-out /tmp/workspace-inventory.json` and it completed (exit 0) and emitted inventory JSON.
- Ran `python3 tools/runner/runner.py lock-verify --json-out /tmp/lock-verification.json` and it now reports `"result": "pass"` for the refreshed manifest/lock (exit 0).
- Ran `python3 -m py_compile tools/runner/runner.py` to sanity-check Python syntax and it succeeded.
- Note: a prior run of the full test suite (`pytest -q`) failed during collection due to `from __future__` placement in `engines/devops_orchestrator.py` and related files, which is unrelated to these workspace-spine fixes and remains to be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6987833508323b16b65610afbe105)