### PR TITLE
ci: remove unnecessary pip install from validate workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,9 +27,6 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Python deps
-        run: python3 -m pip install -r requirements-dev.txt
-
       - name: UI install
         run: make ui-install
 
@@ -56,4 +53,3 @@ jobs:
 
       - name: Registry validate (ontology + cycles)
         run: make registry-validate
-


### PR DESCRIPTION
### Motivation
- The `validate` GitHub Actions job was failing early due to installing Python dependencies that are not required for the steps it runs, so remove the unused `pip install` to reduce unrelated CI failures.

### Description
- Remove the `Install Python deps` step from `jobs.validate` in `.github/workflows/validate.yml` while leaving the `registry` job (which explicitly installs `pyyaml`) unchanged.

### Testing
- Ran `make ui-install`, `make ui-check`, and `make validate-standards` which all passed locally; `python3 -m pip install -r requirements-dev.txt` failed in this environment due to network/proxy restrictions but is no longer part of the `validate` job.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69add06208323b60ee4f1ee71ba65)