### PR TITLE
docs: fix short hash label and remote-safe update command in BRANCH_MERGE_PLAN

### DIFF
--- a/docs/BRANCH_MERGE_PLAN.md
+++ b/docs/BRANCH_MERGE_PLAN.md
@@ -8,7 +8,7 @@
 ## Safe Consolidation Action Taken
 1. Verified all local branch refs and tags.
 2. Created `main` at the exact same commit as `work`.
-3. Confirmed both branches now point to commit `1f019f3`.
+3. Confirmed both branches now point to the same commit (short hash `1f019f3`).
 
 Because there was only one branch tip, no merge commit was required and no conflict risk existed.
 
@@ -24,7 +24,7 @@ When additional branches exist in the future:
 ## Suggested Command Sequence
 ```bash
 git checkout main
-git pull --ff-only
+# if a remote/upstream is configured, update main first (for example: git fetch origin && git merge --ff-only origin/main)
 git merge --no-ff <branch-1>
 # run checks
 git merge --no-ff <branch-2>

--- a/docs/BRANCH_MERGE_PLAN.md
+++ b/docs/BRANCH_MERGE_PLAN.md
@@ -1,0 +1,32 @@
+# Branch Merge Plan (as of 2026-04-04)
+
+## Current Repository State
+- Local branches discovered: `work` only.
+- Remotes configured: none.
+- `main` did not exist before this operation.
+
+## Safe Consolidation Action Taken
+1. Verified all local branch refs and tags.
+2. Created `main` at the exact same commit as `work`.
+3. Confirmed both branches now point to commit `1f019f3`.
+
+Because there was only one branch tip, no merge commit was required and no conflict risk existed.
+
+## Ongoing "Thoughtful Merge" Checklist
+When additional branches exist in the future:
+1. Update local refs (`git fetch --all --prune` when remotes are configured).
+2. Start from up-to-date `main`.
+3. Merge one branch at a time with `--no-ff`.
+4. Run repo checks/tests after each merge.
+5. Resolve conflicts immediately and re-run checks.
+6. Only continue after each incremental merge is green.
+
+## Suggested Command Sequence
+```bash
+git checkout main
+git pull --ff-only
+git merge --no-ff <branch-1>
+# run checks
+git merge --no-ff <branch-2>
+# run checks
+```


### PR DESCRIPTION
Two accuracy issues in `docs/BRANCH_MERGE_PLAN.md` flagged in review.

- **Short hash label**: `1f019f3` now explicitly marked as a short hash to avoid ambiguity as history grows.
- **Remote-safe command sequence**: `git pull --ff-only` (broken without a configured upstream) replaced with an explicit comment showing the equivalent safe form:

```bash
# if a remote/upstream is configured, update main first (for example: git fetch origin && git merge --ff-only origin/main)
```