### PR TITLE
docs: link workspace OS and agent boundary from docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@
 - [Glossary](GLOSSARY.md) — controlled vocabulary for all workspace concepts
 - [Topology](TOPOLOGY.md) — repo roles, dependency directionality, submodule update playbook
 - [Naming & versioning policy](NAMING_VERSIONING.md) — repo naming, SemVer, pin-bump rules
+- [Workspace / OS / agent boundary](WORKSPACE_OS_AGENT_BOUNDARY.md) — explicit split between product doctrine and cross-repo orchestration doctrine
 
 ## Ecosystem intelligence
 - [Ecosystem index](ecosystem/README.md) — per-repo analysis (purpose, vocabulary, topics, dependency graph, change impact rules) for all 8 core SocioProphet repos


### PR DESCRIPTION
## Summary

This follow-on PR makes the new workspace / OS / agent boundary doc discoverable from the main Sociosphere docs index.

## Changes

- adds a Governance-section link to `docs/WORKSPACE_OS_AGENT_BOUNDARY.md`

## Why

PR #19 landed the boundary doc, but the docs index did not yet point to it. This tiny follow-up fixes discoverability so the repo-boundary split is visible without file-path archaeology.
