### PR TITLE
followup(fog): add fog-pack-data import bundle after upstream boundary refresh

### DIFF
--- a/bootstrap/fog-packs/fog-pack-data/IMPORT-CHECKLIST.md
+++ b/bootstrap/fog-packs/fog-pack-data/IMPORT-CHECKLIST.md
@@ -1,0 +1,25 @@
+# fog-pack-data import checklist
+
+Use this checklist when `SocioProphet/fog-pack-data` exists.
+
+## Import now
+- [ ] `README.md`
+- [ ] `MIGRATION.md`
+- [ ] `UPSTREAM-BOUNDARIES.md`
+- [ ] `fog-pack.yaml`
+- [ ] `specs/fog-stack-spec.yaml`
+- [ ] `release/knowledge/v0.1/manifest/fog-release-manifest.yaml`
+- [ ] `release/knowledge/v0.1/pins/fog-release-lock.yaml`
+
+## Keep in `sociosphere`
+- [ ] `docs/fog/repo-topology.yaml`
+- [ ] `docs/fog/repo-governance.yaml`
+- [ ] `docs/fog/shared-foundations-map.yaml`
+- [ ] `docs/fog/upstream-delta-2026-04-09.md`
+- [ ] `docs/fog/import-boundaries-2026-04-09.yaml`
+
+## Validate after import
+- [ ] repo root is narrow and pack-specific
+- [ ] shared foundations are referenced, not copied
+- [ ] release manifest and release lock still match
+- [ ] import note still matches current upstream boundaries

--- a/bootstrap/fog-packs/fog-pack-data/IMPORT-MANIFEST.yaml
+++ b/bootstrap/fog-packs/fog-pack-data/IMPORT-MANIFEST.yaml
@@ -1,0 +1,43 @@
+source_repo: SocioProphet/sociosphere
+target_repo: SocioProphet/fog-pack-data
+mode: seed-first-import
+principle: import pack-local distro artifacts only
+entries:
+- source: bootstrap/fog-packs/fog-pack-data/README.md
+  target: README.md
+  class: pack-root
+- source: bootstrap/fog-packs/fog-pack-data/MIGRATION.md
+  target: MIGRATION.md
+  class: migration-note
+- source: bootstrap/fog-packs/fog-pack-data/UPSTREAM-BOUNDARIES.md
+  target: UPSTREAM-BOUNDARIES.md
+  class: boundary-note
+- source: bootstrap/fog-packs/fog-pack-data/fog-pack.yaml
+  target: fog-pack.yaml
+  class: pack-identity
+- source: bootstrap/fog-packs/fog-pack-data/specs/fog-stack-spec.yaml
+  target: specs/fog-stack-spec.yaml
+  class: pack-spec
+- source: bootstrap/fog-packs/fog-pack-data/release/knowledge/v0.1/manifest/fog-release-manifest.yaml
+  target: release/knowledge/v0.1/manifest/fog-release-manifest.yaml
+  class: release-manifest
+- source: bootstrap/fog-packs/fog-pack-data/release/knowledge/v0.1/pins/fog-release-lock.yaml
+  target: release/knowledge/v0.1/pins/fog-release-lock.yaml
+  class: release-lock
+references_only:
+- docs/fog/repo-topology.yaml
+- docs/fog/repo-governance.yaml
+- docs/fog/shared-foundations-map.yaml
+- docs/fog/upstream-delta-2026-04-09.md
+- docs/fog/import-boundaries-2026-04-09.yaml
+consume_from:
+- SocioProphet/sociosphere
+- SocioProphet/agentplane
+- SocioProphet/TriTRPC
+forbid_copying:
+- shared workflow/workspace control docs
+- runtime envelope canon
+- receipt canon
+- durablegraph runtime canon
+- transport method canon
+- protocol fixture canon

--- a/bootstrap/fog-packs/fog-pack-data/UPSTREAM-BOUNDARIES.md
+++ b/bootstrap/fog-packs/fog-pack-data/UPSTREAM-BOUNDARIES.md
@@ -1,0 +1,20 @@
+# fog-pack-data upstream boundaries
+
+This note travels with the `fog-pack-data` bootstrap seed.
+
+## `fog-pack-data` owns
+- Fog Stack for Data release contract, lock, BOM, profiles
+- Fog Base / Lake / Catalog / Knowledge / Trust composition
+- pack-local manifests, overlays, conformance, and packaging
+- data-pack docs and ADRs
+
+## `fog-pack-data` does not own
+- shared workflow/workspace governance canon from `SocioProphet/sociosphere`
+- shared runtime envelope / receipt / proof-consumer / durablegraph canon from `SocioProphet/agentplane`
+- shared protocol slices, transport methods, and wire fixture canon from `SocioProphet/TriTRPC`
+
+## Import rule
+Prefer dependency references, upstream pins, and compatibility notes over copying shared-foundation material into this pack.
+
+## Immediate implication
+When `SocioProphet/fog-pack-data` is created, import only the pack-local distro content from this bootstrap subtree.


### PR DESCRIPTION
## What this adds

This draft PR adds the commit-ready import bundle for `SocioProphet/fog-pack-data` after re-checking upstream state.

### Included
- `bootstrap/fog-packs/fog-pack-data/UPSTREAM-BOUNDARIES.md`
- `bootstrap/fog-packs/fog-pack-data/IMPORT-MANIFEST.yaml`
- `bootstrap/fog-packs/fog-pack-data/IMPORT-CHECKLIST.md`

## Why
Upstream changed materially after the original Fog pack bootstrap landed:
- `sociosphere` strengthened its cross-pack workspace/governance role
- `agentplane` strengthened its shared runtime/trust-envelope role
- `TriTRPC` strengthened its shared protocol/method/fixture role

That means `fog-pack-data` should import only pack-local distro content and consume shared foundations by reference rather than copying them.

## Effect
This PR makes the future `fog-pack-data` import mechanical:
- exact file map from `sociosphere` bootstrap subtree to `fog-pack-data`
- explicit keep-vs-import split
- explicit no-copy boundary rules

## Next
1. Create `SocioProphet/fog-pack-data`.
2. Import the files listed in `IMPORT-MANIFEST.yaml`.
3. Keep the cross-pack governance files in `SocioProphet/sociosphere`.
4. Repeat the same pattern for the remaining six Fog pack repos.
