### PR TITLE
feat: add agentic workbench v1 schema + packs + fixtures

### DIFF
--- a/protocol/agentic-workbench/v1/fixtures/a2a.delegate.step.v0.1.json
+++ b/protocol/agentic-workbench/v1/fixtures/a2a.delegate.step.v0.1.json
@@ -1,0 +1,63 @@
+{
+  "apiVersion": "agentic-workbench.socios@1",
+  "kind": "Workflow",
+  "metadata": {
+    "name": "a2a-delegate-smoke",
+    "version": "0.1",
+    "createdAt": "2026-04-02T00:00:00Z"
+  },
+  "spec": {
+    "input": {
+      "schemaRef": "inline://none"
+    },
+    "output": {
+      "schemaRef": "inline://delegate-result"
+    },
+    "defaults": {
+      "timeoutSec": 60,
+      "retryMax": 0,
+      "retryBackoffSec": 0,
+      "cacheMode": "off",
+      "ledgerMode": "required",
+      "humanGateRequired": false,
+      "lane": "dev"
+    },
+    "policy": {
+      "policyPackRef": "protocol/agentic-workbench/v1/policy_packs/workspace-default.v0.1.json",
+      "policyPackHash": "sha256:5bf7c8abab452ccf16685af2780af25d0d85e9a09a7c4b9a31e548a9fc50296c",
+      "trustProfileRef": "protocol/agentic-workbench/v1/trust_profiles/default.v0.1.json",
+      "defaultQuorumRule": "2of3-human",
+      "attestationRequired": true,
+      "ledgerMode": "required"
+    },
+    "steps": [
+      {
+        "stepId": "delegate-a2a",
+        "name": "delegate work to remote agent",
+        "transport": "a2a",
+        "capabilityRef": "capd://caps.bus.tritrpc",
+        "effect": "compute",
+        "target": {
+          "agentId": "remote-agent",
+          "skill": "delegate-work"
+        },
+        "placement": {
+          "side": "either"
+        },
+        "approval": {
+          "required": false
+        },
+        "observability": {
+          "traceLevel": "standard"
+        }
+      }
+    ],
+    "edges": [],
+    "bundleProjection": {
+      "targetRepo": "agentplane",
+      "artifactOutDir": "artifacts/a2a-delegate-smoke",
+      "executorStrategy": "placement",
+      "backendIntentDefault": "fleet"
+    }
+  }
+}

--- a/protocol/agentic-workbench/v1/fixtures/human.gated.exec.step.v0.1.json
+++ b/protocol/agentic-workbench/v1/fixtures/human.gated.exec.step.v0.1.json
@@ -1,0 +1,63 @@
+{
+  "apiVersion": "agentic-workbench.socios@1",
+  "kind": "Workflow",
+  "metadata": {
+    "name": "human-gated-exec-smoke",
+    "version": "0.1",
+    "createdAt": "2026-04-02T00:00:00Z"
+  },
+  "spec": {
+    "input": {
+      "schemaRef": "inline://none"
+    },
+    "output": {
+      "schemaRef": "inline://exec-result"
+    },
+    "defaults": {
+      "timeoutSec": 120,
+      "retryMax": 0,
+      "retryBackoffSec": 0,
+      "cacheMode": "off",
+      "ledgerMode": "required",
+      "humanGateRequired": true,
+      "lane": "dev"
+    },
+    "policy": {
+      "policyPackRef": "protocol/agentic-workbench/v1/policy_packs/human-gated-exec.v0.1.json",
+      "policyPackHash": "sha256:9a11ee40ab7e45a96c8c7f3977e17c80e0187e80c8754c2f4d62556ecd25d425",
+      "trustProfileRef": "protocol/agentic-workbench/v1/trust_profiles/human-gated-exec.v0.1.json",
+      "defaultQuorumRule": "2of3-human",
+      "attestationRequired": true,
+      "ledgerMode": "required"
+    },
+    "steps": [
+      {
+        "stepId": "dangerous-exec",
+        "name": "dangerous exec requiring quorum",
+        "transport": "local",
+        "capabilityRef": "capd://caps.audit.appendonly",
+        "effect": "exec",
+        "target": {
+          "operation": "dangerous-run"
+        },
+        "placement": {
+          "side": "either"
+        },
+        "approval": {
+          "required": true,
+          "quorumRule": "2of3-human"
+        },
+        "observability": {
+          "traceLevel": "full"
+        }
+      }
+    ],
+    "edges": [],
+    "bundleProjection": {
+      "targetRepo": "agentplane",
+      "artifactOutDir": "artifacts/human-gated-exec-smoke",
+      "executorStrategy": "fixed",
+      "backendIntentDefault": "fleet"
+    }
+  }
+}

--- a/protocol/agentic-workbench/v1/fixtures/mcp.read.step.v0.1.json
+++ b/protocol/agentic-workbench/v1/fixtures/mcp.read.step.v0.1.json
@@ -1,0 +1,63 @@
+{
+  "apiVersion": "agentic-workbench.socios@1",
+  "kind": "Workflow",
+  "metadata": {
+    "name": "mcp-read-smoke",
+    "version": "0.1",
+    "createdAt": "2026-04-02T00:00:00Z"
+  },
+  "spec": {
+    "input": {
+      "schemaRef": "inline://none"
+    },
+    "output": {
+      "schemaRef": "inline://hash-result"
+    },
+    "defaults": {
+      "timeoutSec": 30,
+      "retryMax": 0,
+      "retryBackoffSec": 0,
+      "cacheMode": "off",
+      "ledgerMode": "required",
+      "humanGateRequired": false,
+      "lane": "dev"
+    },
+    "policy": {
+      "policyPackRef": "protocol/agentic-workbench/v1/policy_packs/workspace-default.v0.1.json",
+      "policyPackHash": "sha256:5bf7c8abab452ccf16685af2780af25d0d85e9a09a7c4b9a31e548a9fc50296c",
+      "trustProfileRef": "protocol/agentic-workbench/v1/trust_profiles/default.v0.1.json",
+      "defaultQuorumRule": "2of3-human",
+      "attestationRequired": true,
+      "ledgerMode": "required"
+    },
+    "steps": [
+      {
+        "stepId": "hash-readme",
+        "name": "hash a file using MCP read-only tool",
+        "transport": "mcp",
+        "capabilityRef": "capd://caps.semantic.search_bi",
+        "effect": "read",
+        "target": {
+          "server": "fs.introspect",
+          "tool": "hash"
+        },
+        "placement": {
+          "side": "either"
+        },
+        "approval": {
+          "required": false
+        },
+        "observability": {
+          "traceLevel": "standard"
+        }
+      }
+    ],
+    "edges": [],
+    "bundleProjection": {
+      "targetRepo": "agentplane",
+      "artifactOutDir": "artifacts/mcp-read-smoke",
+      "executorStrategy": "placement",
+      "backendIntentDefault": "fleet"
+    }
+  }
+}

--- a/protocol/agentic-workbench/v1/policy_packs/control-plane.v0.1.json
+++ b/protocol/agentic-workbench/v1/policy_packs/control-plane.v0.1.json
@@ -1,0 +1,52 @@
+{
+  "apiVersion": "agentic-workbench.socios@1",
+  "kind": "PolicyPack",
+  "metadata": {
+    "name": "control-plane",
+    "version": "0.1",
+    "description": "Strict policy pack for control-plane repos and enforcement services."
+  },
+  "spec": {
+    "defaults": {
+      "lane": "staging",
+      "ledgerMode": "required",
+      "attestationRequired": true,
+      "retryMax": 0,
+      "timeoutSec": 120
+    },
+    "transportPolicy": {
+      "allowedTransports": [
+        "mcp",
+        "a2a",
+        "human",
+        "local"
+      ],
+      "disallowedTransports": [
+        "openai"
+      ]
+    },
+    "effects": {
+      "requireGrantFor": [
+        "read",
+        "write",
+        "compute",
+        "exec",
+        "egress"
+      ],
+      "humanGateFor": [
+        "exec",
+        "egress"
+      ]
+    },
+    "approvalRules": {
+      "low": "1of1-human",
+      "medium": "2of3-human",
+      "high": "2of3-human"
+    },
+    "constraints": {
+      "bytesMaxDefault": 50000000,
+      "ratePerMinDefault": 6,
+      "allowDomainsDefault": []
+    }
+  }
+}

--- a/protocol/agentic-workbench/v1/policy_packs/human-gated-exec.v0.1.json
+++ b/protocol/agentic-workbench/v1/policy_packs/human-gated-exec.v0.1.json
@@ -1,0 +1,51 @@
+{
+  "apiVersion": "agentic-workbench.socios@1",
+  "kind": "PolicyPack",
+  "metadata": {
+    "name": "human-gated-exec",
+    "version": "0.1",
+    "description": "Policy pack for dangerous exec/write/egress flows requiring explicit human quorum."
+  },
+  "spec": {
+    "defaults": {
+      "lane": "dev",
+      "ledgerMode": "required",
+      "attestationRequired": true,
+      "retryMax": 0,
+      "timeoutSec": 180
+    },
+    "transportPolicy": {
+      "allowedTransports": [
+        "human",
+        "local",
+        "mcp",
+        "a2a"
+      ],
+      "disallowedTransports": [
+        "openai"
+      ]
+    },
+    "effects": {
+      "requireGrantFor": [
+        "write",
+        "exec",
+        "egress"
+      ],
+      "humanGateFor": [
+        "write",
+        "exec",
+        "egress"
+      ]
+    },
+    "approvalRules": {
+      "low": "1of1-human",
+      "medium": "2of3-human",
+      "high": "2of3-human"
+    },
+    "constraints": {
+      "bytesMaxDefault": 10000000,
+      "ratePerMinDefault": 3,
+      "allowDomainsDefault": []
+    }
+  }
+}

--- a/protocol/agentic-workbench/v1/policy_packs/workspace-default.v0.1.json
+++ b/protocol/agentic-workbench/v1/policy_packs/workspace-default.v0.1.json
@@ -1,0 +1,48 @@
+{
+  "apiVersion": "agentic-workbench.socios@1",
+  "kind": "PolicyPack",
+  "metadata": {
+    "name": "workspace-default",
+    "version": "0.1",
+    "description": "Default workspace policy pack for low-to-moderate risk orchestrated work."
+  },
+  "spec": {
+    "defaults": {
+      "lane": "dev",
+      "ledgerMode": "required",
+      "attestationRequired": true,
+      "retryMax": 0,
+      "timeoutSec": 300
+    },
+    "transportPolicy": {
+      "allowedTransports": [
+        "mcp",
+        "a2a",
+        "openai",
+        "human",
+        "local"
+      ],
+      "disallowedTransports": []
+    },
+    "effects": {
+      "requireGrantFor": [
+        "write",
+        "exec",
+        "egress"
+      ],
+      "humanGateFor": [
+        "egress"
+      ]
+    },
+    "approvalRules": {
+      "low": "0of0",
+      "medium": "1of1-human",
+      "high": "2of3-human"
+    },
+    "constraints": {
+      "bytesMaxDefault": 0,
+      "ratePerMinDefault": 0,
+      "allowDomainsDefault": []
+    }
+  }
+}

--- a/protocol/agentic-workbench/v1/trust_profiles/control-plane.v0.1.json
+++ b/protocol/agentic-workbench/v1/trust_profiles/control-plane.v0.1.json
@@ -1,0 +1,62 @@
+{
+  "apiVersion": "agentic-workbench.socios@1",
+  "kind": "TrustProfile",
+  "metadata": {
+    "name": "control-plane",
+    "version": "0.1",
+    "description": "Strict profile for agentplane, zero-trust services, and workspace control repos."
+  },
+  "spec": {
+    "attestation": {
+      "subjectRequired": true,
+      "executorRequired": true,
+      "requireAumDigest": true,
+      "acceptedEvidence": [
+        "tpm",
+        "cosign",
+        "fido2"
+      ]
+    },
+    "grants": {
+      "requiredEffects": [
+        "read",
+        "write",
+        "compute",
+        "exec",
+        "egress"
+      ],
+      "ttlSecMax": 300,
+      "requirePolicyHash": true
+    },
+    "approvals": {
+      "dangerClassesRequiringQuorum": [
+        "MEDIUM",
+        "HIGH"
+      ],
+      "defaultRule": "2of3-human",
+      "allowServiceOnlyForLow": false
+    },
+    "ledger": {
+      "mode": "required",
+      "redactionProfileRef": "repo://mcp-a2a-zero-trust/redaction/control-plane",
+      "redactByDefault": true
+    },
+    "network": {
+      "requireEgressGrant": true,
+      "defaultAllowDomains": []
+    },
+    "constraints": {
+      "pathsAllowDefault": [],
+      "pathsDenyDefault": [
+        "**/.git/**",
+        "**/.ssh/**"
+      ],
+      "bytesMaxDefault": 50000000,
+      "ratePerMinDefault": 6
+    },
+    "enforcement": {
+      "failClosed": true,
+      "requireSignedLedgerEvents": true
+    }
+  }
+}

--- a/protocol/agentic-workbench/v1/trust_profiles/default.v0.1.json
+++ b/protocol/agentic-workbench/v1/trust_profiles/default.v0.1.json
@@ -1,0 +1,55 @@
+{
+  "apiVersion": "agentic-workbench.socios@1",
+  "kind": "TrustProfile",
+  "metadata": {
+    "name": "default",
+    "version": "0.1",
+    "description": "Workspace-default trust posture for ordinary orchestrated steps."
+  },
+  "spec": {
+    "attestation": {
+      "subjectRequired": true,
+      "executorRequired": false,
+      "requireAumDigest": true,
+      "acceptedEvidence": [
+        "tpm",
+        "cosign"
+      ]
+    },
+    "grants": {
+      "requiredEffects": [
+        "write",
+        "exec",
+        "egress"
+      ],
+      "ttlSecMax": 900,
+      "requirePolicyHash": true
+    },
+    "approvals": {
+      "dangerClassesRequiringQuorum": [
+        "HIGH"
+      ],
+      "defaultRule": "2of3-human",
+      "allowServiceOnlyForLow": false
+    },
+    "ledger": {
+      "mode": "required",
+      "redactionProfileRef": "repo://mcp-a2a-zero-trust/redaction/default",
+      "redactByDefault": false
+    },
+    "network": {
+      "requireEgressGrant": true,
+      "defaultAllowDomains": []
+    },
+    "constraints": {
+      "pathsAllowDefault": [],
+      "pathsDenyDefault": [],
+      "bytesMaxDefault": 0,
+      "ratePerMinDefault": 0
+    },
+    "enforcement": {
+      "failClosed": true,
+      "requireSignedLedgerEvents": true
+    }
+  }
+}

--- a/protocol/agentic-workbench/v1/trust_profiles/human-gated-exec.v0.1.json
+++ b/protocol/agentic-workbench/v1/trust_profiles/human-gated-exec.v0.1.json
@@ -1,0 +1,57 @@
+{
+  "apiVersion": "agentic-workbench.socios@1",
+  "kind": "TrustProfile",
+  "metadata": {
+    "name": "human-gated-exec",
+    "version": "0.1",
+    "description": "Profile for side-effecting exec/write/egress steps requiring human quorum."
+  },
+  "spec": {
+    "attestation": {
+      "subjectRequired": true,
+      "executorRequired": true,
+      "requireAumDigest": true,
+      "acceptedEvidence": [
+        "tpm",
+        "cosign",
+        "fido2"
+      ]
+    },
+    "grants": {
+      "requiredEffects": [
+        "write",
+        "exec",
+        "egress"
+      ],
+      "ttlSecMax": 300,
+      "requirePolicyHash": true
+    },
+    "approvals": {
+      "dangerClassesRequiringQuorum": [
+        "MEDIUM",
+        "HIGH"
+      ],
+      "defaultRule": "2of3-human",
+      "allowServiceOnlyForLow": false
+    },
+    "ledger": {
+      "mode": "required",
+      "redactionProfileRef": "repo://mcp-a2a-zero-trust/redaction/high-risk",
+      "redactByDefault": true
+    },
+    "network": {
+      "requireEgressGrant": true,
+      "defaultAllowDomains": []
+    },
+    "constraints": {
+      "pathsAllowDefault": [],
+      "pathsDenyDefault": [],
+      "bytesMaxDefault": 10000000,
+      "ratePerMinDefault": 3
+    },
+    "enforcement": {
+      "failClosed": true,
+      "requireSignedLedgerEvents": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Main already references `protocol/agentic-workbench/v1` in `manifest/workspace.toml` (`workspace.policy.policy_pack_ref`, `trust_profile_ref`) but the v1 directory and artifacts are not present.

This PR supplies the missing v1 payload:

- v1 workflow kernel schemas
- schema index
- trust profiles
- policy packs (hashes match manifest)
- fixture workflows for MCP/A2A/human-gated exec
- index generator helper (`tools/runner/gen_agentic_workbench_index.py`)

## Why

Without these files, the workspace policy references are broken. This PR makes the v1 protocol surface real and testable.

## Notes

This PR does not change runner behavior. It only materializes the protocol payload that the workspace controller already references.
