### PR TITLE
docs: align protocol router and canonical sources for agentic workbench v1

### DIFF
--- a/governance/CANONICAL_SOURCES.yaml
+++ b/governance/CANONICAL_SOURCES.yaml
@@ -11,6 +11,11 @@ namespaces:
   workspace/registry: { canonical_repo: sociosphere }
   workspace/compliance: { canonical_repo: sociosphere }
 
+  # Agentic workbench / workflow kernel
+  protocol/agentic-workbench/v1: { canonical_repo: sociosphere }
+  protocol/agentic-workbench/v1/trust_profiles: { canonical_repo: sociosphere }
+  protocol/agentic-workbench/v1/policy_packs: { canonical_repo: sociosphere }
+
   # Standards
   standards/platform: { canonical_repo: prophet-platform-standards }
   standards/storage: { canonical_repo: socioprophet-standards-storage }

--- a/protocol/protocol.md
+++ b/protocol/protocol.md
@@ -4,22 +4,21 @@ The workspace controller is the canonical home for shared protocol schemas, fixt
 
 ## Active protocol roots
 
-- `protocol/agentic-workbench/v0/` — active workflow-kernel, trust-profile, policy-pack, and governed artifact lifecycle surface
+- `protocol/agentic-workbench/v0/` — legacy governed artifact lifecycle surface
+- `protocol/agentic-workbench/v1/` — active workflow-kernel, trust-profile, and policy-pack surface
 
 ## Ownership boundaries
 
-- `sociosphere/protocol/agentic-workbench/v0/*` owns workflow orchestration objects and workspace-level trust profiles/policy packs.
+- `sociosphere/protocol/agentic-workbench/v1/*` owns workflow orchestration objects and workspace-level trust profiles/policy packs.
 - `mcp-a2a-zero-trust` owns canonical trust objects and the transport-facing capability registry.
 - `agentplane` owns static bundle execution contracts, runtime dispatch, receipts, and replay.
 
 ## Compatibility and fixtures
 
-Fixture vectors under `protocol/agentic-workbench/v0/fixtures/` are the canonical inputs for workflow-kernel contract tests and controller preflight validation.
+Fixture vectors under `protocol/agentic-workbench/v1/fixtures/` are the canonical inputs for workflow-kernel contract tests and controller preflight validation.
 
 ## Runner integration
 
 The workspace controller relies on runner-supported workflows for workspace operations.
 
-Policy and trust integrity checks remain workspace-level concerns, but they are not currently exposed here as dedicated `runner validate-policy`, `runner validate-trust`, or `runner trust-report` subcommands.
-
-Keep this document aligned with the commands actually implemented by `tools/runner/runner.py`.
+Policy and trust integrity checks remain workspace-level concerns. Dedicated validation/reporting commands may be introduced in follow-on changes, but this router should always reflect the protocol surface actually carried by the repo.


### PR DESCRIPTION
## Summary

Follow-up alignment PR for the workflow-kernel rollout.

Main now carries workspace policy references to `protocol/agentic-workbench/v1`, and PR #65 supplies the concrete v1 schema/policy/fixture payload. This PR fixes the remaining controller-facing drift:

- updates `protocol/protocol.md` to describe both `agentic-workbench/v0` and `v1`
- records `protocol/agentic-workbench/v1`, `trust_profiles`, and `policy_packs` in `governance/CANONICAL_SOURCES.yaml`

## Why

Without this, the workspace controller still documents only `v0` as active and does not record canonical ownership for the new `v1` workflow namespace.

## Merge order

This PR should merge after or alongside PR #65.
