### PR TITLE
chore(workspace): capture manifest cleanup tranche after connector write block

### DIFF
--- a/patches/workspace-manifest-cleanup-2026-04-09.md
+++ b/patches/workspace-manifest-cleanup-2026-04-09.md
@@ -1,0 +1,19 @@
+# Workspace manifest cleanup tranche — 2026-04-09
+
+This branch captures the smallest no-churn cleanup identified during live connector review.
+
+## Verified defects
+
+1. `manifest/workspace.toml` maps `socioprophet_web` to `https://github.com/SocioProphet/socioprophet` with `ref = "main"`, but the live repository does not expose a `main` branch.
+2. `manifest/workspace.lock.json` repeats the same `socioprophet_web` ref mismatch.
+3. `manifest/workspace.toml` contains a duplicate `agentplane` entry. The canonical `execution-plane` entry should retain the trust metadata, and the later duplicate entry should be removed.
+
+## Intended direct fix
+
+- change `socioprophet_web` from `ref = "main"` to `ref = "master"` in both manifest and lock
+- fold trust metadata into the canonical `agentplane` entry
+- remove the duplicate `agentplane` block
+
+## Why this note exists
+
+The connector session allowed branch creation and full repo verification, but tracked-file overwrite was blocked by the current safety layer. This note preserves the exact tranche in GitHub without claiming the tracked files were updated here.


### PR DESCRIPTION
## Summary

This draft PR captures the smallest validated workspace-manifest cleanup tranche identified during the live connector rebase.

### Verified defects
- `manifest/workspace.toml` maps `socioprophet_web` to `SocioProphet/socioprophet` with `ref = "main"`, but the live repository does not expose a `main` branch.
- `manifest/workspace.lock.json` repeats the same `socioprophet_web` ref mismatch.
- `manifest/workspace.toml` contains a duplicate `agentplane` entry. The canonical `execution-plane` entry should retain the trust metadata, and the later duplicate entry should be removed.

### Intended direct fix
- change `socioprophet_web` from `ref = "main"` to `ref = "master"` in both manifest and lock
- fold trust metadata into the canonical `agentplane` entry
- remove the duplicate `agentplane` block

## Why this PR is capture-only

The live GitHub connector session allowed:
- upstream verification
- isolated branch creation
- branch-local commit creation for a new note file

But tracked-file overwrite of `manifest/workspace.toml` and `manifest/workspace.lock.json` was blocked by the current safety layer in this environment. This draft PR preserves the exact tranche and blocker state in GitHub without pretending the tracked files were updated here.

## Next move

Apply the exact manifest/lock patch through a fuller write surface or local clone, then either update this PR or supersede it with the direct-fix PR.
