### PR TITLE
docs(workspace): capture ContractForge registration tranche

### DIFF
--- a/docs/CONTRACTFORGE_REPO_METADATA.md
+++ b/docs/CONTRACTFORGE_REPO_METADATA.md
@@ -1,0 +1,42 @@
+# ContractForge repo metadata
+
+## Canonical identity
+
+- repo id: `contractforge`
+- repository full name: `SocioProphet/contractforge`
+- url: `https://github.com/SocioProphet/contractforge`
+- intended role: `component`
+- intended layer: `core-platform`
+- status: `active`
+
+## Summary
+
+ContractForge is the canonical repository for contract lifecycle, contractual economics, settlement semantics, adjustments, reversals, restatements, and ledger-anchored finalization.
+
+## Adjacent repositories
+
+- `sociosphere`
+- `policy-fabric`
+- `prophet-platform`
+- `socioprophet-standards-storage`
+- `ontogenesis`
+- `socioprophet-standards-knowledge`
+
+## Forbidden responsibilities
+
+ContractForge should not be used as:
+
+- workspace controller
+- generic policy canon
+- generic standards canon
+- generic ontology canon
+- umbrella public-surface default home
+
+## Registration note
+
+This document exists to pin the intended metadata before the corresponding updates land in:
+
+- `registry/canonical-repos.yaml`
+- `manifest/workspace.toml`
+- `manifest/workspace.lock.json`
+- `governance/CANONICAL_SOURCES.yaml`

--- a/docs/CONTRACTFORGE_REPO_REGISTRATION_TRANCHE.md
+++ b/docs/CONTRACTFORGE_REPO_REGISTRATION_TRANCHE.md
@@ -1,0 +1,62 @@
+# ContractForge registration tranche
+
+## Purpose
+
+This document captures the workspace-controller changes required to register `SocioProphet/contractforge` cleanly inside `sociosphere` without increasing existing controller drift.
+
+## Why a tranche is needed
+
+`contractforge` now exists as the canonical repository for contract lifecycle, contractual economics, settlement semantics, adjustments, reversals, restatements, and ledger-anchored finalization.
+
+`Sociosphere` should register it, but several controller cleanup items should be completed in the same discipline lane:
+
+1. normalize manifest identity drift
+2. normalize lock completeness
+3. normalize canonical registry shape
+4. then add `contractforge` as a managed canonical repo
+
+## Intended repo role
+
+- canonical repo id: `contractforge`
+- repository full name: `SocioProphet/contractforge`
+- primary role: `component`
+- status: `active`
+- control-plane classification: contract-domain product repo, not workspace controller, not policy repo, not generic standards repo
+
+## Boundary summary
+
+ContractForge should be registered in `sociosphere` as:
+- a managed canonical repository,
+- governed by workspace policy and topology rules,
+- adjacent to `policy-fabric`, `prophet-platform`, and `socioprophet-standards-storage`,
+- but not merged into any of those repos.
+
+## Required follow-on file edits
+
+### 1. `registry/canonical-repos.yaml`
+- add `contractforge`
+- normalize the file so only one registry schema remains authoritative
+
+### 2. `manifest/workspace.toml`
+- add `contractforge` as a remote canonical repo entry
+- do this only after duplicate/alias drift is cleaned up in the manifest
+
+### 3. `manifest/workspace.lock.json`
+- pin `contractforge` once fetched
+- continue eliminating `rev: null` for active materialized repos
+
+### 4. `governance/CANONICAL_SOURCES.yaml`
+- add contract-domain namespace ownership once the first canonical namespaces are frozen
+
+## Recommended namespace candidates
+
+These are candidates only and should be confirmed before canonization:
+- `contracts/core`
+- `contracts/lifecycle`
+- `contracts/settlement`
+- `contracts/adjustment`
+- `contracts/commitment`
+
+## Merge policy
+
+This tranche is intentionally documentation-first because the current connector surface is better suited to additive file creation than tracked-file overwrite. The actual manifest/registry edits should follow immediately in the next controller-normalization PR.


### PR DESCRIPTION
## Summary

Add the first explicit workspace-controller tranche for the new `SocioProphet/contractforge` repository.

### Added
- `docs/CONTRACTFORGE_REPO_REGISTRATION_TRANCHE.md`
- `docs/CONTRACTFORGE_REPO_METADATA.md`

## Why

`SocioProphet/contractforge` now exists as the canonical contract-domain repository, but `sociosphere` should not register it casually while controller normalization work is still pending.

This PR records:
- the intended repo role and boundaries,
- the exact controller files that need follow-on edits,
- the recommended namespace candidates,
- and the rule that `contractforge` is adjacent to workspace/policy/runtime/standards repos without being collapsed into them.

## Important scope note

This PR is intentionally documentation-first.

The current connector session is reliable for additive file creation but not ideal for tracked-file overwrite of the existing controller registry/manifest surfaces. The next follow-on controller-normalization PR should perform the actual edits to:

- `registry/canonical-repos.yaml`
- `manifest/workspace.toml`
- `manifest/workspace.lock.json`
- `governance/CANONICAL_SOURCES.yaml`

## Follow-on order

1. normalize `registry/canonical-repos.yaml` to a single authoritative schema
2. normalize duplicate/alias drift in `manifest/workspace.toml`
3. eliminate `rev: null` for active materialized repos in `manifest/workspace.lock.json`
4. add `contractforge` to the registry / manifest / lock / canonical sources in one disciplined tranche
