### PR TITLE
docs(architecture): add control-plane placement tranche

### DIFF
--- a/docs/architecture/control-plane-placement.md
+++ b/docs/architecture/control-plane-placement.md
@@ -1,0 +1,109 @@
+# Control-plane placement
+
+This document records the canonical upstream placement for the Matrix / MCP / A2A / capability-lease control-plane slice.
+
+It is intentionally **placement-first** and **implementation-light**.
+
+The goal is to stop repo-boundary drift before runtime code, schemas, and policy bundles land across the SocioProphet estate.
+
+## Canonical split
+
+### `sociosphere`
+
+`Sociosphere` is the **workspace controller**.
+
+It owns:
+- workspace composition
+- workspace manifest + lock
+- canonical ownership registry
+- trust profile references
+- policy-pack references
+- cross-repo placement guidance
+
+It does **not** own downstream feature implementation for the control plane.
+
+### `prophet-platform-standards`
+
+This repo is the canonical home for **normative control-plane standards**.
+
+It should carry:
+- Matrix dual-estate ADRs
+- capability-lease and approval ADRs
+- moderation / publication ADRs
+- MCP / A2A control-plane operating guidance
+
+### `socioprophet-standards-storage`
+
+This repo is the canonical home for **portable control-plane schemas and event contracts**.
+
+It should carry:
+- capability-lease schema
+- lease issued / denied / revoked events
+- Matrix room-pivot events
+- moderation decision events
+- provenance overlays for control-plane actions
+
+### `mcp-a2a-zero-trust`
+
+This repo is the canonical home for **zero-trust enforcement and registry implementation**.
+
+It should carry:
+- capability broker logic
+- capability registry mechanics
+- grant / ledger paths
+- attestation hooks
+- policy enforcement bundles
+- public and extended agent-card examples
+
+### `prophet-platform`
+
+This repo is the canonical home for the **deployable runtime and deployment topology**.
+
+It should carry:
+- public Matrix edge runtime
+- private Matrix core runtime
+- Keycloak deployment profile
+- capability broker runtime wiring
+- MCP gateway runtime wiring
+- A2A registry runtime wiring
+- control-plane infra / k8s topology
+
+### `policy-fabric`
+
+`Policy Fabric` is a **first-class downstream consumer**, not the source of truth for the generic control plane.
+
+It should adopt:
+- capability-lease semantics
+- approval / replay linkage
+- broker and registry integration
+
+## Recommended namespace additions
+
+The following namespace candidates should be added in a follow-on ownership tranche:
+
+```yaml
+identity/capability-broker: { canonical_repo: mcp-a2a-zero-trust }
+identity/capability-registry: { canonical_repo: mcp-a2a-zero-trust }
+standards/control-plane: { canonical_repo: prophet-platform-standards }
+standards/control-plane-contracts: { canonical_repo: socioprophet-standards-storage }
+prophet/control-plane-runtime: { canonical_repo: prophet-platform }
+collaboration/matrix: { canonical_repo: prophet-platform }
+```
+
+## Sequencing
+
+Recommended order:
+
+1. `sociosphere` manifest dedupe and controller normalization
+2. `sociosphere` ownership / placement tranche
+3. `prophet-platform-standards` normative ADR tranche
+4. `socioprophet-standards-storage` schema tranche
+5. `mcp-a2a-zero-trust` broker / registry tranche
+6. `prophet-platform` runtime tranche
+7. `policy-fabric` consumer-adoption tranche
+
+## Notes
+
+This document does not change canonical ownership by itself.
+
+It is intended to make the next ownership / namespace follow-on PR narrow, explicit, and reviewable.

--- a/manifest/workspace.toml
+++ b/manifest/workspace.toml
@@ -12,9 +12,8 @@ default_quorum_rule = "2of3-human"
 
 # NOTE: This manifest supports both local materialized repos (local_path)
 # and remote repos (url + ref/rev). The lock file resolves remote inputs.
-# Local development overrides should be expressed directly in this file by
-# updating each repo entry's source fields (for example, `local_path` for a
-# local checkout or `url` + `ref`/`rev` for a remote source).
+# Local development overrides should be expressed in `manifest/overrides.toml`
+# where possible, rather than editing this committed manifest directly.
 # Canonical repo inventory: registry/canonical-repos.yaml (materialized entries + remote-only canonical mirrors live here)
 # Merge order for open PRs: governance/MERGE-ORDER.md
 # Controlled glossary: docs/GLOSSARY.md
@@ -31,7 +30,7 @@ default_quorum_rule = "2of3-human"
 #   local_path    – path inside this workspace after materialization
 #   license_hint  – non-authoritative; used by supply-chain policy checks
 #   entry         – optional runtime metadata (kind, module, etc.)
-#   required_capabilities – adapter-only capability declarations
+#   required_capabilities – optional capability declarations
 
 # ── Control-plane tools ──────────────────────────────────────────────────────
 
@@ -117,6 +116,9 @@ url = "https://github.com/SocioProphet/agentplane"
 ref = "main"
 local_path = "components/agentplane"
 license_hint = "MIT"
+trust_zone = "control"
+trust_profile_ref = "protocol/agentic-workbench/v1/trust_profiles/control-plane.v0.1.json"
+required_grants = ["agentplane.run:exec", "agentplane.replay:compute"]
 
 [[repos]]
 name = "semantic_serdes"
@@ -200,6 +202,9 @@ url = "https://github.com/SocioProphet/mcp-a2a-zero-trust"
 ref = "main"
 local_path = "components/mcp_a2a_zero_trust"
 license_hint = "MIT"
+trust_zone = "control"
+trust_profile_ref = "protocol/agentic-workbench/v1/trust_profiles/control-plane.v0.1.json"
+required_capabilities = ["policy", "attestation", "grant", "ledger", "capability_registry"]
 
 [[repos]]
 name = "new_hope"
@@ -236,26 +241,6 @@ role = "docs"
 local_path = "components/socioprophet_integration"
 url = "https://github.com/SocioProphet/socioprophet_integration"
 ref = "main"
-
-[[repos]]
-name = "agentplane"
-role = "component"
-url = "https://github.com/SocioProphet/agentplane.git"
-ref = "main"
-local_path = "components/agentplane"
-trust_zone = "control"
-trust_profile_ref = "protocol/agentic-workbench/v1/trust_profiles/control-plane.v0.1.json"
-required_grants = ["agentplane.run:exec", "agentplane.replay:compute"]
-
-[[repos]]
-name = "mcp-a2a-zero-trust"
-role = "adapter"
-url = "https://github.com/SocioProphet/mcp-a2a-zero-trust.git"
-ref = "main"
-local_path = "adapters/mcp-a2a-zero-trust"
-required_capabilities = ["policy", "attestation", "grant", "ledger", "capability_registry"]
-trust_zone = "control"
-trust_profile_ref = "protocol/agentic-workbench/v1/trust_profiles/control-plane.v0.1.json"
 
 [[repos]]
 name = "socioprophet_docs"


### PR DESCRIPTION
## Summary

Add a small stacked follow-on on top of `#71` that records the canonical upstream placement for the Matrix / MCP / A2A / capability-lease control-plane slice.

### Added
- `docs/architecture/control-plane-placement.md`

## Why

`#71` is correctly keeping the manifest dedupe narrow.

This child PR captures the repo-boundary decision so the next ownership and registry follow-ons can stay precise:
- `sociosphere` = workspace/controller/composition
- `prophet-platform-standards` = normative control-plane ADRs and ops standards
- `socioprophet-standards-storage` = schemas / event contracts / provenance overlays
- `mcp-a2a-zero-trust` = broker / registry / grant / ledger / enforcement implementation
- `prophet-platform` = runtime and deployment topology
- `policy-fabric` = governed downstream consumer

## Scope note

This PR is intentionally docs-only.

It also records the exact namespace additions that should be applied in the next ownership tranche without overloading `#71`.

## Next follow-on

After this PR, the next stacked controller tranche should update:
- `governance/CANONICAL_SOURCES.yaml`
- and, separately if still needed, `registry/canonical-repos.yaml`

## Stack position

Base branch: `workflow-trust/pr1e-manifest-dedup` (`#71`)
