### PR TITLE
governance(market-data): register standards and runtime ownership lanes

### DIFF
--- a/governance/CANONICAL_SOURCES.yaml
+++ b/governance/CANONICAL_SOURCES.yaml
@@ -19,6 +19,7 @@ namespaces:
   # Standards
   standards/platform: { canonical_repo: prophet-platform-standards }
   standards/storage: { canonical_repo: socioprophet-standards-storage }
+  standards/market-data: { canonical_repo: prophet-platform-standards, upstream_standard: socioprophet-standards-storage, note: "runtime market-data profile authority; storage semantics remain upstream" }
   standards/knowledge: { canonical_repo: socioprophet-standards-knowledge }
 
   # Transport & protocol
@@ -45,6 +46,7 @@ namespaces:
 
   # Prophet core cluster
   prophet/platform: { canonical_repo: prophet-platform }
+  prophet/market-data: { canonical_repo: prophet-platform, note: "runtime adoption surface for market-data profile v0" }
   prophet/libs: { canonical_repo: prophet-platform, consolidation_note: "collapse prophet-core-libs into prophet-platform/libs" }
   prophet/contracts: { canonical_repo: gaia-world-model, consolidation_note: "collapse prophet-core-contracts into gaia-world-model/contracts" }
   prophet/ledger: { canonical_repo: prophet-platform, consolidation_note: "collapse prophet-core-ledger into prophet-platform/contracts" }


### PR DESCRIPTION
## Summary
- update `governance/CANONICAL_SOURCES.yaml`
- register `standards/market-data` under `prophet-platform-standards`
- record `prophet/market-data` as the runtime adoption lane in `prophet-platform`
- keep storage semantics explicitly upstream in `socioprophet-standards-storage`

## Why
This makes the workspace controller aware of the new market-data standards lane and avoids a split-brain authority model between runtime standards and upstream storage semantics.

## Related PRs
- standards: https://github.com/SocioProphet/prophet-platform-standards/pull/3
- runtime: https://github.com/SocioProphet/prophet-platform/pull/40
