### PR TITLE
Draft: Formalize fabric follow-up contracts (manifest, indexpack, conflict matrix, FabricFS, quorum)

### DIFF
--- a/docs/design/conflict-matrix.md
+++ b/docs/design/conflict-matrix.md
@@ -1,0 +1,59 @@
+# Conflict matrix
+
+## Purpose
+Define authoritative side, version source, tombstone semantics, and manual intervention triggers for each connector and topology.
+
+## Default strategy hierarchy
+1. explicit release snapshot beats mutable head
+2. authoritative local cell beats remote replica in `local_first`
+3. explicit quorum failover can temporarily change authority
+4. manual reconcile queue beats silent destructive merge
+
+## Topology matrix
+
+### Local mount ↔ local canonical object store
+- authority: local mount ingest path
+- version source: manifest generation order
+- tombstones: explicit and immediate
+- manual intervention: no
+
+### Google Drive ↔ local-first workspace
+- authority: local in `local_first`, drive in `provider_first`
+- version source: Drive revision / modified time + local manifest generation
+- tombstones: remote delete becomes local tombstone only after policy check
+- manual intervention: yes when local edits exist after last synced revision
+
+### rsync peer ↔ local-first workspace
+- authority: configured per connector; default local
+- version source: checksum if enabled, otherwise mtime+size
+- tombstones: delete propagation only when explicitly enabled
+- manual intervention: yes for bidirectional mutable trees unless one side is declared source-of-truth
+
+### S3/MinIO replica ↔ local-first workspace
+- authority: local unless replica is promoted
+- version source: object version id or etag + manifest generation
+- tombstones: propagate as signed delete markers
+- manual intervention: only when split-brain promotion occurs
+
+### Hyper mesh peer ↔ local-first workspace
+- authority: release snapshot or signed feed ordering
+- version source: feed sequence + signed manifest/index refs
+- tombstones: feed deltas carry tombstones explicitly
+- manual intervention: yes if peer presents conflicting mutable head without accepted quorum event
+
+### Cloud twin ↔ edge authoritative site
+- authority: edge by default
+- version source: snapshot generation + manifest generation
+- tombstones: mirrored after replication checkpoint
+- manual intervention: required for failover/failback transitions
+
+## Safe defaults
+- Drive connectors default to pull or local-authoritative sync
+- rsync defaults to one-way mirror unless explicitly promoted
+- Hyper distribution defaults to manifest/index export only
+- vendor file stores are never authoritative
+
+## Open decisions
+- exact tie-breakers when local edits and remote tombstones race
+- branch/merge semantics for collaborative mutable datasets
+- failback rules after cloud twin promotion

--- a/docs/design/fabricfs-commands.md
+++ b/docs/design/fabricfs-commands.md
@@ -1,0 +1,23 @@
+# FabricFS command surface
+
+## Goals
+Provide an AFS-inspired operator interface for mounts, quotas, ACLs, replication status, and governance.
+
+## Core commands
+- `fs examine <path>`
+  - prints mount type, MountRef, manifest root, index generation, quota, replication status
+- `fs listquota <path>`
+  - prints data bytes, index bytes, cache bytes, limits
+- `fs setquota <path> <limit>`
+  - updates quota envelope (policy-gated)
+- `fs listacl <path>` / `fs setacl <path> <principal> <rights>`
+  - directory-scoped ACLs using `rlidwka`
+- `fs whereis <path>`
+  - shows backing endpoints / replica locations
+- `fs whichcell <path>`
+  - shows trust/admin domain
+
+## Required semantics
+- `lookup`/traversal requirements must be linted; no effective read/write without traversable parents
+- command output must be scriptable (`--json`)
+- governance objects under `.quorum/` must be visible and inspectable

--- a/docs/design/indexpack-v1.md
+++ b/docs/design/indexpack-v1.md
@@ -1,0 +1,61 @@
+# indexpack.v1
+
+## Purpose
+`indexpack.v1` is the portable bundle of derived retrieval state associated with a specific `manifest.v1` root.
+
+## Invariants
+- every indexpack binds to exactly one `manifest_id`
+- indexpacks are rebuildable from canonical objects + pipeline definition
+- indexpacks may be exported without raw objects when policy permits
+
+## Required fields
+- `schema_version`: `indexpack.v1`
+- `indexpack_id`
+- `manifest_id`
+- `pipeline_version`
+- `created_at`
+- `created_by`
+- `chunk_sets[]`
+- `embedding_sets[]`
+- `keyword_index_refs[]`
+- `provenance`
+
+## Chunk set
+Each chunk record includes:
+- `chunk_id`
+- `object_id`
+- `object_version`
+- `byte_range` or logical segment ref
+- `text_hash`
+- `classification_tags[]`
+
+## Embedding set
+Each embedding record includes:
+- `embedding_id`
+- `chunk_id`
+- `model_id`
+- `vector_dim`
+- `storage_ref`
+- optional `redaction_profile`
+
+## Keyword index refs
+May include:
+- local sqlite/fts path ref
+- tantivy/lucene segment ref
+- exported postings bundle ref
+
+## Provenance
+Must describe:
+- source `manifest_id`
+- extraction policy version
+- chunking policy version
+- embedding model id/version
+- indexing tool/runtime id
+
+## Export modes
+- `local_only`
+- `portable_bundle`
+- `mesh_export`
+
+## Security note
+Embedding export MAY leak semantic content. `high_threat` policy SHOULD require explicit allow before exporting embedding sets outside the authoritative cell.

--- a/docs/design/manifest-v1.md
+++ b/docs/design/manifest-v1.md
@@ -1,0 +1,84 @@
+# manifest.v1
+
+## Purpose
+`manifest.v1` is the canonical, deterministic description of a mounted dataset view. It is the root object that connectors, indexers, Hyper feeds, releases, and conflict resolution bind to.
+
+## Invariants
+- every manifest has exactly one `manifest_id`
+- `manifest_id` is the hash of the canonical serialized manifest body
+- ordering is deterministic
+- path entries may be plaintext or encrypted depending on policy profile
+- every entry points to a canonical `object_id`
+- manifests are immutable once committed; changes produce a new manifest
+
+## Required fields
+- `schema_version`: `manifest.v1`
+- `manifest_id`
+- `created_at`
+- `created_by`
+- `dataset_ref`
+- `mount_ref`
+- `policy_bundle_ref`
+- `entries[]`
+- `root_hash`
+
+## Entry fields
+Each entry contains:
+- `logical_path`
+- `path_mode`: `plaintext | encrypted`
+- `object_id`
+- `object_version`
+- `size_bytes`
+- `mtime`
+- `mime_type`
+- `connector_source_refs[]`
+- `classification_tags[]`
+- `acl_snapshot_ref`
+- `tombstone`: boolean
+
+## Canonical ordering
+Entries sort by:
+1. normalized logical path bytes
+2. object_id
+3. object_version
+
+## Hashing
+- hash algorithm: `sha256`
+- `root_hash` is the Merkle-like aggregate over ordered entry hashes
+- each entry hash is over the canonical serialized form of that entry
+
+## Encryption mode
+When `path_mode=encrypted`:
+- `logical_path` stores ciphertext or opaque token
+- cleartext path mapping remains local to the authoritative cell unless policy allows export
+
+## Connector source references
+`connector_source_refs[]` may include:
+- Drive: `drive:file_id:revision_id`
+- S3: `s3:bucket:key:version_or_etag`
+- rsync: `rsync:path:fingerprint`
+- Hyperdrive: `hyperdrive:key:path`
+- local fs: `localfs:device:path:fingerprint`
+
+## Authority rules
+- local-first mode: local manifest authority wins unless explicit failover/quorum says otherwise
+- release snapshots are immutable manifests
+- mutable heads always point to the latest accepted manifest
+
+## Export profiles
+- `full`: plaintext paths + connector refs + object refs
+- `redacted`: reduced metadata, plaintext optional
+- `high_threat`: encrypted paths, minimized connector refs
+
+## Signing
+A detached signature SHOULD cover:
+- `manifest_id`
+- `dataset_ref`
+- `root_hash`
+- `policy_bundle_ref`
+- `created_at`
+
+## Relationship to other objects
+- `indexpack.v1` binds to one `manifest_id`
+- `ManifestDelta` events transition one manifest to the next
+- releases point at immutable manifest roots

--- a/docs/design/quorum-policy.md
+++ b/docs/design/quorum-policy.md
@@ -1,0 +1,43 @@
+# Quorum and policy
+
+## Purpose
+Govern high-impact actions in a local-first multi-user fabric.
+
+## Action classes
+
+### Class 0 — no quorum
+- read/search within ACLs
+- local reindex
+- local tool run without network/secrets expansion
+
+### Class 1 — owner or project-admin approval
+- add approved connector to project
+- publish read-only release to allowlisted peers
+- adjust project quota within cell limits
+
+### Class 2 — quorum required
+- enable WAN egress for tools
+- publish discovery topics beyond allowlist
+- add tool with network + secrets
+- rotate dataset root keys
+- destructive purge of canonical data
+- promote cloud twin as authority
+
+## Object model
+- `proposal`: action, scope, threshold, expiry, nonce, requested_by
+- `approval`: proposal_id, approver, signature, timestamp
+- `commit`: proposal_id, threshold_met, applied_at, controller_ref, resulting policy/version refs
+
+## Filesystem placement
+- `/fabric/<cell>/.quorum/proposals/`
+- `/fabric/<cell>/.quorum/approvals/`
+- `/fabric/<cell>/.quorum/commits/`
+
+## Policy bundles
+Profiles should include:
+- normal
+- high_threat
+- airgap
+- connector-specific rules
+- vendor egress rules
+- retention classes


### PR DESCRIPTION
## Summary
This draft PR converts the already-landed umbrella architecture doc into reviewable implementation contracts.

It adds:
- `docs/design/manifest-v1.md`
- `docs/design/indexpack-v1.md`
- `docs/design/conflict-matrix.md`
- `docs/design/fabricfs-commands.md`
- `docs/design/quorum-policy.md`

These documents refine the architecture in `docs/design/fabric-architecture.md` into concrete next-step artifacts for buildout.

## Why
The architecture doc landed directly on `main`, so the right next move is not another empty `main -> main` PR. The right move is a follow-up branch that freezes the load-bearing contracts before connector and runtime work expands the surface area.

## Review focus
1. `manifest.v1`
   - canonical fields
   - hashing / ordering
   - connector source refs
   - export profiles
2. `indexpack.v1`
   - binding to manifest root
   - provenance shape
   - export modes and embedding leakage policy
3. Conflict matrix
   - authoritative side per topology
   - tombstone propagation
   - manual reconcile triggers
4. FabricFS command surface
   - operator UX
   - AFS-inspired semantics
   - scriptability / JSON output
5. Quorum and policy
   - action classes
   - object model
   - filesystem placement and profile coverage

## Follow-on after merge
- formal wire encoding + signatures
- connector implementations (Drive / rsync / S3 / Hyper)
- mount registration handshake
- Tool ABI execution bindings

## Notes
This PR is intentionally draft because several decisions remain open:
- canonical serialization format
- signature scheme
- full conflict truth table
- FabricFS implementation order (CLI/API/FUSE)
