### PR TITLE
Draft: Add execution bridge docs for Tool ABI, mount agent, retrieval flow, and evidence

### DIFF
--- a/docs/design/conflict-matrix.md
+++ b/docs/design/conflict-matrix.md
@@ -1,0 +1,59 @@
+# Conflict matrix
+
+## Purpose
+Define authoritative side, version source, tombstone semantics, and manual intervention triggers for each connector and topology.
+
+## Default strategy hierarchy
+1. explicit release snapshot beats mutable head
+2. authoritative local cell beats remote replica in `local_first`
+3. explicit quorum failover can temporarily change authority
+4. manual reconcile queue beats silent destructive merge
+
+## Topology matrix
+
+### Local mount ↔ local canonical object store
+- authority: local mount ingest path
+- version source: manifest generation order
+- tombstones: explicit and immediate
+- manual intervention: no
+
+### Google Drive ↔ local-first workspace
+- authority: local in `local_first`, drive in `provider_first`
+- version source: Drive revision / modified time + local manifest generation
+- tombstones: remote delete becomes local tombstone only after policy check
+- manual intervention: yes when local edits exist after last synced revision
+
+### rsync peer ↔ local-first workspace
+- authority: configured per connector; default local
+- version source: checksum if enabled, otherwise mtime+size
+- tombstones: delete propagation only when explicitly enabled
+- manual intervention: yes for bidirectional mutable trees unless one side is declared source-of-truth
+
+### S3/MinIO replica ↔ local-first workspace
+- authority: local unless replica is promoted
+- version source: object version id or etag + manifest generation
+- tombstones: propagate as signed delete markers
+- manual intervention: only when split-brain promotion occurs
+
+### Hyper mesh peer ↔ local-first workspace
+- authority: release snapshot or signed feed ordering
+- version source: feed sequence + signed manifest/index refs
+- tombstones: feed deltas carry tombstones explicitly
+- manual intervention: yes if peer presents conflicting mutable head without accepted quorum event
+
+### Cloud twin ↔ edge authoritative site
+- authority: edge by default
+- version source: snapshot generation + manifest generation
+- tombstones: mirrored after replication checkpoint
+- manual intervention: required for failover/failback transitions
+
+## Safe defaults
+- Drive connectors default to pull or local-authoritative sync
+- rsync defaults to one-way mirror unless explicitly promoted
+- Hyper distribution defaults to manifest/index export only
+- vendor file stores are never authoritative
+
+## Open decisions
+- exact tie-breakers when local edits and remote tombstones race
+- branch/merge semantics for collaborative mutable datasets
+- failback rules after cloud twin promotion

--- a/docs/design/connector-contracts.md
+++ b/docs/design/connector-contracts.md
@@ -1,0 +1,138 @@
+# Connector contracts
+
+## Purpose
+Define a uniform adapter contract for external and inter-site data movement.
+
+Connectors covered in v1:
+- Google Drive
+- rsync
+- S3 / MinIO
+- Hyper manifest/index distribution
+
+## Core rule
+Connectors do not own canonical identity.
+
+Canonical identity is always:
+- `object_id`
+- `object_version`
+- `manifest_id`
+
+Connectors only provide:
+- source references
+- transport
+- incremental change signals
+- optional ACL metadata
+
+## Common connector interface
+Each connector SHOULD implement:
+- `scan(cursor) -> changes[]`
+- `fetch(source_ref) -> object bytes or stream`
+- `push(local_ref) -> source_ref` when enabled
+- `ack(cursor)`
+- `checkpoint() -> connector state`
+- `restore(checkpoint)`
+- optional `map_acl(remote_acl)`
+
+## Change record shape
+Each `change` includes:
+- `change_id`
+- `source_ref`
+- `operation` (`create | update | delete | move | permission_change`)
+- `remote_version_hint`
+- `observed_at`
+- optional `metadata`
+
+## Drive connector
+### Source refs
+`drive:file_id:revision_id`
+
+### Expected behavior
+- baseline import via listing scoped roots
+- incremental sync via change cursor
+- downloads resolve to canonical objects locally
+- remote permissions may be captured as advisory metadata and mapped into local policy where allowed
+
+### Default policy
+- `local_first`: pull or staged-sync default
+- remote deletes become tombstones only after policy check
+- local edits after last synced revision trigger manual reconcile queue
+
+## rsync connector
+### Source refs
+`rsync:path:fingerprint`
+
+### Expected behavior
+- treated primarily as filesystem transport
+- by default used for one-way mirror or controlled sync jobs
+- quick-check mode uses mtime + size semantics unless stronger verification policy is enabled
+
+### Default policy
+- do not use bidirectional mutable sync by default
+- destructive delete propagation must be explicit
+
+## S3 / MinIO connector
+### Source refs
+` s3:bucket:key:version_or_etag `
+
+### Expected behavior
+- may act as canonical object store or replica depending on deployment mode
+- when used as replica, local manifest authority remains primary in `local_first`
+- object version ids or etags inform remote version hints
+
+### Default policy
+- signed tombstones for deletes
+- budget + lifecycle rules apply to replica storage independently of local hot storage
+
+## Hyper distribution connector
+### Source refs
+- `hypercore:feed_key:seq`
+- `hyperdrive:key:path`
+
+### Expected behavior
+- manifest/index delta export by default
+- optional raw object distribution only when policy allows
+- topic exposure controlled by threat profile
+
+### Default policy
+- `high_threat` disables public discovery
+- out-of-band sharing of topic refs preferred
+
+## Connector checkpoints
+Every connector checkpoint SHOULD include:
+- connector id
+- dataset scope
+- last committed cursor/marker
+- last successful scan time
+- integrity summary
+
+## Error classes
+- `TRANSIENT_UNAVAILABLE`
+- `AUTH_EXPIRED`
+- `PERMISSION_DENIED`
+- `SOURCE_CONFLICT`
+- `CHECKPOINT_CORRUPT`
+- `POLICY_BLOCKED`
+
+## Worked examples
+### Example 1 — Drive pull into local-first corpus
+1. `scan(cursor)` returns changed file ids
+2. `fetch()` downloads bytes
+3. bytes become canonical `object_id`
+4. manifest advances
+5. index warms on new manifest
+
+### Example 2 — rsync export outbox
+1. local release snapshot selected
+2. export tree materialized
+3. rsync transport copies tree to peer
+4. peer ingests into its own canonical store
+
+### Example 3 — Hyper mesh index sharing
+1. local manifest/index deltas emitted
+2. Hyper connector publishes feeds
+3. peer replicates feeds and reconstructs import-side manifest/index state
+
+## Follow-on implementation work
+- exact checkpoint serialization
+- ACL mapping schemas
+- per-connector metrics and lag reporting

--- a/docs/design/evidence-audit-events.md
+++ b/docs/design/evidence-audit-events.md
@@ -1,0 +1,66 @@
+# Evidence and audit event schema
+
+## Purpose
+Define the minimum event surface needed to audit mount, index, connector, tool, and governance behavior.
+
+## Event envelope
+Every event MUST include:
+- `event_id`
+- `event_type`
+- `occurred_at`
+- `actor_ref`
+- `workspace_ref`
+- `dataset_ref` (when applicable)
+- `policy_bundle_ref`
+- `correlation_id`
+- `payload_ref` or inline canonical payload
+- optional `signature_ref`
+
+## Core event families
+### Mount events
+- `mount.ready`
+- `mount.degraded`
+- `mount.failed`
+
+### Manifest events
+- `manifest.created`
+- `manifest.advanced`
+- `manifest.tombstone_applied`
+
+### Index events
+- `index.warming`
+- `index.ready`
+- `index.degraded`
+
+### Connector events
+- `connector.scan.started`
+- `connector.scan.completed`
+- `connector.fetch.completed`
+- `connector.push.completed`
+- `connector.conflict.detected`
+
+### Tool events
+- `tool.execution.started`
+- `tool.execution.completed`
+- `tool.execution.denied`
+
+### Governance events
+- `quorum.proposal.created`
+- `quorum.approval.recorded`
+- `quorum.commit.applied`
+
+## Evidence requirements
+For state-changing events, the payload SHOULD include refs to:
+- prior manifest/index state
+- resulting manifest/index state
+- artifacts created
+- policy decision records
+
+## Retention guidance
+- governance and destructive actions: keep-until-deleted-by-policy or legal hold
+- operational transient events: policy-driven TTL
+
+## Follow-on work
+- canonical wire encoding
+- signing profile
+- event correlation rules across connectors and tools

--- a/docs/design/fabricfs-commands.md
+++ b/docs/design/fabricfs-commands.md
@@ -1,0 +1,23 @@
+# FabricFS command surface
+
+## Goals
+Provide an AFS-inspired operator interface for mounts, quotas, ACLs, replication status, and governance.
+
+## Core commands
+- `fs examine <path>`
+  - prints mount type, MountRef, manifest root, index generation, quota, replication status
+- `fs listquota <path>`
+  - prints data bytes, index bytes, cache bytes, limits
+- `fs setquota <path> <limit>`
+  - updates quota envelope (policy-gated)
+- `fs listacl <path>` / `fs setacl <path> <principal> <rights>`
+  - directory-scoped ACLs using `rlidwka`
+- `fs whereis <path>`
+  - shows backing endpoints / replica locations
+- `fs whichcell <path>`
+  - shows trust/admin domain
+
+## Required semantics
+- `lookup`/traversal requirements must be linted; no effective read/write without traversable parents
+- command output must be scriptable (`--json`)
+- governance objects under `.quorum/` must be visible and inspectable

--- a/docs/design/indexpack-v1.md
+++ b/docs/design/indexpack-v1.md
@@ -1,0 +1,61 @@
+# indexpack.v1
+
+## Purpose
+`indexpack.v1` is the portable bundle of derived retrieval state associated with a specific `manifest.v1` root.
+
+## Invariants
+- every indexpack binds to exactly one `manifest_id`
+- indexpacks are rebuildable from canonical objects + pipeline definition
+- indexpacks may be exported without raw objects when policy permits
+
+## Required fields
+- `schema_version`: `indexpack.v1`
+- `indexpack_id`
+- `manifest_id`
+- `pipeline_version`
+- `created_at`
+- `created_by`
+- `chunk_sets[]`
+- `embedding_sets[]`
+- `keyword_index_refs[]`
+- `provenance`
+
+## Chunk set
+Each chunk record includes:
+- `chunk_id`
+- `object_id`
+- `object_version`
+- `byte_range` or logical segment ref
+- `text_hash`
+- `classification_tags[]`
+
+## Embedding set
+Each embedding record includes:
+- `embedding_id`
+- `chunk_id`
+- `model_id`
+- `vector_dim`
+- `storage_ref`
+- optional `redaction_profile`
+
+## Keyword index refs
+May include:
+- local sqlite/fts path ref
+- tantivy/lucene segment ref
+- exported postings bundle ref
+
+## Provenance
+Must describe:
+- source `manifest_id`
+- extraction policy version
+- chunking policy version
+- embedding model id/version
+- indexing tool/runtime id
+
+## Export modes
+- `local_only`
+- `portable_bundle`
+- `mesh_export`
+
+## Security note
+Embedding export MAY leak semantic content. `high_threat` policy SHOULD require explicit allow before exporting embedding sets outside the authoritative cell.

--- a/docs/design/manifest-v1.md
+++ b/docs/design/manifest-v1.md
@@ -1,0 +1,84 @@
+# manifest.v1
+
+## Purpose
+`manifest.v1` is the canonical, deterministic description of a mounted dataset view. It is the root object that connectors, indexers, Hyper feeds, releases, and conflict resolution bind to.
+
+## Invariants
+- every manifest has exactly one `manifest_id`
+- `manifest_id` is the hash of the canonical serialized manifest body
+- ordering is deterministic
+- path entries may be plaintext or encrypted depending on policy profile
+- every entry points to a canonical `object_id`
+- manifests are immutable once committed; changes produce a new manifest
+
+## Required fields
+- `schema_version`: `manifest.v1`
+- `manifest_id`
+- `created_at`
+- `created_by`
+- `dataset_ref`
+- `mount_ref`
+- `policy_bundle_ref`
+- `entries[]`
+- `root_hash`
+
+## Entry fields
+Each entry contains:
+- `logical_path`
+- `path_mode`: `plaintext | encrypted`
+- `object_id`
+- `object_version`
+- `size_bytes`
+- `mtime`
+- `mime_type`
+- `connector_source_refs[]`
+- `classification_tags[]`
+- `acl_snapshot_ref`
+- `tombstone`: boolean
+
+## Canonical ordering
+Entries sort by:
+1. normalized logical path bytes
+2. object_id
+3. object_version
+
+## Hashing
+- hash algorithm: `sha256`
+- `root_hash` is the Merkle-like aggregate over ordered entry hashes
+- each entry hash is over the canonical serialized form of that entry
+
+## Encryption mode
+When `path_mode=encrypted`:
+- `logical_path` stores ciphertext or opaque token
+- cleartext path mapping remains local to the authoritative cell unless policy allows export
+
+## Connector source references
+`connector_source_refs[]` may include:
+- Drive: `drive:file_id:revision_id`
+- S3: `s3:bucket:key:version_or_etag`
+- rsync: `rsync:path:fingerprint`
+- Hyperdrive: `hyperdrive:key:path`
+- local fs: `localfs:device:path:fingerprint`
+
+## Authority rules
+- local-first mode: local manifest authority wins unless explicit failover/quorum says otherwise
+- release snapshots are immutable manifests
+- mutable heads always point to the latest accepted manifest
+
+## Export profiles
+- `full`: plaintext paths + connector refs + object refs
+- `redacted`: reduced metadata, plaintext optional
+- `high_threat`: encrypted paths, minimized connector refs
+
+## Signing
+A detached signature SHOULD cover:
+- `manifest_id`
+- `dataset_ref`
+- `root_hash`
+- `policy_bundle_ref`
+- `created_at`
+
+## Relationship to other objects
+- `indexpack.v1` binds to one `manifest_id`
+- `ManifestDelta` events transition one manifest to the next
+- releases point at immutable manifest roots

--- a/docs/design/mount-agent.md
+++ b/docs/design/mount-agent.md
@@ -1,0 +1,69 @@
+# Mount agent responsibilities
+
+## Purpose
+Define the local/runtime component that turns mounted storage into manifest/index state and keeps that state current.
+
+## Core role
+The mount agent is the authoritative observer for a resolved mount within a workspace/runtime boundary.
+
+## Responsibilities
+1. verify mount readiness
+2. fingerprint backend identity
+3. scan filesystem/object view into `manifest.v1`
+4. trigger index attach or rebuild according to policy
+5. emit manifest/index deltas to the local journal
+6. optionally hand deltas to distribution connectors
+
+## Inputs
+- `MountRef`
+- `PolicyBundleRef`
+- `IndexPolicyRef`
+- `CapabilityGrantSet`
+
+## Outputs
+- `ManifestRef`
+- `IndexRef`
+- `ManifestDelta` events
+- `IndexDelta` events
+- `MountHealth` state
+
+## Required checks
+### Identity
+- backend fingerprint matches strict/relaxed policy
+
+### Capacity
+- mount free space above minimum operational watermark
+
+### Policy
+- mount intent class allowed in current workspace/profile
+
+### Readability
+- required subtree walk succeeds
+
+## Change detection
+Supported strategies:
+- periodic scan
+- filesystem watch when available
+- connector-driven updates
+- release-based immutable refresh
+
+## Health states
+- `READY`
+- `WARMING`
+- `DEGRADED`
+- `FAILED`
+
+## Event emission
+The mount agent MUST emit:
+- `mount.ready`
+- `mount.degraded`
+- `manifest.created`
+- `manifest.advanced`
+- `index.warming`
+- `index.ready`
+- `distribution.publish.requested` when enabled
+
+## Recovery behavior
+- on restart, restore last checkpoint
+- rebuild manifest/index state if checkpoint missing or corrupt
+- never silently downgrade strict fingerprint failures

--- a/docs/design/mount-registration-handshake.md
+++ b/docs/design/mount-registration-handshake.md
@@ -1,0 +1,169 @@
+# Mount registration handshake
+
+## Purpose
+Define the runtime contract for turning a requested mount into a usable, queryable workspace surface.
+
+This contract applies uniformly across:
+- TopoLVM-backed PVC mounts
+- host/bind mounts
+- named engine volumes
+- network filesystems
+- Hyperdrive-backed materializations
+- object-backed import/export surfaces
+
+## Goal
+A mount is not considered ready until the system can return:
+- `MountRef`
+- `ManifestRef`
+- `IndexRef`
+- `CapabilityGrantSet`
+- optional `DistributionRefs`
+
+## Core rule
+`mounted != ready`
+
+Ready means:
+1. the storage surface resolved successfully
+2. fingerprint and policy checks passed
+3. an initial manifest exists
+4. an index handle exists, even if state is `WARMING`
+5. retrieval graph registration succeeded
+
+## Request object
+`MountSpec` MUST include:
+- `mount_name`
+- `intent_class`
+- `backend_type`
+- `access_mode` (`ro` or `rw`)
+- `authority_mode` (`local_first | hybrid | provider_first`)
+- `index_policy_ref`
+- `retention_class_ref`
+- `capability_policy_ref`
+- optional `distribution_policy_ref`
+
+## Response object
+`MountRegistrationResponse` MUST include:
+- `mount_ref`
+- `manifest_ref`
+- `index_ref`
+- `readiness_state`
+- `policy_bundle_ref`
+- `capability_grants[]`
+- optional `distribution_refs[]`
+- optional `warnings[]`
+
+## MountRef
+`MountRef` fields:
+- `mount_id`
+- `backend_type`
+- `resolved_path_or_handle`
+- `node_ref`
+- `rw_mode`
+- `fingerprint`
+- `capacity_bytes`
+- `created_at`
+
+## ManifestRef
+`ManifestRef` fields:
+- `manifest_id`
+- `root_hash`
+- `entry_count`
+- `generation`
+- `created_at`
+
+## IndexRef
+`IndexRef` fields:
+- `index_id`
+- `manifest_id`
+- `pipeline_version`
+- `state` (`WARMING | READY | DEGRADED`)
+- `chunk_set_ref`
+- `embedding_set_ref`
+- `keyword_index_ref`
+
+## CapabilityGrantSet
+Each grant includes:
+- `principal`
+- `mount_id`
+- `rights` (`r l i d w k a` plus execution scopes as needed)
+- `network_profile`
+- `secret_scope_refs[]`
+- `expires_at`
+
+## DistributionRefs
+May include:
+- `manifest_feed_ref`
+- `index_feed_ref`
+- `hyperdrive_ref`
+- `topic_refs[]`
+
+## Handshake phases
+### Phase 1 — resolve
+Resolve the requested backend into a concrete mount handle.
+
+### Phase 2 — verify
+Run:
+- fingerprint check
+- ACL/policy check
+- capacity sanity
+- backend-specific readiness probe
+
+### Phase 3 — manifest
+Produce `manifest.v1` root for the current visible dataset view.
+
+### Phase 4 — index attach
+Attach an existing index if one matches `(manifest_id, pipeline_version)`; otherwise create a new `IndexRef` in `WARMING` state.
+
+### Phase 5 — retrieval registration
+Register `IndexRef` in retrieval graph immediately.
+
+### Phase 6 — distribution publish (optional)
+Publish manifest/index deltas according to distribution policy.
+
+## Failure classes
+### Hard fail
+Return `FAILED` and do not expose mount to retrieval when:
+- fingerprint mismatch under strict mode
+- policy denies access
+- backend cannot be mounted
+- manifest generation fails
+
+### Soft fail
+Return `DEGRADED` but keep mount usable when:
+- index build warming exceeds threshold
+- optional distribution publish fails
+- remote connector dependency is unavailable but local cache is valid
+
+## Backend notes
+### TopoLVM
+- authoritative cluster-local mount path is the mounted PVC in the workspace/runtime pod
+- `mount_id` should bind to PVC UID + pod-local mount path + volume fingerprint
+
+### Bind/host mounts
+- fingerprint SHOULD include device/inode or equivalent host identity markers
+
+### Network filesystems
+- readiness should record staleness and lease/callback status where available
+
+### Hyperdrive materializations
+- treat imported materialization as a mount view, not as local authority unless policy promotes it
+
+## Worked example
+### Request
+- backend: `topolvm`
+- pvc: `ws-alpha-data`
+- access: `rw`
+- index policy: `rag-default-v1`
+- authority: `local_first`
+
+### Response
+- `mount_ref.mount_id = mnt_ws_alpha_data_001`
+- `manifest_ref.manifest_id = sha256:...`
+- `index_ref.index_id = idx_ws_alpha_data_001`
+- `index_ref.state = WARMING`
+- retrieval graph accepts the mount immediately
+
+## Follow-on implementation work
+- canonical serialization for request/response envelopes
+- signature format for manifest/index refs
+- concrete health probe rules per backend

--- a/docs/design/quorum-policy.md
+++ b/docs/design/quorum-policy.md
@@ -1,0 +1,43 @@
+# Quorum and policy
+
+## Purpose
+Govern high-impact actions in a local-first multi-user fabric.
+
+## Action classes
+
+### Class 0 — no quorum
+- read/search within ACLs
+- local reindex
+- local tool run without network/secrets expansion
+
+### Class 1 — owner or project-admin approval
+- add approved connector to project
+- publish read-only release to allowlisted peers
+- adjust project quota within cell limits
+
+### Class 2 — quorum required
+- enable WAN egress for tools
+- publish discovery topics beyond allowlist
+- add tool with network + secrets
+- rotate dataset root keys
+- destructive purge of canonical data
+- promote cloud twin as authority
+
+## Object model
+- `proposal`: action, scope, threshold, expiry, nonce, requested_by
+- `approval`: proposal_id, approver, signature, timestamp
+- `commit`: proposal_id, threshold_met, applied_at, controller_ref, resulting policy/version refs
+
+## Filesystem placement
+- `/fabric/<cell>/.quorum/proposals/`
+- `/fabric/<cell>/.quorum/approvals/`
+- `/fabric/<cell>/.quorum/commits/`
+
+## Policy bundles
+Profiles should include:
+- normal
+- high_threat
+- airgap
+- connector-specific rules
+- vendor egress rules
+- retention classes

--- a/docs/design/retrieval-registration-flow.md
+++ b/docs/design/retrieval-registration-flow.md
@@ -1,0 +1,54 @@
+# Retrieval registration flow
+
+## Purpose
+Define how an `IndexRef` becomes queryable in the workspace retrieval graph.
+
+## Core rule
+Registration happens immediately after index attachment, even when the index is still `WARMING`.
+
+## Inputs
+- `IndexRef`
+- `ManifestRef`
+- `PolicyBundleRef`
+- workspace and dataset scope refs
+
+## Registration phases
+### Phase 1 — accept
+The retrieval graph records the new `IndexRef` and binds it to dataset/workspace scope.
+
+### Phase 2 — expose
+The retrieval planner may use the index in `WARMING` state for partial or degraded retrieval according to policy.
+
+### Phase 3 — promote
+When index state becomes `READY`, the planner promotes it to preferred candidate for the associated manifest.
+
+## Required registration fields
+- `index_id`
+- `manifest_id`
+- `dataset_ref`
+- `workspace_ref`
+- `state`
+- `pipeline_version`
+- `classification_tags[]`
+- `query_visibility`
+
+## Query visibility modes
+- `hidden`
+- `partial`
+- `full`
+
+## Planner rules
+- `READY + full` beats `WARMING + partial`
+- local authoritative indexes beat remote mirrors in `local_first`
+- stale remote indexes may be used only when policy allows stale reads
+
+## Failure behavior
+- failed registration blocks queryability even if the index artifacts exist
+- distribution success is not required for local retrieval registration
+
+## Example
+1. mount registration yields `IndexRef(state=WARMING)`
+2. retrieval graph registers it as `partial`
+3. chunk lookup works for already-materialized segments
+4. when embeddings and keyword segments complete, state becomes `READY`
+5. planner promotes to `full`

--- a/docs/design/tool-abi-v1.md
+++ b/docs/design/tool-abi-v1.md
@@ -1,0 +1,89 @@
+# Tool ABI v1
+
+## Purpose
+Define a portable execution contract for tools across local runners, K3s pods, containers, and future execution backends.
+
+## Core rule
+A tool does not receive ambient authority.
+
+Every execution must be governed by an explicit `CapabilityGrantSet` tied to:
+- mounts
+- network profile
+- secret scopes
+- retention/export policy
+- audit/evidence hooks
+
+## Tool descriptor
+Each `ToolRef` MUST include:
+- `tool_id`
+- `tool_version`
+- `runtime_type` (`container | pod | wasm | process`)
+- `input_schema_ref`
+- `output_schema_ref`
+- `default_offline_behavior`
+- `required_capability_classes[]`
+- `emitted_event_types[]`
+
+## Capability classes
+### Filesystem
+- `mount.read`
+- `mount.write`
+- `mount.append`
+- `mount.index.invalidate`
+- `mount.export`
+
+### Network
+- `network.none`
+- `network.lan`
+- `network.tor`
+- `network.wan.allowlist`
+
+### Secrets
+- `secret.read:<scope>`
+
+### Distribution
+- `distribution.publish.manifest`
+- `distribution.publish.index`
+- `distribution.publish.content`
+
+## Execution request
+A `ToolExecutionRequest` MUST include:
+- `execution_id`
+- `tool_ref`
+- `invoker_ref`
+- `mount_bindings[]`
+- `capability_grants[]`
+- `input_payload_ref`
+- `network_profile`
+- `secret_scope_refs[]`
+- `policy_bundle_ref`
+
+## Execution response
+A `ToolExecutionResponse` MUST include:
+- `execution_id`
+- `status`
+- `output_payload_ref`
+- `artifact_refs[]`
+- `emitted_event_refs[]`
+- `manifest_delta_refs[]`
+- `index_delta_refs[]`
+- `warnings[]`
+
+## Offline behavior
+Each tool MUST declare one of:
+- `must_succeed_offline`
+- `degrade_offline`
+- `deny_offline`
+
+## Safety defaults
+- default network profile is `network.none`
+- default secret scope is empty
+- tools MAY only publish artifacts covered by policy
+
+## Worked example
+A PDF ingest tool may receive:
+- read access to canonical mount
+- write access to scratch mount
+- no network
+- no secrets
+- permission to emit manifest and index deltas


### PR DESCRIPTION
## Summary
This stacked draft PR builds on #83 by adding the execution bridge docs needed to turn the runtime contracts into an implementable control surface.

It adds:
- `docs/design/tool-abi-v1.md`
- `docs/design/mount-agent.md`
- `docs/design/retrieval-registration-flow.md`
- `docs/design/evidence-audit-events.md`

## Why
#82 froze the portable artifacts and governance surface.
#83 froze mount and connector runtime contracts.
This PR freezes the next execution seam:
- how tools declare and receive authority
- what the mount agent is responsible for
- how `IndexRef` becomes queryable
- what evidence/audit events must exist for replay and review

## Review focus
1. Tool ABI
   - capability classes
   - execution request/response shape
   - offline behavior contract
2. Mount agent
   - responsibilities
   - health states
   - change detection and recovery behavior
3. Retrieval registration
   - `WARMING` vs `READY`
   - visibility and planner rules
4. Evidence/audit events
   - minimum event envelope
   - event families
   - state-change evidence requirements

## Notes
- This PR is stacked on top of #83 and should be reviewed after #82 and #83.
- Follow-on after this PR: connector executor details, canonical wire encoding, signature formats, and implementation PRs.
