### PR TITLE
Draft: Add sync/signing contracts and partial-replication query semantics

### DIFF
--- a/docs/design/canonical-encoding-and-signatures.md
+++ b/docs/design/canonical-encoding-and-signatures.md
@@ -1,0 +1,146 @@
+# Canonical encoding and signatures
+
+## Purpose
+Freeze the normative serialization and signing profile for fabric control objects before implementation fans out.
+
+This document applies to:
+- `manifest.v1`
+- `indexpack.v1`
+- `ManifestDelta`
+- `IndexDelta`
+- `CapabilityGrant`
+- quorum proposal / approval / commit objects
+- evidence and audit envelopes when marked `signed=true`
+
+## Design choice summary
+### Canonical object encoding
+Long-lived normative objects use:
+- canonical JSON as the source-of-truth representation
+- UTF-8 bytes
+- deterministic key ordering
+- no insignificant whitespace
+
+### Feed/event transport
+Streaming feeds use:
+- NDJSON where each line is one canonical JSON object
+- object digests computed over each line's canonical JSON payload only
+
+### Binary payloads
+Large binary payloads are never embedded in canonical signed objects.
+They are referenced by:
+- `object_id`
+- `object_version`
+- content hash
+- optional size and mime metadata
+
+### Optional transport optimization
+CBOR or other compact transport encodings MAY be used on the wire for efficiency, but the canonical digest and signature base MUST still be derived from the canonical JSON representation.
+
+## Canonical JSON rules
+The canonicalization profile MUST enforce:
+- UTF-8 encoding
+- object keys sorted lexicographically by code point
+- arrays preserved in semantically defined order only
+- numbers rendered deterministically; avoid floats where exact integer/fixed-point forms are available
+- booleans and null rendered with standard JSON literals
+- no duplicate keys
+- no comments
+- no trailing commas
+
+## Digest rules
+Default digest algorithm:
+- `sha256`
+
+For every signed object, compute:
+1. canonical JSON bytes
+2. `sha256(canonical_bytes)`
+3. detached signature over the digest or over the canonical bytes, but the profile must be consistent per object class
+
+## Signature algorithm choice
+Default signature algorithm:
+- `Ed25519`
+
+Reasons:
+- small keys and signatures
+- broad open-source support
+- good fit for offline/local-first environments
+- simple detached-signature workflows
+
+## Key hierarchy
+### Cell root key
+Used for:
+- signing policy bundle releases
+- signing quorum authority set updates
+- signing trust-domain transitions
+
+### Dataset signing key
+Used for:
+- release manifests
+- immutable dataset releases
+- delegated signing for dataset-specific objects
+
+### Service/operator key
+Used for:
+- runtime-generated evidence objects
+- mount-agent and connector executor signed events
+
+### Quorum signer keys
+Used for:
+- approvals on high-impact governance actions
+
+## Signature object shape
+A detached signature object SHOULD include:
+- `signature_id`
+- `signed_object_type`
+- `signed_object_id`
+- `signer_key_id`
+- `signature_algorithm`
+- `digest_algorithm`
+- `digest`
+- `signature`
+- `signed_at`
+
+## Signing requirements by object class
+### `manifest.v1`
+Sign:
+- `manifest_id`
+- `root_hash`
+- `dataset_ref`
+- `policy_bundle_ref`
+- `created_at`
+
+### `indexpack.v1`
+Sign:
+- `indexpack_id`
+- `manifest_id`
+- `pipeline_version`
+- `created_at`
+
+### `CapabilityGrant`
+Sign:
+- `grant_id`
+- `principal`
+- `mount_ref`
+- `rights`
+- `network_profile`
+- `expires_at`
+
+### Quorum objects
+- proposals MAY be unsigned at creation but SHOULD become signed before review in hostile environments
+- approvals MUST be signed
+- commits MUST be signed by the controller/service applying the change and SHOULD reference the satisfied approvals
+
+## Replay and anti-tamper guidance
+Every signed object SHOULD support:
+- monotonic or nonce-based replay protection where applicable
+- explicit expiry for grants and approvals
+- correlation to prior object/version where mutation is involved
+
+## Implementation guidance
+- canonicalize once, hash once, sign once
+- persist canonical bytes or exact digest inputs for audit reproducibility
+- reject objects that cannot be round-tripped to canonical JSON without semantic change
+
+## Open decisions
+- whether to sign canonical bytes directly or sign the digest uniformly across all object classes
+- whether to adopt multi-signature aggregation for quorum commits or keep detached individual approval signatures plus a signed commit summary

--- a/docs/design/connector-executors-and-checkpoints.md
+++ b/docs/design/connector-executors-and-checkpoints.md
@@ -1,0 +1,139 @@
+# Connector executors and checkpoint persistence
+
+## Purpose
+Define how connector contracts are executed at runtime and how they persist progress safely across restarts, partitions, and replay.
+
+This document covers executor behavior for:
+- Google Drive
+- rsync
+- S3 / MinIO
+- Hyper distribution
+
+## Core rule
+Connector execution is idempotent relative to canonical identity and checkpoints.
+
+Executors do not invent authority. They materialize changes into the local-first canonical fabric according to connector policy.
+
+## Executor model
+Each connector executor runs as a bounded worker with:
+- `connector_id`
+- `dataset_ref`
+- `policy_bundle_ref`
+- `checkpoint_ref`
+- `health_state`
+- `lag_metrics`
+
+## Common executor phases
+1. restore checkpoint
+2. scan for remote/local changes
+3. stage candidate changes
+4. policy check candidates
+5. fetch/push as allowed
+6. emit manifest/index deltas
+7. persist checkpoint atomically
+8. emit evidence/audit events
+
+## Checkpoint object
+`ConnectorCheckpoint` MUST include:
+- `checkpoint_id`
+- `connector_id`
+- `dataset_ref`
+- `cursor_or_marker`
+- `last_successful_scan_at`
+- `last_applied_change_id`
+- `integrity_digest`
+- `executor_version`
+- `created_at`
+- `updated_at`
+
+## Atomicity rules
+- a checkpoint is only advanced after all associated local state mutations are committed
+- partial fetches may be tracked in executor-private scratch state but MUST NOT advance the shared checkpoint until complete
+- corrupted checkpoints force replay from the last known-good checkpoint or a connector-specific recovery baseline
+
+## Health states
+- `IDLE`
+- `RUNNING`
+- `DEGRADED`
+- `FAILED`
+- `BLOCKED_BY_POLICY`
+
+## Lag metrics
+Executors SHOULD report:
+- scan lag
+- apply lag
+- queued change count
+- bytes pending
+- last success timestamp
+
+## Google Drive executor
+### Scan source
+- change cursor / page token
+
+### Runtime behavior
+- baseline listing establishes initial cursor state
+- changes are processed in cursor order
+- local objects are created from downloaded bytes and attached to new manifests
+- local edits that conflict with newer remote revisions go to manual reconcile queue under `local_first`
+
+### Checkpoint fields
+Additional optional fields:
+- `start_page_token`
+- `last_page_token`
+- `last_processed_file_ids[]` (bounded/debug only)
+
+## rsync executor
+### Scan source
+- explicit scheduled sync job or manual invocation
+
+### Runtime behavior
+- rsync is treated as filesystem transport, not canonical metadata authority
+- default mode is one-way mirror unless policy explicitly enables bidirectional flows
+- deletes only propagate when configured
+
+### Checkpoint fields
+Additional optional fields:
+- `source_tree_fingerprint`
+- `last_sync_mode`
+- `last_remote_snapshot_hint`
+
+## S3 / MinIO executor
+### Scan source
+- object listing, version markers, or event stream if configured
+
+### Runtime behavior
+- when S3 is canonical, executor may materialize local caches/indexes
+- when S3 is replica, local manifest authority remains primary in `local_first`
+- delete markers become signed tombstones before local application when needed
+
+### Checkpoint fields
+Additional optional fields:
+- `continuation_token`
+- `last_seen_version_marker`
+- `bucket_generation_hint`
+
+## Hyper executor
+### Scan source
+- replicated feed sequence positions
+
+### Runtime behavior
+- manifest and index delta feeds are primary; raw content replication is policy-gated
+- executor tracks feed seq positions independently for manifest feed, index feed, and optional hyperdrive content
+- public topic exposure is forbidden in `high_threat` unless explicitly allowed
+
+### Checkpoint fields
+Additional optional fields:
+- `manifest_feed_seq`
+- `index_feed_seq`
+- `content_feed_seq`
+- `peer_set_digest`
+
+## Recovery rules
+- executors MUST tolerate restarts without duplicating destructive operations
+- replay from checkpoint MUST be safe and idempotent
+- policy changes MAY force executor pause until reauthorized
+
+## Follow-on implementation work
+- exact persistent store layout for checkpoints
+- backoff and retry tuning
+- manual reconcile queue schema

--- a/docs/design/query-semantics-partial-replication.md
+++ b/docs/design/query-semantics-partial-replication.md
@@ -1,0 +1,79 @@
+# Query semantics for partial and stale replication
+
+## Purpose
+Define what it means to query datasets when content and indexes are only partially replicated, stale, or mirror-only.
+
+## Core rule
+Every query result set MUST be labeled with its visibility and freshness posture.
+
+## Visibility classes
+- `authoritative_local`
+- `local_partial`
+- `stale_mirror`
+- `remote_metadata_only`
+- `hydrated_on_demand`
+
+## Freshness classes
+- `fresh`
+- `bounded_stale`
+- `unknown_stale`
+
+## Planner inputs
+The retrieval planner MUST consider:
+- local `IndexRef` state (`WARMING | READY | DEGRADED`)
+- local manifest generation
+- remote mirror manifest generation if known
+- connector lag metrics
+- policy profile (`local_first`, `high_threat`, etc.)
+
+## Default planner order in `local_first`
+1. local authoritative ready index
+2. local authoritative warming index with partial visibility
+3. local stale mirror if policy allows stale reads
+4. metadata-only results when content/index hydration is not allowed or unavailable
+5. on-demand hydration only if connector and policy permit
+
+## Result labeling
+Each query response SHOULD include:
+- `visibility_class`
+- `freshness_class`
+- `manifest_id_used`
+- `index_id_used`
+- optional `staleness_reason`
+
+## Allowed behaviors by profile
+### Normal
+- may use bounded-stale mirrors
+- may hydrate on demand through approved connectors
+
+### High threat
+- prefer local-only
+- do not automatically hydrate from remote sources unless explicitly allowed
+- metadata-only results may be preferable to remote pulls
+
+### Airgap
+- local-only
+- no hydration from connectors
+
+## Worked examples
+### Example 1 — local partial index warming
+A new mount is registered. Keyword index exists, embeddings are still warming.
+- result visibility: `local_partial`
+- freshness: `fresh`
+- planner may answer lexical queries and limited chunk retrieval
+
+### Example 2 — remote mirror only
+Local node has only manifest and indexpack mirror, not raw objects.
+- result visibility: `stale_mirror` or `remote_metadata_only`
+- policy may allow metadata search but not content hydration
+
+### Example 3 — connector unavailable
+Last known remote mirror generation exists, but connector lag is unknown after partition.
+- result visibility: `stale_mirror`
+- freshness: `unknown_stale`
+- response must label this clearly
+
+## Follow-on implementation work
+- confidence scoring tied to freshness/visibility
+- UI and CLI surface for result labeling
+- hydration prompts and operator overrides


### PR DESCRIPTION
## Summary
This stacked draft PR builds on #84 by closing three of the biggest remaining contract gaps before implementation:

- `docs/design/canonical-encoding-and-signatures.md`
- `docs/design/connector-executors-and-checkpoints.md`
- `docs/design/query-semantics-partial-replication.md`

## Why
Earlier PRs defined:
- portable artifacts and governance (#82)
- runtime contracts for mounts/connectors (#83)
- execution bridge docs for tools, mount agent, retrieval flow, and evidence (#84)

This PR remediates the next major gaps:
1. canonical encoding and detached signing profile
2. connector executor behavior and checkpoint persistence
3. query/result semantics when replication is partial, stale, or metadata-only

## Review focus
1. Canonical encoding + signatures
   - canonical JSON as source-of-truth
   - NDJSON feed usage
   - Ed25519 default signing profile
   - key hierarchy and object-class signing requirements
2. Connector executors + checkpoints
   - atomic checkpoint advancement
   - idempotent replay requirements
   - per-connector checkpoint fields
   - lag/health metric expectations
3. Partial replication query semantics
   - visibility/freshness classes
   - planner order in `local_first`
   - result labeling requirements
   - high-threat and airgap restrictions

## Notes
- This PR is stacked on top of #84 and should be reviewed after #82, #83, and #84.
- Follow-on after this PR: implementation PRs for mount agent skeleton, connector executors, and retrieval planner surfaces.
