### PR TITLE
Draft: Add machine-readable fabric schemas for core control objects

### DIFF
--- a/schemas/fabric/capability-grant.v1.schema.json
+++ b/schemas/fabric/capability-grant.v1.schema.json
@@ -1,0 +1,41 @@
+{
+  "title": "capability-grant.v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "grant_id",
+    "principal",
+    "mount_ref",
+    "rights",
+    "network_profile",
+    "expires_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "capability-grant.v1" },
+    "grant_id": { "type": "string", "minLength": 1 },
+    "principal": { "type": "string", "minLength": 1 },
+    "mount_ref": { "type": "string", "minLength": 1 },
+    "rights": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1
+    },
+    "network_profile": {
+      "enum": ["network.none", "network.lan", "network.tor", "network.wan.allowlist"]
+    },
+    "secret_scope_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "distribution_rights": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "issued_at": { "type": "string" },
+    "expires_at": { "type": "string", "minLength": 1 },
+    "issuer_ref": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/fabric/evidence-event.v1.schema.json
+++ b/schemas/fabric/evidence-event.v1.schema.json
@@ -1,0 +1,29 @@
+{
+  "title": "evidence-event.v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_id",
+    "event_type",
+    "occurred_at",
+    "actor_ref",
+    "workspace_ref",
+    "policy_bundle_ref",
+    "correlation_id"
+  ],
+  "properties": {
+    "schema_version": { "const": "evidence-event.v1" },
+    "event_id": { "type": "string", "minLength": 1 },
+    "event_type": { "type": "string", "minLength": 1 },
+    "occurred_at": { "type": "string" },
+    "actor_ref": { "type": "string", "minLength": 1 },
+    "workspace_ref": { "type": "string", "minLength": 1 },
+    "dataset_ref": { "type": "string" },
+    "policy_bundle_ref": { "type": "string", "minLength": 1 },
+    "correlation_id": { "type": "string", "minLength": 1 },
+    "payload_ref": { "type": "string" },
+    "payload": { "type": ["object", "array", "string", "number", "boolean", "null"] },
+    "signature_ref": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/fabric/indexpack.v1.schema.json
+++ b/schemas/fabric/indexpack.v1.schema.json
@@ -1,0 +1,69 @@
+{
+  "title": "indexpack.v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "indexpack_id",
+    "manifest_id",
+    "pipeline_version",
+    "created_at",
+    "chunk_sets",
+    "embedding_sets",
+    "keyword_index_refs",
+    "provenance"
+  ],
+  "properties": {
+    "schema_version": { "const": "indexpack.v1" },
+    "indexpack_id": { "type": "string", "minLength": 1 },
+    "manifest_id": { "type": "string", "minLength": 1 },
+    "pipeline_version": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string" },
+    "created_by": { "type": "string" },
+    "chunk_sets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["chunk_id", "object_id", "object_version", "text_hash"],
+        "properties": {
+          "chunk_id": { "type": "string", "minLength": 1 },
+          "object_id": { "type": "string", "minLength": 1 },
+          "object_version": { "type": "string", "minLength": 1 },
+          "byte_range": { "type": ["string", "object"] },
+          "text_hash": { "type": "string", "minLength": 1 },
+          "classification_tags": { "type": "array", "items": { "type": "string" }, "default": [] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "embedding_sets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["embedding_id", "chunk_id", "model_id", "vector_dim", "storage_ref"],
+        "properties": {
+          "embedding_id": { "type": "string", "minLength": 1 },
+          "chunk_id": { "type": "string", "minLength": 1 },
+          "model_id": { "type": "string", "minLength": 1 },
+          "vector_dim": { "type": "integer", "minimum": 1 },
+          "storage_ref": { "type": "string", "minLength": 1 },
+          "redaction_profile": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "keyword_index_refs": { "type": "array", "items": { "type": "string" } },
+    "provenance": {
+      "type": "object",
+      "required": ["manifest_id", "extraction_policy_version", "chunking_policy_version", "embedding_model_id"],
+      "properties": {
+        "manifest_id": { "type": "string", "minLength": 1 },
+        "extraction_policy_version": { "type": "string", "minLength": 1 },
+        "chunking_policy_version": { "type": "string", "minLength": 1 },
+        "embedding_model_id": { "type": "string", "minLength": 1 },
+        "indexing_runtime_id": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/fabric/manifest.v1.schema.json
+++ b/schemas/fabric/manifest.v1.schema.json
@@ -1,0 +1,63 @@
+{
+  "title": "manifest.v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "manifest_id",
+    "created_at",
+    "dataset_ref",
+    "mount_ref",
+    "policy_bundle_ref",
+    "entries",
+    "root_hash"
+  ],
+  "properties": {
+    "schema_version": { "const": "manifest.v1" },
+    "manifest_id": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string" },
+    "created_by": { "type": "string" },
+    "dataset_ref": { "type": "string", "minLength": 1 },
+    "mount_ref": { "type": "string", "minLength": 1 },
+    "policy_bundle_ref": { "type": "string", "minLength": 1 },
+    "root_hash": { "type": "string", "minLength": 1 },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "logical_path",
+          "path_mode",
+          "object_id",
+          "object_version",
+          "size_bytes",
+          "mtime",
+          "mime_type",
+          "tombstone"
+        ],
+        "properties": {
+          "logical_path": { "type": "string" },
+          "path_mode": { "enum": ["plaintext", "encrypted"] },
+          "object_id": { "type": "string", "minLength": 1 },
+          "object_version": { "type": "string", "minLength": 1 },
+          "size_bytes": { "type": "integer", "minimum": 0 },
+          "mtime": { "type": "string" },
+          "mime_type": { "type": "string" },
+          "connector_source_refs": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": []
+          },
+          "classification_tags": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": []
+          },
+          "acl_snapshot_ref": { "type": "string" },
+          "tombstone": { "type": "boolean" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
This stacked draft PR builds on #85 by adding the first machine-readable schema tranche for the fabric control plane.

It adds:
- `schemas/fabric/manifest.v1.schema.json`
- `schemas/fabric/indexpack.v1.schema.json`
- `schemas/fabric/capability-grant.v1.schema.json`
- `schemas/fabric/evidence-event.v1.schema.json`

## Why
The preceding PRs froze the design and contract surfaces:
- #82 portable artifacts + governance docs
- #83 mount and connector runtime contracts
- #84 execution bridge docs
- #85 canonical encoding/signatures, executor/checkpoint behavior, and query semantics

This PR starts turning those contracts into validation artifacts that can be used by CI, generators, validators, and implementation code.

## Review focus
1. Field coverage vs the prose specs
2. Required vs optional fields
3. Whether any enums or core identifiers are still too loose
4. Whether the schema path and naming fit existing repo conventions

## Notes
- This PR is intentionally a first schema tranche, not the full schema universe.
- Follow-on work after this PR: delta event schemas, quorum object schemas, and implementation-side validators.
