### PR TITLE
docs(architecture): align sociosphere to software operational risk automation lane

### DIFF
--- a/docs/architecture/software-oprisk-automation.md
+++ b/docs/architecture/software-oprisk-automation.md
@@ -1,0 +1,63 @@
+# Software Operational Risk Automation Alignment
+
+## Purpose
+
+This note records how `sociosphere` aligns to the software operational risk governance pack proposed in `SocioProphet/socioprophet-standards-storage` PR #72.
+
+## Why this repo is in scope
+
+The current upstream `main` README positions `sociosphere` as the platform meta-workspace controller and the owner of the canonical workspace manifest, lock, registry, governance metadata, topology validation, and deterministic multi-repo materialization.
+
+That makes `sociosphere` the correct downstream owner for the **automation and harvesting lane** of software operational risk.
+
+## Expected responsibilities
+
+### 1. Outage corpus harvesting
+
+`Sociosphere` SHOULD own scheduled collection and normalization of official outage histories for platform-critical providers, including at minimum:
+
+- AWS,
+- Azure,
+- Google Cloud,
+- Cloudflare,
+- GitHub,
+- npm,
+- and model-provider status histories.
+
+### 2. Upstream-drift watchlists
+
+`Sociosphere` SHOULD maintain watchlists or registry enrichments for:
+
+- active platform repos,
+- default branches,
+- release surfaces,
+- package surfaces,
+- PR volume,
+- issue signals,
+- and other upstream movement relevant to dependency and integration risk.
+
+### 3. Registry and governance integration
+
+Registry and governance assets SHOULD be extended to represent:
+
+- outage corpus records,
+- upstream-drift KRIs,
+- concentration / nth-party dependency signals,
+- and cross-repository control ownership.
+
+### 4. Workspace validation and trust reporting
+
+The runner and validation layers SHOULD eventually expose software operational-risk signals in a way that can feed:
+
+- trust reports,
+- topology / dependency validation,
+- integration status views,
+- and future reserve / scenario dashboards.
+
+## Immediate backlog
+
+1. Define the first machine-readable outage incident schema.  
+2. Add a scheduled harvester lane and normalized output location.  
+3. Extend registry / governance metadata with upstream-drift watch objects.  
+4. Add cross-references to the standards pack after PR #72 lands.  
+5. Decide how trust reports and topology validation surface operational-risk signals.


### PR DESCRIPTION
## Summary

Adds an automation/workspace alignment note for the software operational risk governance pack proposed in `SocioProphet/socioprophet-standards-storage` PR #72.

## Why here

Before writing, the current upstream README on `main` was checked. `sociosphere` is explicitly positioned as the meta-workspace controller, registry owner, governance metadata owner, topology validator, and deterministic multi-repo materialization lane. That makes it the correct downstream repo for outage-corpus harvesting, upstream-drift watchlists, registry enrichment, and operational-risk telemetry production.

## Included

- `docs/architecture/software-oprisk-automation.md`

## Follow-on

- define machine-readable outage and watchlist schemas
- add scheduled harvester lanes and normalized outputs
- extend registry / governance assets with operational-risk objects
- surface these signals in trust reports and validation views
- cross-reference the standards pack after PR #72 lands
