### PR TITLE
docs and schemas: add Dolt build ledger starter tranche

### DIFF
--- a/docs/design/dolt-build-ledger-layout.md
+++ b/docs/design/dolt-build-ledger-layout.md
@@ -1,0 +1,93 @@
+# Dolt build ledger table layout
+
+This note captures the first recommended Dolt table layout for dependency resolution and build-cache state.
+
+## Core tables
+
+### `dependency_resolutions`
+One row per evaluated dependency graph.
+
+Suggested fields:
+- `resolution_id`
+- `workspace_ref`
+- `created_at`
+- `resolver_kind`
+- `inputs_hash`
+- `notes`
+
+### `dependency_nodes`
+One row per selected dependency node.
+
+Suggested fields:
+- `resolution_id`
+- `node_id`
+- `repo_ref`
+- `revision_ref`
+- `artifact_kind`
+
+### `dependency_edges`
+Edges for the selected dependency graph.
+
+Suggested fields:
+- `resolution_id`
+- `from_node_id`
+- `to_node_id`
+- `edge_kind`
+
+### `build_choices`
+One row per evaluated build decision.
+
+Suggested fields:
+- `build_choice_id`
+- `resolution_ref`
+- `created_at`
+- `target_system`
+- `executor_class`
+- `decision_status`
+- `notes`
+
+### `build_cache_entries`
+One row per reusable cache record.
+
+Suggested fields:
+- `cache_entry_id`
+- `created_at`
+- `cache_key`
+- `resolution_ref`
+- `build_choice_ref`
+- `artifact_class`
+- `target_system`
+- `producer_ref`
+- `content_ref`
+- `state`
+- `notes`
+
+### `build_materializations`
+One row per materialization run.
+
+Suggested fields:
+- `materialization_id`
+- `created_at`
+- `build_choice_ref`
+- `result_state`
+- `notes`
+
+### `build_materialization_artifacts`
+Artifact refs emitted by a materialization.
+
+Suggested fields:
+- `materialization_id`
+- `artifact_ref`
+
+## Operational rule
+
+These tables live in Dolt so that build-plan state can be:
+- branched
+- reviewed
+- merged
+- diffed
+- replicated
+- backed up
+
+Git and the workspace lock remain canonical for source and desired inputs.
+Dolt becomes canonical for the evaluated build/cache state derived from those inputs.

--- a/docs/design/dolt-build-ledger-operations.md
+++ b/docs/design/dolt-build-ledger-operations.md
@@ -1,0 +1,57 @@
+# Dolt build ledger operational rules
+
+## Purpose
+This note defines the operational rules for the Dolt-backed build ledger so dependency resolution, build choices, cache state, and materializations are preserved in a robust and reviewable way.
+
+## Branch strategy
+Use Dolt branches as isolated workspaces for build state.
+
+Recommended branch families:
+- `main` — accepted build ledger state
+- `resolve/<workspace>/<ts>` — dependency resolution work
+- `build/<workspace>/<ts>` — build/materialization run state
+- `cache-repair/<site>/<ts>` — cache repair and invalidation work
+
+No direct write to `main` without merge.
+
+## Remote / replication strategy
+Use Dolt remotes for committed state replication.
+
+Recommended posture:
+- writer pushes committed branch state to remote
+- readers / mirrors pull from remote on demand
+- remote mirrors are used for read and disaster recovery of committed state
+
+## Backup strategy
+Use Dolt backups for states that must preserve uncommitted working sets.
+
+Operational rule:
+- remotes protect committed history
+- backups protect both committed and uncommitted branch state
+
+## Conflict handling
+Conflicts are treated as a signal that competing build or cache state needs explicit resolution.
+
+Operational rule:
+- do not auto-commit unresolved conflicts
+- resolve conflicts before accepting branch state into `main`
+- treat cache invalidation or dependency-choice disagreement as reviewable ledger events, not silent overwrite behavior
+
+## Queryability expectations
+The ledger should support answering:
+- which dependency resolution produced this build choice?
+- which cache state was active for that choice?
+- which materialization consumed or produced a given artifact?
+- what branch introduced a cache invalidation or changed a dependency edge?
+
+## Minimal persisted families
+Even before full schema coverage lands, the ledger must preserve these concepts:
+- dependency resolution
+- build choice
+- cache state
+- materialization state
+- failure / invalidation notes
+
+## Integration rule
+Git remains canonical for source code and lockfiles.
+Dolt remains canonical for evaluated build state derived from those inputs.

--- a/docs/design/dolt-build-ledger.md
+++ b/docs/design/dolt-build-ledger.md
@@ -1,0 +1,119 @@
+# Dolt build ledger for dependency resolution and build cache state
+
+## Purpose
+Define a robust, versioned state layer for workspace dependency choices, build inputs, cache hits/misses, and materialized outputs.
+
+`Sociosphere` already owns the workspace manifest + lock and deterministic multi-repo materialization path. The missing persistence seam is a control-plane ledger that records **why** a build used a particular dependency graph and **what** cache/materialization state resulted.
+
+## Decision
+Use **Dolt** as the canonical relational ledger for:
+
+- dependency graph snapshots
+- dependency resolution decisions
+- build-choice decisions
+- cache entries and cache provenance
+- build materializations and receipts
+
+## Why Dolt
+Dolt gives us:
+
+- branch-based isolation for parallel build plans and canary resolution work
+- commit history and diffs over relational state
+- SQL-queryable history/diff/system tables
+- remote-based or standby replication for read replicas / disaster recovery
+- backup paths for both committed and uncommitted state
+
+## Core rule
+Git remains the source of truth for source code and workspace lockfiles.
+
+Dolt becomes the source of truth for **evaluated build state**:
+
+- which dependency set was chosen
+- which upstream revisions were selected
+- which cache objects are valid for a given choice set
+- which materializations were produced
+- which failures or invalidations occurred
+
+## Minimal object family
+
+The first persistent object family is:
+
+- `dependency-resolution.v1`
+- `build-choice.v1`
+- `build-cache-entry.v1`
+- `build-materialization.v1`
+
+## Branch model
+
+Use Dolt branches as isolated build-plan workspaces.
+
+Examples:
+- `main` — accepted build ledger state
+- `resolve/<workspace>/<ts>` — dependency resolver proposal
+- `build/<workspace>/<ts>` — materialization run state
+- `cache-repair/<site>/<ts>` — cache invalidation or refill work
+
+No branch writes directly to `main` without merge.
+
+## Dependency semantics
+
+The dependency ledger must be able to answer:
+
+- which upstream repo/revision/input was selected?
+- what solver or policy produced that choice?
+- what alternatives were rejected?
+- what lockfile/manifests did this choice correspond to?
+- did this choice produce a reusable cache lineage?
+
+## Cache semantics
+
+Cache entries are not just blobs. They are keyed by:
+
+- dependency-resolution identity
+- build-choice identity
+- target system / platform
+- artifact class
+- producer toolchain / executor
+- validity state
+
+A cache hit is only valid if the cache entry is still compatible with the current dependency resolution and build choice.
+
+## Recommended tables
+
+- `dependency_nodes`
+- `dependency_edges`
+- `dependency_resolutions`
+- `build_choices`
+- `build_choice_inputs`
+- `build_cache_entries`
+- `build_cache_bindings`
+- `build_materializations`
+- `build_failures`
+- `cache_invalidations`
+
+## Consumption path
+
+1. workspace manifest + lock identify candidate inputs
+2. resolver emits a `dependency-resolution` record in Dolt
+3. build planner emits a `build-choice` record in Dolt
+4. cache lookup binds or rejects `build-cache-entry` rows
+5. materialization emits `build-materialization`
+6. failures / invalidations emit ledger updates instead of disappearing into CI logs
+
+## Non-goals
+
+This design does not replace:
+
+- Git history
+- binary/object storage
+- artifact registries
+- Nix store semantics
+
+It complements them by making evaluated build state reviewable, mergeable, and queryable.
+
+## Follow-on
+
+- land the starter schemas under `schemas/fabric/`
+- land the starter Dolt DDL
+- bind runner/orchestrator emissions to the ledger
+- add cache validation and invalidation routines

--- a/schemas/fabric/build-choice.v1.schema.json
+++ b/schemas/fabric/build-choice.v1.schema.json
@@ -1,0 +1,32 @@
+{
+  "title": "build-choice.v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "build_choice_id",
+    "resolution_ref",
+    "created_at",
+    "target_system",
+    "executor_class",
+    "decision_status"
+  ],
+  "properties": {
+    "schema_version": { "const": "build-choice.v1" },
+    "build_choice_id": { "type": "string", "minLength": 1 },
+    "resolution_ref": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string" },
+    "target_system": { "type": "string", "minLength": 1 },
+    "executor_class": { "type": "string", "minLength": 1 },
+    "decision_status": {
+      "enum": ["planned", "materialized", "failed", "superseded"]
+    },
+    "toolchain_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "policy_bundle_ref": { "type": ["string", "null"] },
+    "notes": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/schemas/fabric/dependency-resolution.v1.schema.json
+++ b/schemas/fabric/dependency-resolution.v1.schema.json
@@ -1,0 +1,33 @@
+{
+  "title": "dependency-resolution.v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "resolution_id",
+    "workspace_ref",
+    "created_at",
+    "resolver_kind",
+    "inputs_hash",
+    "root_nodes"
+  ],
+  "properties": {
+    "schema_version": { "const": "dependency-resolution.v1" },
+    "resolution_id": { "type": "string", "minLength": 1 },
+    "workspace_ref": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string" },
+    "resolver_kind": { "type": "string", "minLength": 1 },
+    "inputs_hash": { "type": "string", "minLength": 1 },
+    "root_nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "lock_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "notes": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Add a Dolt-backed starter design for dependency resolution and build-choice state in sociosphere, including a design note, a table-layout note, and starter fabric schemas.