### PR TITLE
Draft: Add fabric runtime skeleton for mount registration, checkpoints, events, and retrieval registry

### DIFF
--- a/tools/fabric/__init__.py
+++ b/tools/fabric/__init__.py
@@ -1,0 +1,1 @@
+"""Fabric control-plane implementation skeleton."""

--- a/tools/fabric/cli.py
+++ b/tools/fabric/cli.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .events import EventSink
+from .mount_agent import MountAgent, MountRequest
+from .retrieval_registry import RetrievalRegistry
+from .schema_refs import schema_paths
+from .validator import validate_file
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    schemas = schema_paths()
+    if args.schema not in schemas:
+        print(json.dumps({"error": f"unknown schema {args.schema!r}", "known": sorted(schemas)}))
+        return 2
+    errors = validate_file(args.instance, schemas[args.schema])
+    print(json.dumps({"valid": not errors, "errors": errors}, indent=2))
+    return 0 if not errors else 1
+
+
+def cmd_register_demo(args: argparse.Namespace) -> int:
+    registry = RetrievalRegistry()
+    sink = EventSink(Path(args.events_file))
+    agent = MountAgent(registry, sink)
+    response = agent.register_mount(
+        MountRequest(
+            mount_name=args.mount_name,
+            backend_type=args.backend_type,
+            resolved_path_or_handle=args.path,
+            node_ref=args.node_ref,
+            rw_mode=args.rw_mode,
+            capacity_bytes=args.capacity_bytes,
+            workspace_ref=args.workspace_ref,
+            dataset_ref=args.dataset_ref,
+            pipeline_version=args.pipeline_version,
+            policy_bundle_ref=args.policy_bundle_ref,
+            principal=args.principal,
+        )
+    )
+    print(json.dumps(response, default=lambda o: getattr(o, "__dict__", str(o)), indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="fabric")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    validate = sub.add_parser("validate-json")
+    validate.add_argument("schema", help="schema key, e.g. manifest.v1")
+    validate.add_argument("instance", help="path to JSON instance file")
+    validate.set_defaults(func=cmd_validate)
+
+    demo = sub.add_parser("register-demo")
+    demo.add_argument("--mount-name", required=True)
+    demo.add_argument("--backend-type", required=True)
+    demo.add_argument("--path", required=True)
+    demo.add_argument("--node-ref", default="node.local")
+    demo.add_argument("--rw-mode", default="rw")
+    demo.add_argument("--capacity-bytes", type=int, default=0)
+    demo.add_argument("--workspace-ref", required=True)
+    demo.add_argument("--dataset-ref", required=True)
+    demo.add_argument("--pipeline-version", default="v1")
+    demo.add_argument("--policy-bundle-ref", default="policy/default")
+    demo.add_argument("--principal", default="operator")
+    demo.add_argument("--events-file", default="/tmp/fabric-events.ndjson")
+    demo.set_defaults(func=cmd_register_demo)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/fabric/mount_agent.py
+++ b/tools/fabric/mount_agent.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+
+from .events import EventSink
+from .retrieval_registry import RetrievalRegistry
+from .types import (
+    CapabilityGrant,
+    EvidenceEvent,
+    IndexRef,
+    IndexState,
+    ManifestRef,
+    MountRef,
+    MountRegistrationResponse,
+    ReadinessState,
+)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _digest(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class MountRequest:
+    mount_name: str
+    backend_type: str
+    resolved_path_or_handle: str
+    node_ref: str
+    rw_mode: str
+    capacity_bytes: int
+    workspace_ref: str
+    dataset_ref: str
+    pipeline_version: str
+    policy_bundle_ref: str
+    principal: str
+
+
+class MountAgent:
+    def __init__(self, registry: RetrievalRegistry, events: EventSink) -> None:
+        self.registry = registry
+        self.events = events
+
+    def register_mount(self, request: MountRequest) -> MountRegistrationResponse:
+        now = _now()
+        fingerprint = _digest(f"{request.backend_type}:{request.resolved_path_or_handle}")
+        mount_ref = MountRef(
+            mount_id=f"mnt_{_digest(request.mount_name)[:12]}",
+            backend_type=request.backend_type,
+            resolved_path_or_handle=request.resolved_path_or_handle,
+            node_ref=request.node_ref,
+            rw_mode=request.rw_mode,
+            fingerprint=fingerprint,
+            capacity_bytes=request.capacity_bytes,
+            created_at=now,
+        )
+        manifest_ref = ManifestRef(
+            manifest_id=f"manifest_{_digest(request.resolved_path_or_handle + now)}",
+            root_hash=_digest(request.resolved_path_or_handle),
+            entry_count=0,
+            generation=1,
+            created_at=now,
+        )
+        index_ref = IndexRef(
+            index_id=f"idx_{_digest(request.dataset_ref + request.pipeline_version)[:12]}",
+            manifest_id=manifest_ref.manifest_id,
+            pipeline_version=request.pipeline_version,
+            state=IndexState.WARMING,
+        )
+        grant = CapabilityGrant(
+            grant_id=f"grant_{_digest(request.principal + request.mount_name)[:12]}",
+            principal=request.principal,
+            mount_ref=mount_ref.mount_id,
+            rights=["l", "r"],
+            network_profile="network.none",
+            expires_at=now,
+        )
+        self.registry.register(
+            workspace_ref=request.workspace_ref,
+            dataset_ref=request.dataset_ref,
+            visibility="partial",
+            index_ref=index_ref,
+        )
+        self.events.emit(
+            EvidenceEvent(
+                event_id=f"evt_{_digest(mount_ref.mount_id + now)[:16]}",
+                event_type="mount.ready",
+                occurred_at=now,
+                actor_ref=request.principal,
+                workspace_ref=request.workspace_ref,
+                dataset_ref=request.dataset_ref,
+                policy_bundle_ref=request.policy_bundle_ref,
+                correlation_id=mount_ref.mount_id,
+                payload={
+                    "mount_id": mount_ref.mount_id,
+                    "manifest_id": manifest_ref.manifest_id,
+                    "index_id": index_ref.index_id,
+                },
+            )
+        )
+        return MountRegistrationResponse(
+            mount_ref=mount_ref,
+            manifest_ref=manifest_ref,
+            index_ref=index_ref,
+            readiness_state=ReadinessState.WARMING,
+            policy_bundle_ref=request.policy_bundle_ref,
+            capability_grants=[grant],
+        )

--- a/tools/fabric/retrieval_registry.py
+++ b/tools/fabric/retrieval_registry.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from .types import IndexRef
+
+
+@dataclass(frozen=True)
+class RegisteredIndex:
+    workspace_ref: str
+    dataset_ref: str
+    visibility: str
+    index_ref: IndexRef
+
+
+class RetrievalRegistry:
+    def __init__(self) -> None:
+        self._entries: Dict[Tuple[str, str], RegisteredIndex] = {}
+
+    def register(self, workspace_ref: str, dataset_ref: str, visibility: str, index_ref: IndexRef) -> None:
+        self._entries[(workspace_ref, dataset_ref)] = RegisteredIndex(
+            workspace_ref=workspace_ref,
+            dataset_ref=dataset_ref,
+            visibility=visibility,
+            index_ref=index_ref,
+        )
+
+    def get(self, workspace_ref: str, dataset_ref: str) -> RegisteredIndex | None:
+        return self._entries.get((workspace_ref, dataset_ref))

--- a/tools/fabric/schema_refs.py
+++ b/tools/fabric/schema_refs.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SCHEMA_ROOT = Path("schemas") / "fabric"
+
+MANIFEST_V1 = SCHEMA_ROOT / "manifest.v1.schema.json"
+INDEXPACK_V1 = SCHEMA_ROOT / "indexpack.v1.schema.json"
+CAPABILITY_GRANT_V1 = SCHEMA_ROOT / "capability-grant.v1.schema.json"
+EVIDENCE_EVENT_V1 = SCHEMA_ROOT / "evidence-event.v1.schema.json"
+
+
+def schema_paths() -> dict[str, Path]:
+    return {
+        "manifest.v1": MANIFEST_V1,
+        "indexpack.v1": INDEXPACK_V1,
+        "capability-grant.v1": CAPABILITY_GRANT_V1,
+        "evidence-event.v1": EVIDENCE_EVENT_V1,
+    }

--- a/tools/fabric/selftest.py
+++ b/tools/fabric/selftest.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from .events import EventSink
+from .mount_agent import MountAgent, MountRequest
+from .retrieval_registry import RetrievalRegistry
+from .schema_refs import MANIFEST_V1
+from .validator import load_schema, validate_instance
+
+
+class FabricSmokeTest(unittest.TestCase):
+    def test_mount_registration_and_event_emission(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            events_path = Path(tmpdir) / "events.ndjson"
+            registry = RetrievalRegistry()
+            sink = EventSink(events_path)
+            agent = MountAgent(registry, sink)
+            response = agent.register_mount(
+                MountRequest(
+                    mount_name="demo",
+                    backend_type="topolvm",
+                    resolved_path_or_handle="/workspaces/demo/mnt/data",
+                    node_ref="node-a",
+                    rw_mode="rw",
+                    capacity_bytes=1024,
+                    workspace_ref="ws/demo",
+                    dataset_ref="ds/demo",
+                    pipeline_version="v1",
+                    policy_bundle_ref="policy/default",
+                    principal="tester",
+                )
+            )
+            self.assertEqual(response.mount_ref.backend_type, "topolvm")
+            self.assertTrue(events_path.exists())
+            lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+            self.assertEqual(len(lines), 1)
+            payload = json.loads(lines[0])
+            self.assertEqual(payload["event_type"], "mount.ready")
+
+    def test_manifest_schema_validator_basics(self) -> None:
+        schema = load_schema(MANIFEST_V1)
+        instance = {
+            "schema_version": "manifest.v1",
+            "manifest_id": "m1",
+            "created_at": "2026-04-16T00:00:00Z",
+            "dataset_ref": "ds/demo",
+            "mount_ref": "mnt/demo",
+            "policy_bundle_ref": "policy/default",
+            "entries": [],
+            "root_hash": "abc"
+        }
+        errors = validate_instance(instance, schema)
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/fabric/validator.py
+++ b/tools/fabric/validator.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+import json
+from typing import Any
+
+
+class ValidationError(Exception):
+    pass
+
+
+def _py_type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
+def _normalize(value: Any) -> Any:
+    if is_dataclass(value):
+        return asdict(value)
+    return value
+
+
+def load_schema(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def validate_instance(instance: Any, schema: dict[str, Any], path: str = "$") -> list[str]:
+    instance = _normalize(instance)
+    errors: list[str] = []
+
+    if "const" in schema and instance != schema["const"]:
+        errors.append(f"{path}: expected const {schema['const']!r}, got {instance!r}")
+        return errors
+
+    if "enum" in schema and instance not in schema["enum"]:
+        errors.append(f"{path}: expected one of {schema['enum']!r}, got {instance!r}")
+
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        allowed = schema_type
+    elif isinstance(schema_type, str):
+        allowed = [schema_type]
+    else:
+        allowed = []
+
+    if allowed:
+        actual = _py_type_name(instance)
+        if actual not in allowed:
+            errors.append(f"{path}: expected type {allowed!r}, got {actual!r}")
+            return errors
+
+    if isinstance(instance, dict):
+        required = schema.get("required", [])
+        for key in required:
+            if key not in instance:
+                errors.append(f"{path}: missing required key {key!r}")
+        properties = schema.get("properties", {})
+        for key, subschema in properties.items():
+            if key in instance:
+                errors.extend(validate_instance(instance[key], subschema, f"{path}.{key}"))
+        if schema.get("additionalProperties") is False:
+            for key in instance.keys():
+                if key not in properties:
+                    errors.append(f"{path}: unexpected key {key!r}")
+
+    elif isinstance(instance, list):
+        item_schema = schema.get("items")
+        if item_schema:
+            for idx, item in enumerate(instance):
+                errors.extend(validate_instance(item, item_schema, f"{path}[{idx}]"))
+
+    return errors
+
+
+def validate_file(instance_path: str | Path, schema_path: str | Path) -> list[str]:
+    instance = json.loads(Path(instance_path).read_text(encoding="utf-8"))
+    schema = load_schema(schema_path)
+    return validate_instance(instance, schema)


### PR DESCRIPTION
## Summary
This draft PR adds the first code-bearing runtime scaffold for the fabric control plane under `tools/fabric/`.

It adds:
- `tools/fabric/__init__.py`
- `tools/fabric/README.md`
- `tools/fabric/types.py`
- `tools/fabric/checkpoints.py`
- `tools/fabric/events.py`
- `tools/fabric/retrieval_registry.py`
- `tools/fabric/schema_refs.py`
- `tools/fabric/mount_agent.py`

## Why
The fabric contract stack is already upstream on `main`:
- portable artifacts + governance
- runtime contracts for mounts/connectors
- execution bridge docs
- sync/signing + partial replication semantics
- first machine-readable schema tranche

This PR is the next logical step: a small, dependency-light implementation scaffold that gives those contracts a concrete in-repo home.

## What this scaffold does
- models the core control-plane objects as dataclasses
- persists connector checkpoints
- emits NDJSON evidence events
- registers `IndexRef` objects in an in-memory retrieval registry
- performs a minimal mount registration flow in `MountAgent`

## Review focus
1. Package location and naming under `tools/fabric/`
2. Whether the object shapes align with the already-merged contracts and schemas
3. Whether the `MountAgent` is the right first seam for real implementation
4. Whether standard-library-only remains the right v1 constraint

## Notes
- This is intentionally a scaffold, not a production runtime.
- Follow-on after this PR: schema validation wiring, connector executor skeletons, tests/CLI, and integration into repo tooling.
