### PR TITLE
Draft: fabric connector executor skeletons

### DIFF
--- a/tools/fabric/connectors/__init__.py
+++ b/tools/fabric/connectors/__init__.py
@@ -1,0 +1,1 @@
+# fabric connector package

--- a/tools/fabric/connectors/base.py
+++ b/tools/fabric/connectors/base.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from ..checkpoints import CheckpointStore
+from ..events import EventSink
+from ..types import ConnectorCheckpoint, EvidenceEvent
+
+
+@dataclass(frozen=True)
+class ConnectorContext:
+    connector_id: str
+    dataset_ref: str
+    policy_bundle_ref: str
+    actor_ref: str
+    workspace_ref: str
+
+
+class ConnectorExecutor:
+    def __init__(self, context: ConnectorContext, checkpoints: CheckpointStore, events: EventSink) -> None:
+        self.context = context
+        self.checkpoints = checkpoints
+        self.events = events
+
+    def restore_checkpoint(self) -> ConnectorCheckpoint | None:
+        return self.checkpoints.load(self.context.connector_id, self.context.dataset_ref)
+
+    def emit(self, event_type: str, correlation_id: str, payload: dict[str, Any]) -> None:
+        self.events.emit(
+            EvidenceEvent(
+                event_id=f"{self.context.connector_id}:{correlation_id}:{event_type}",
+                event_type=event_type,
+                occurred_at=payload.get("occurred_at", ""),
+                actor_ref=self.context.actor_ref,
+                workspace_ref=self.context.workspace_ref,
+                dataset_ref=self.context.dataset_ref,
+                policy_bundle_ref=self.context.policy_bundle_ref,
+                correlation_id=correlation_id,
+                payload=payload,
+            )
+        )
+
+    def scan(self) -> Iterable[dict[str, Any]]:
+        raise NotImplementedError
+
+    def apply(self) -> None:
+        raise NotImplementedError

--- a/tools/fabric/connectors/drive.py
+++ b/tools/fabric/connectors/drive.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from .base import ConnectorExecutor
+from ..types import ConnectorCheckpoint
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class DriveExecutor(ConnectorExecutor):
+    def scan(self) -> Iterable[dict[str, Any]]:
+        checkpoint = self.restore_checkpoint()
+        yield {
+            "change_id": "drive-scan-demo",
+            "source_ref": "drive:file_id:revision_id",
+            "operation": "scan",
+            "cursor": getattr(checkpoint, "cursor_or_marker", ""),
+            "occurred_at": _now(),
+        }
+
+    def apply(self) -> None:
+        for change in self.scan():
+            self.emit("connector.scan.completed", change["change_id"], change)
+            checkpoint = ConnectorCheckpoint(
+                checkpoint_id="ckpt-drive-demo",
+                connector_id=self.context.connector_id,
+                dataset_ref=self.context.dataset_ref,
+                cursor_or_marker=change["change_id"],
+                last_successful_scan_at=change["occurred_at"],
+                last_applied_change_id=change["change_id"],
+                integrity_digest="demo",
+                executor_version="v1",
+                created_at=change["occurred_at"],
+                updated_at=change["occurred_at"],
+            )
+            self.checkpoints.save(checkpoint)

--- a/tools/fabric/connectors/hyper.py
+++ b/tools/fabric/connectors/hyper.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+from .base import ConnectorExecutor
+from ..types import ConnectorCheckpoint
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class HyperExecutor(ConnectorExecutor):
+    def scan(self) -> Iterable[dict[str, str]]:
+        checkpoint = self.restore_checkpoint()
+        yield {
+            "change_id": "hyper-scan-demo",
+            "source_ref": "hypercore:feed_key:seq",
+            "operation": "feed-sync",
+            "cursor": getattr(checkpoint, "cursor_or_marker", ""),
+            "occurred_at": _now(),
+        }
+
+    def apply(self) -> None:
+        for change in self.scan():
+            self.emit("connector.scan.completed", change["change_id"], change)
+            checkpoint = ConnectorCheckpoint(
+                checkpoint_id="ckpt-hyper-demo",
+                connector_id=self.context.connector_id,
+                dataset_ref=self.context.dataset_ref,
+                cursor_or_marker=change["change_id"],
+                last_successful_scan_at=change["occurred_at"],
+                last_applied_change_id=change["change_id"],
+                integrity_digest="demo",
+                executor_version="v1",
+                created_at=change["occurred_at"],
+                updated_at=change["occurred_at"],
+            )
+            self.checkpoints.save(checkpoint)

--- a/tools/fabric/connectors/rsync.py
+++ b/tools/fabric/connectors/rsync.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+from .base import ConnectorExecutor
+from ..types import ConnectorCheckpoint
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class RsyncExecutor(ConnectorExecutor):
+    def scan(self) -> Iterable[dict[str, str]]:
+        checkpoint = self.restore_checkpoint()
+        yield {
+            "change_id": "rsync-scan-demo",
+            "source_ref": "rsync:path:fingerprint",
+            "operation": "mirror",
+            "cursor": getattr(checkpoint, "cursor_or_marker", ""),
+            "occurred_at": _now(),
+        }
+
+    def apply(self) -> None:
+        for change in self.scan():
+            self.emit("connector.scan.completed", change["change_id"], change)
+            checkpoint = ConnectorCheckpoint(
+                checkpoint_id="ckpt-rsync-demo",
+                connector_id=self.context.connector_id,
+                dataset_ref=self.context.dataset_ref,
+                cursor_or_marker=change["change_id"],
+                last_successful_scan_at=change["occurred_at"],
+                last_applied_change_id=change["change_id"],
+                integrity_digest="demo",
+                executor_version="v1",
+                created_at=change["occurred_at"],
+                updated_at=change["occurred_at"],
+            )
+            self.checkpoints.save(checkpoint)

--- a/tools/fabric/connectors/s3.py
+++ b/tools/fabric/connectors/s3.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+from .base import ConnectorExecutor
+from ..types import ConnectorCheckpoint
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class S3Executor(ConnectorExecutor):
+    def scan(self) -> Iterable[dict[str, str]]:
+        checkpoint = self.restore_checkpoint()
+        yield {
+            "change_id": "s3-scan-demo",
+            "source_ref": "s3:bucket:key:etag",
+            "operation": "replica-sync",
+            "cursor": getattr(checkpoint, "cursor_or_marker", ""),
+            "occurred_at": _now(),
+        }
+
+    def apply(self) -> None:
+        for change in self.scan():
+            self.emit("connector.scan.completed", change["change_id"], change)
+            checkpoint = ConnectorCheckpoint(
+                checkpoint_id="ckpt-s3-demo",
+                connector_id=self.context.connector_id,
+                dataset_ref=self.context.dataset_ref,
+                cursor_or_marker=change["change_id"],
+                last_successful_scan_at=change["occurred_at"],
+                last_applied_change_id=change["change_id"],
+                integrity_digest="demo",
+                executor_version="v1",
+                created_at=change["occurred_at"],
+                updated_at=change["occurred_at"],
+            )
+            self.checkpoints.save(checkpoint)

--- a/tools/fabric/connectors_selftest.py
+++ b/tools/fabric/connectors_selftest.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .checkpoints import CheckpointStore
+from .connectors.base import ConnectorContext
+from .connectors.drive import DriveExecutor
+from .connectors.hyper import HyperExecutor
+from .connectors.rsync import RsyncExecutor
+from .connectors.s3 import S3Executor
+from .events import EventSink
+
+
+class ConnectorSmokeTest(unittest.TestCase):
+    def test_all_connector_executors_emit_and_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            checkpoints = CheckpointStore(root / "ckpt")
+            events = EventSink(root / "events.ndjson")
+
+            executors = [
+                DriveExecutor,
+                RsyncExecutor,
+                S3Executor,
+                HyperExecutor,
+            ]
+            for executor_cls in executors:
+                context = ConnectorContext(
+                    connector_id=executor_cls.__name__.lower(),
+                    dataset_ref="ds/demo",
+                    policy_bundle_ref="policy/default",
+                    actor_ref="tester",
+                    workspace_ref="ws/demo",
+                )
+                executor = executor_cls(context, checkpoints, events)
+                executor.apply()
+                self.assertIsNotNone(checkpoints.load(context.connector_id, context.dataset_ref))
+
+            lines = events.path.read_text(encoding="utf-8").strip().splitlines()
+            self.assertEqual(len(lines), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds connector executor skeletons and a smoke test on top of the fabric validation branch:
- Drive
- rsync
- S3
- Hyper
- shared executor base
- connector smoke test

This keeps the fabric runtime moving from generic scaffolding toward actual connector behavior.