### PR TITLE
Draft: add fabric integration harness for mount registration and drive executor flow

### DIFF
--- a/tools/fabric/integration_harness.py
+++ b/tools/fabric/integration_harness.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from .checkpoints import CheckpointStore
+from .connectors.base import ConnectorContext
+from .connectors.drive import DriveExecutor
+from .events import EventSink
+from .mount_agent import MountAgent, MountRequest
+from .retrieval_registry import RetrievalRegistry
+
+
+def run_mount_and_drive_flow(root: Path) -> dict[str, Any]:
+    root.mkdir(parents=True, exist_ok=True)
+    checkpoints = CheckpointStore(root / "checkpoints")
+    events = EventSink(root / "events.ndjson")
+    registry = RetrievalRegistry()
+
+    agent = MountAgent(registry, events)
+    response = agent.register_mount(
+        MountRequest(
+            mount_name="demo",
+            backend_type="topolvm",
+            resolved_path_or_handle="/workspaces/demo/mnt/data",
+            node_ref="node-a",
+            rw_mode="rw",
+            capacity_bytes=1024,
+            workspace_ref="ws/demo",
+            dataset_ref="ds/demo",
+            pipeline_version="v1",
+            policy_bundle_ref="policy/default",
+            principal="tester",
+        )
+    )
+
+    executor = DriveExecutor(
+        ConnectorContext(
+            connector_id="drive",
+            dataset_ref="ds/demo",
+            policy_bundle_ref="policy/default",
+            actor_ref="tester",
+            workspace_ref="ws/demo",
+        ),
+        checkpoints,
+        events,
+    )
+    executor.apply()
+
+    checkpoint = checkpoints.load("drive", "ds/demo")
+    registration = registry.get("ws/demo", "ds/demo")
+    event_lines = (root / "events.ndjson").read_text(encoding="utf-8").strip().splitlines()
+
+    return {
+        "mount_registration": asdict(response),
+        "registry_entry": asdict(registration) if registration else None,
+        "checkpoint": asdict(checkpoint) if checkpoint else None,
+        "event_count": len([line for line in event_lines if line]),
+    }

--- a/tools/fabric/integration_selftest.py
+++ b/tools/fabric/integration_selftest.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .integration_harness import run_mount_and_drive_flow
+
+
+class IntegrationHarnessSmokeTest(unittest.TestCase):
+    def test_mount_and_drive_flow(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_mount_and_drive_flow(Path(tmpdir))
+            self.assertIsNotNone(result["mount_registration"])
+            self.assertIsNotNone(result["registry_entry"])
+            self.assertIsNotNone(result["checkpoint"])
+            self.assertGreaterEqual(result["event_count"], 2)
+            self.assertEqual(result["checkpoint"]["connector_id"], "drive")
+            self.assertEqual(result["registry_entry"]["workspace_ref"], "ws/demo")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This stacked draft PR adds a small end-to-end integration harness on top of the connector executor tranche.

It adds:
- `tools/fabric/integration_harness.py`
- `tools/fabric/integration_selftest.py`

## What it covers
One runnable smoke path that exercises:
- mount registration via `MountAgent`
- retrieval registration
- checkpoint persistence
- NDJSON evidence event emission
- one connector executor (`DriveExecutor`)

## Why
The fabric lane already has:
- runtime scaffold (#100)
- validation / CLI / self-test (#101)
- connector executors (#104)

This PR ties those together into the first end-to-end execution slice so the runtime stops being only isolated components.

## Review focus
1. Whether the harness is the right minimal composition point
2. Whether the smoke path exercises the most important first seam
3. Whether we should generalize this harness shape for additional connector flows next

## Notes
- This is intentionally a small integration slice, not a full orchestrator.
- Follow-on after this PR: replay/idempotence tests and additional connector-path harnesses.
