### PR TITLE
Draft: add fabric replay/idempotence and conflict-path tests

### DIFF
--- a/tools/fabric/conflict_harness.py
+++ b/tools/fabric/conflict_harness.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+def classify_conflict(local_dirty: bool, remote_delete: bool, authority_mode: str = "local_first") -> str:
+    """Return the minimal conflict action aligned to the documented conflict matrix."""
+    if local_dirty and remote_delete:
+        return "manual_reconcile"
+    if authority_mode == "local_first":
+        return "local_wins"
+    if authority_mode == "provider_first":
+        return "remote_wins"
+    return "manual_reconcile"

--- a/tools/fabric/conflict_selftest.py
+++ b/tools/fabric/conflict_selftest.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import unittest
+
+from .conflict_harness import classify_conflict
+
+
+class ConflictPathSmokeTest(unittest.TestCase):
+    def test_local_dirty_and_remote_delete_requires_manual_reconcile(self) -> None:
+        self.assertEqual(
+            classify_conflict(local_dirty=True, remote_delete=True, authority_mode="local_first"),
+            "manual_reconcile",
+        )
+
+    def test_authority_modes_choose_expected_default(self) -> None:
+        self.assertEqual(classify_conflict(False, False, authority_mode="local_first"), "local_wins")
+        self.assertEqual(classify_conflict(False, False, authority_mode="provider_first"), "remote_wins")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/fabric/replay_harness.py
+++ b/tools/fabric/replay_harness.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from .checkpoints import CheckpointStore
+from .connectors.base import ConnectorContext
+from .connectors.drive import DriveExecutor
+from .events import EventSink
+
+
+def run_repeated_drive_executor(root: Path, runs: int = 2) -> dict[str, Any]:
+    root.mkdir(parents=True, exist_ok=True)
+    checkpoints = CheckpointStore(root / "checkpoints")
+    events = EventSink(root / "events.ndjson")
+
+    executor = DriveExecutor(
+        ConnectorContext(
+            connector_id="drive",
+            dataset_ref="ds/demo",
+            policy_bundle_ref="policy/default",
+            actor_ref="tester",
+            workspace_ref="ws/demo",
+        ),
+        checkpoints,
+        events,
+    )
+
+    for _ in range(runs):
+        executor.apply()
+
+    checkpoint = checkpoints.load("drive", "ds/demo")
+    event_lines = (root / "events.ndjson").read_text(encoding="utf-8").strip().splitlines()
+
+    return {
+        "runs": runs,
+        "checkpoint": asdict(checkpoint) if checkpoint else None,
+        "event_count": len([line for line in event_lines if line]),
+        "last_event": event_lines[-1] if event_lines else None,
+    }

--- a/tools/fabric/replay_selftest.py
+++ b/tools/fabric/replay_selftest.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .checkpoints import CheckpointStore
+from .replay_harness import run_repeated_drive_executor
+from .types import ConnectorCheckpoint
+
+
+class ReplayAndIdempotenceSmokeTest(unittest.TestCase):
+    def test_repeated_drive_executor_runs_keep_checkpoint_and_emit_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_repeated_drive_executor(Path(tmpdir), runs=2)
+            self.assertEqual(result["runs"], 2)
+            self.assertIsNotNone(result["checkpoint"])
+            self.assertEqual(result["checkpoint"]["connector_id"], "drive")
+            self.assertEqual(result["checkpoint"]["last_applied_change_id"], "drive-scan-demo")
+            self.assertEqual(result["event_count"], 2)
+
+    def test_checkpoint_roundtrip_is_stable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = CheckpointStore(Path(tmpdir))
+            checkpoint = ConnectorCheckpoint(
+                checkpoint_id="ckpt-demo",
+                connector_id="drive",
+                dataset_ref="ds/demo",
+                cursor_or_marker="cursor-1",
+                last_successful_scan_at="2026-04-16T00:00:00Z",
+                last_applied_change_id="change-1",
+                integrity_digest="demo",
+                executor_version="v1",
+                created_at="2026-04-16T00:00:00Z",
+                updated_at="2026-04-16T00:00:00Z",
+            )
+            store.save(checkpoint)
+            loaded = store.load("drive", "ds/demo")
+            self.assertEqual(loaded, checkpoint)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This stacked draft PR adds the next runtime-hardening tranche on top of the integration harness.

It adds:
- `tools/fabric/replay_harness.py`
- `tools/fabric/replay_selftest.py`
- `tools/fabric/conflict_harness.py`
- `tools/fabric/conflict_selftest.py`

## What it covers
- repeated connector execution against the same checkpoint/event store
- checkpoint round-trip stability
- one explicit conflict-path rule aligned to the documented conflict matrix

## Why
The fabric lane already has:
- runtime scaffold (#100)
- validation / CLI / self-test (#101)
- connector executors (#104)
- integration harness (#105)

This PR adds the first hardening slice for runtime behavior under repetition and simple conflict conditions.

## Review focus
1. Whether the replay harness is the right place to capture repeated-run semantics
2. Whether the smoke tests meaningfully protect the checkpoint/event behavior
3. Whether the minimal conflict helper is the right interim bridge before richer reconcile logic lands

## Notes
- This is intentionally a small hardening tranche, not the final replay/reconcile implementation.
- Follow-on after this PR: a second connector-path integration harness (`S3` or `Hyper`) and richer conflict/idempotence coverage.
