### PR TITLE
Draft: add fabric S3 integration harness and smoke test

### DIFF
--- a/tools/fabric/integration_harness_s3.py
+++ b/tools/fabric/integration_harness_s3.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from .checkpoints import CheckpointStore
+from .connectors.base import ConnectorContext
+from .connectors.s3 import S3Executor
+from .events import EventSink
+from .mount_agent import MountAgent, MountRequest
+from .retrieval_registry import RetrievalRegistry
+
+
+def run_mount_and_s3_flow(root: Path) -> dict[str, Any]:
+    root.mkdir(parents=True, exist_ok=True)
+    checkpoints = CheckpointStore(root / "checkpoints")
+    events = EventSink(root / "events.ndjson")
+    registry = RetrievalRegistry()
+
+    agent = MountAgent(registry, events)
+    response = agent.register_mount(
+        MountRequest(
+            mount_name="demo-s3",
+            backend_type="topolvm",
+            resolved_path_or_handle="/workspaces/demo/mnt/data",
+            node_ref="node-a",
+            rw_mode="rw",
+            capacity_bytes=2048,
+            workspace_ref="ws/demo",
+            dataset_ref="ds/demo-s3",
+            pipeline_version="v1",
+            policy_bundle_ref="policy/default",
+            principal="tester",
+        )
+    )
+
+    executor = S3Executor(
+        ConnectorContext(
+            connector_id="s3",
+            dataset_ref="ds/demo-s3",
+            policy_bundle_ref="policy/default",
+            actor_ref="tester",
+            workspace_ref="ws/demo",
+        ),
+        checkpoints,
+        events,
+    )
+    executor.apply()
+
+    checkpoint = checkpoints.load("s3", "ds/demo-s3")
+    registration = registry.get("ws/demo", "ds/demo-s3")
+    event_lines = (root / "events.ndjson").read_text(encoding="utf-8").strip().splitlines()
+
+    return {
+        "mount_registration": asdict(response),
+        "registry_entry": asdict(registration) if registration else None,
+        "checkpoint": asdict(checkpoint) if checkpoint else None,
+        "event_count": len([line for line in event_lines if line]),
+    }

--- a/tools/fabric/integration_s3_selftest.py
+++ b/tools/fabric/integration_s3_selftest.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .integration_harness_s3 import run_mount_and_s3_flow
+
+
+class IntegrationS3HarnessSmokeTest(unittest.TestCase):
+    def test_mount_and_s3_flow(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_mount_and_s3_flow(Path(tmpdir))
+            self.assertIsNotNone(result["mount_registration"])
+            self.assertIsNotNone(result["registry_entry"])
+            self.assertIsNotNone(result["checkpoint"])
+            self.assertGreaterEqual(result["event_count"], 2)
+            self.assertEqual(result["checkpoint"]["connector_id"], "s3")
+            self.assertEqual(result["registry_entry"]["workspace_ref"], "ws/demo")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This stacked draft PR adds a second end-to-end connector-path harness on top of the replay/conflict tranche.

It adds:
- `tools/fabric/integration_harness_s3.py`
- `tools/fabric/integration_s3_selftest.py`

## What it covers
One runnable smoke path that exercises:
- mount registration via `MountAgent`
- retrieval registration
- checkpoint persistence
- NDJSON evidence event emission
- one connector executor (`S3Executor`)

## Why
The fabric lane already has:
- runtime scaffold (#100)
- validation / CLI / self-test (#101)
- connector executors (#104)
- integration harness for Drive (#105)
- replay/idempotence + conflict-path tests (#107)

This PR broadens the runtime proof surface so the fabric lane covers more than the Drive path.

## Review focus
1. Whether the second harness follows the right pattern from the first integration slice
2. Whether S3 is the right next connector family to prove after Drive
3. Whether we should factor shared harness setup after this lands

## Notes
- This is intentionally a second smoke path, not a generalized orchestrator.
- Follow-on after this PR: Hyper integration harness and richer reconcile-path tests.
