### PR TITLE
Draft: add fabric Hyper integration harness and smoke test

### DIFF
--- a/tools/fabric/integration_harness_hyper.py
+++ b/tools/fabric/integration_harness_hyper.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from .checkpoints import CheckpointStore
+from .connectors.base import ConnectorContext
+from .connectors.hyper import HyperExecutor
+from .events import EventSink
+from .mount_agent import MountAgent, MountRequest
+from .retrieval_registry import RetrievalRegistry
+
+
+def run_mount_and_hyper_flow(root: Path) -> dict[str, Any]:
+    root.mkdir(parents=True, exist_ok=True)
+    checkpoints = CheckpointStore(root / "checkpoints")
+    events = EventSink(root / "events.ndjson")
+    registry = RetrievalRegistry()
+
+    agent = MountAgent(registry, events)
+    response = agent.register_mount(
+        MountRequest(
+            mount_name="demo-hyper",
+            backend_type="topolvm",
+            resolved_path_or_handle="/workspaces/demo/mnt/data",
+            node_ref="node-a",
+            rw_mode="rw",
+            capacity_bytes=4096,
+            workspace_ref="ws/demo",
+            dataset_ref="ds/demo-hyper",
+            pipeline_version="v1",
+            policy_bundle_ref="policy/default",
+            principal="tester",
+        )
+    )
+
+    executor = HyperExecutor(
+        ConnectorContext(
+            connector_id="hyper",
+            dataset_ref="ds/demo-hyper",
+            policy_bundle_ref="policy/default",
+            actor_ref="tester",
+            workspace_ref="ws/demo",
+        ),
+        checkpoints,
+        events,
+    )
+    executor.apply()
+
+    checkpoint = checkpoints.load("hyper", "ds/demo-hyper")
+    registration = registry.get("ws/demo", "ds/demo-hyper")
+    event_lines = (root / "events.ndjson").read_text(encoding="utf-8").strip().splitlines()
+
+    return {
+        "mount_registration": asdict(response),
+        "registry_entry": asdict(registration) if registration else None,
+        "checkpoint": asdict(checkpoint) if checkpoint else None,
+        "event_count": len([line for line in event_lines if line]),
+    }

--- a/tools/fabric/integration_hyper_selftest.py
+++ b/tools/fabric/integration_hyper_selftest.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .integration_harness_hyper import run_mount_and_hyper_flow
+
+
+class IntegrationHyperHarnessSmokeTest(unittest.TestCase):
+    def test_mount_and_hyper_flow(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_mount_and_hyper_flow(Path(tmpdir))
+            self.assertIsNotNone(result["mount_registration"])
+            self.assertIsNotNone(result["registry_entry"])
+            self.assertIsNotNone(result["checkpoint"])
+            self.assertGreaterEqual(result["event_count"], 2)
+            self.assertEqual(result["checkpoint"]["connector_id"], "hyper")
+            self.assertEqual(result["registry_entry"]["workspace_ref"], "ws/demo")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a third end-to-end connector-path harness on top of the S3 integration tranche:
- tools/fabric/integration_harness_hyper.py
- tools/fabric/integration_hyper_selftest.py

This exercises mount registration, retrieval registration, checkpoint persistence, NDJSON event emission, and the Hyper executor path.