### PR TITLE
Draft: fabric shared integration harness

### DIFF
--- a/tools/fabric/integration_common.py
+++ b/tools/fabric/integration_common.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Type
+
+from .checkpoints import CheckpointStore
+from .connectors.base import ConnectorContext, ConnectorExecutor
+from .events import EventSink
+from .mount_agent import MountAgent, MountRequest
+from .retrieval_registry import RetrievalRegistry
+
+
+def run_mount_and_connector_flow(
+    root: Path,
+    *,
+    executor_cls: Type[ConnectorExecutor],
+    connector_id: str,
+    dataset_ref: str,
+    mount_name: str,
+    capacity_bytes: int,
+) -> dict[str, Any]:
+    root.mkdir(parents=True, exist_ok=True)
+    checkpoints = CheckpointStore(root / "checkpoints")
+    events = EventSink(root / "events.ndjson")
+    registry = RetrievalRegistry()
+
+    agent = MountAgent(registry, events)
+    response = agent.register_mount(
+        MountRequest(
+            mount_name=mount_name,
+            backend_type="topolvm",
+            resolved_path_or_handle="/workspaces/demo/mnt/data",
+            node_ref="node-a",
+            rw_mode="rw",
+            capacity_bytes=capacity_bytes,
+            workspace_ref="ws/demo",
+            dataset_ref=dataset_ref,
+            pipeline_version="v1",
+            policy_bundle_ref="policy/default",
+            principal="tester",
+        )
+    )
+
+    executor = executor_cls(
+        ConnectorContext(
+            connector_id=connector_id,
+            dataset_ref=dataset_ref,
+            policy_bundle_ref="policy/default",
+            actor_ref="tester",
+            workspace_ref="ws/demo",
+        ),
+        checkpoints,
+        events,
+    )
+    executor.apply()
+
+    checkpoint = checkpoints.load(connector_id, dataset_ref)
+    registration = registry.get("ws/demo", dataset_ref)
+    event_lines = (root / "events.ndjson").read_text(encoding="utf-8").strip().splitlines()
+
+    return {
+        "mount_registration": asdict(response),
+        "registry_entry": asdict(registration) if registration else None,
+        "checkpoint": asdict(checkpoint) if checkpoint else None,
+        "event_count": len([line for line in event_lines if line]),
+    }

--- a/tools/fabric/integration_matrix_selftest.py
+++ b/tools/fabric/integration_matrix_selftest.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .connectors.drive import DriveExecutor
+from .connectors.hyper import HyperExecutor
+from .connectors.s3 import S3Executor
+from .integration_common import run_mount_and_connector_flow
+
+
+class IntegrationMatrixSmokeTest(unittest.TestCase):
+    def test_drive_s3_hyper_share_one_harness(self) -> None:
+        cases = [
+            (DriveExecutor, "drive", "ds/demo-drive", "demo-drive", 1024),
+            (S3Executor, "s3", "ds/demo-s3", "demo-s3", 2048),
+            (HyperExecutor, "hyper", "ds/demo-hyper", "demo-hyper", 4096),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for idx, (executor_cls, connector_id, dataset_ref, mount_name, capacity_bytes) in enumerate(cases):
+                root = Path(tmpdir) / f"case-{idx}"
+                result = run_mount_and_connector_flow(
+                    root,
+                    executor_cls=executor_cls,
+                    connector_id=connector_id,
+                    dataset_ref=dataset_ref,
+                    mount_name=mount_name,
+                    capacity_bytes=capacity_bytes,
+                )
+                self.assertIsNotNone(result["mount_registration"])
+                self.assertIsNotNone(result["registry_entry"])
+                self.assertIsNotNone(result["checkpoint"])
+                self.assertGreaterEqual(result["event_count"], 2)
+                self.assertEqual(result["checkpoint"]["connector_id"], connector_id)
+                self.assertEqual(result["registry_entry"]["workspace_ref"], "ws/demo")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a shared integration helper and a matrix smoke test for Drive, S3, and Hyper on top of the current Hyper integration tranche.