### PR TITLE
Draft: migrate fabric harnesses to shared helper

### DIFF
--- a/tools/fabric/integration_harness.py
+++ b/tools/fabric/integration_harness.py
@@ -1,60 +1,18 @@
 from __future__ import annotations
 
-from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-from .checkpoints import CheckpointStore
-from .connectors.base import ConnectorContext
 from .connectors.drive import DriveExecutor
-from .events import EventSink
-from .mount_agent import MountAgent, MountRequest
-from .retrieval_registry import RetrievalRegistry
+from .integration_common import run_mount_and_connector_flow
 
 
 def run_mount_and_drive_flow(root: Path) -> dict[str, Any]:
-    root.mkdir(parents=True, exist_ok=True)
-    checkpoints = CheckpointStore(root / "checkpoints")
-    events = EventSink(root / "events.ndjson")
-    registry = RetrievalRegistry()
-
-    agent = MountAgent(registry, events)
-    response = agent.register_mount(
-        MountRequest(
-            mount_name="demo",
-            backend_type="topolvm",
-            resolved_path_or_handle="/workspaces/demo/mnt/data",
-            node_ref="node-a",
-            rw_mode="rw",
-            capacity_bytes=1024,
-            workspace_ref="ws/demo",
-            dataset_ref="ds/demo",
-            pipeline_version="v1",
-            policy_bundle_ref="policy/default",
-            principal="tester",
-        )
+    return run_mount_and_connector_flow(
+        root,
+        executor_cls=DriveExecutor,
+        connector_id="drive",
+        dataset_ref="ds/demo",
+        mount_name="demo",
+        capacity_bytes=1024,
     )
-
-    executor = DriveExecutor(
-        ConnectorContext(
-            connector_id="drive",
-            dataset_ref="ds/demo",
-            policy_bundle_ref="policy/default",
-            actor_ref="tester",
-            workspace_ref="ws/demo",
-        ),
-        checkpoints,
-        events,
-    )
-    executor.apply()
-
-    checkpoint = checkpoints.load("drive", "ds/demo")
-    registration = registry.get("ws/demo", "ds/demo")
-    event_lines = (root / "events.ndjson").read_text(encoding="utf-8").strip().splitlines()
-
-    return {
-        "mount_registration": asdict(response),
-        "registry_entry": asdict(registration) if registration else None,
-        "checkpoint": asdict(checkpoint) if checkpoint else None,
-        "event_count": len([line for line in event_lines if line]),
-    }

--- a/tools/fabric/integration_harness_hyper.py
+++ b/tools/fabric/integration_harness_hyper.py
@@ -1,60 +1,18 @@
 from __future__ import annotations
 
-from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-from .checkpoints import CheckpointStore
-from .connectors.base import ConnectorContext
 from .connectors.hyper import HyperExecutor
-from .events import EventSink
-from .mount_agent import MountAgent, MountRequest
-from .retrieval_registry import RetrievalRegistry
+from .integration_common import run_mount_and_connector_flow
 
 
 def run_mount_and_hyper_flow(root: Path) -> dict[str, Any]:
-    root.mkdir(parents=True, exist_ok=True)
-    checkpoints = CheckpointStore(root / "checkpoints")
-    events = EventSink(root / "events.ndjson")
-    registry = RetrievalRegistry()
-
-    agent = MountAgent(registry, events)
-    response = agent.register_mount(
-        MountRequest(
-            mount_name="demo-hyper",
-            backend_type="topolvm",
-            resolved_path_or_handle="/workspaces/demo/mnt/data",
-            node_ref="node-a",
-            rw_mode="rw",
-            capacity_bytes=4096,
-            workspace_ref="ws/demo",
-            dataset_ref="ds/demo-hyper",
-            pipeline_version="v1",
-            policy_bundle_ref="policy/default",
-            principal="tester",
-        )
+    return run_mount_and_connector_flow(
+        root,
+        executor_cls=HyperExecutor,
+        connector_id="hyper",
+        dataset_ref="ds/demo-hyper",
+        mount_name="demo-hyper",
+        capacity_bytes=4096,
     )
-
-    executor = HyperExecutor(
-        ConnectorContext(
-            connector_id="hyper",
-            dataset_ref="ds/demo-hyper",
-            policy_bundle_ref="policy/default",
-            actor_ref="tester",
-            workspace_ref="ws/demo",
-        ),
-        checkpoints,
-        events,
-    )
-    executor.apply()
-
-    checkpoint = checkpoints.load("hyper", "ds/demo-hyper")
-    registration = registry.get("ws/demo", "ds/demo-hyper")
-    event_lines = (root / "events.ndjson").read_text(encoding="utf-8").strip().splitlines()
-
-    return {
-        "mount_registration": asdict(response),
-        "registry_entry": asdict(registration) if registration else None,
-        "checkpoint": asdict(checkpoint) if checkpoint else None,
-        "event_count": len([line for line in event_lines if line]),
-    }

--- a/tools/fabric/integration_harness_s3.py
+++ b/tools/fabric/integration_harness_s3.py
@@ -1,60 +1,18 @@
 from __future__ import annotations
 
-from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-from .checkpoints import CheckpointStore
-from .connectors.base import ConnectorContext
 from .connectors.s3 import S3Executor
-from .events import EventSink
-from .mount_agent import MountAgent, MountRequest
-from .retrieval_registry import RetrievalRegistry
+from .integration_common import run_mount_and_connector_flow
 
 
 def run_mount_and_s3_flow(root: Path) -> dict[str, Any]:
-    root.mkdir(parents=True, exist_ok=True)
-    checkpoints = CheckpointStore(root / "checkpoints")
-    events = EventSink(root / "events.ndjson")
-    registry = RetrievalRegistry()
-
-    agent = MountAgent(registry, events)
-    response = agent.register_mount(
-        MountRequest(
-            mount_name="demo-s3",
-            backend_type="topolvm",
-            resolved_path_or_handle="/workspaces/demo/mnt/data",
-            node_ref="node-a",
-            rw_mode="rw",
-            capacity_bytes=2048,
-            workspace_ref="ws/demo",
-            dataset_ref="ds/demo-s3",
-            pipeline_version="v1",
-            policy_bundle_ref="policy/default",
-            principal="tester",
-        )
+    return run_mount_and_connector_flow(
+        root,
+        executor_cls=S3Executor,
+        connector_id="s3",
+        dataset_ref="ds/demo-s3",
+        mount_name="demo-s3",
+        capacity_bytes=2048,
     )
-
-    executor = S3Executor(
-        ConnectorContext(
-            connector_id="s3",
-            dataset_ref="ds/demo-s3",
-            policy_bundle_ref="policy/default",
-            actor_ref="tester",
-            workspace_ref="ws/demo",
-        ),
-        checkpoints,
-        events,
-    )
-    executor.apply()
-
-    checkpoint = checkpoints.load("s3", "ds/demo-s3")
-    registration = registry.get("ws/demo", "ds/demo-s3")
-    event_lines = (root / "events.ndjson").read_text(encoding="utf-8").strip().splitlines()
-
-    return {
-        "mount_registration": asdict(response),
-        "registry_entry": asdict(registration) if registration else None,
-        "checkpoint": asdict(checkpoint) if checkpoint else None,
-        "event_count": len([line for line in event_lines if line]),
-    }


### PR DESCRIPTION
Migrates the Drive, S3, and Hyper harness wrappers to call the shared integration helper instead of carrying duplicate setup code.