### PR TITLE
Draft: deeper fabric reconcile tests

### DIFF
--- a/tools/fabric/reconcile.py
+++ b/tools/fabric/reconcile.py
@@ -69,3 +69,126 @@ def decide_reconcile_action(
         reason="unknown_authority_mode",
         authoritative_side="none",
     )
+
+
+def decide_tombstone_action(
+    *,
+    signed_tombstone: bool,
+    local_dirty: bool,
+    authority_mode: str = "local_first",
+) -> ReconcileDecision:
+    if local_dirty:
+        return ReconcileDecision(
+            action="manual_reconcile",
+            reason="local_dirty_remote_tombstone",
+            authoritative_side="none",
+        )
+
+    if not signed_tombstone:
+        return ReconcileDecision(
+            action="reject_tombstone",
+            reason="unsigned_tombstone",
+            authoritative_side="none",
+        )
+
+    if authority_mode == "provider_first":
+        return ReconcileDecision(
+            action="apply_tombstone",
+            reason="provider_first_signed_tombstone",
+            authoritative_side="remote",
+        )
+
+    if authority_mode == "local_first":
+        return ReconcileDecision(
+            action="manual_reconcile",
+            reason="signed_tombstone_requires_policy_check",
+            authoritative_side="local",
+        )
+
+    if authority_mode == "hybrid":
+        return ReconcileDecision(
+            action="manual_reconcile",
+            reason="hybrid_tombstone_requires_resolution",
+            authoritative_side="none",
+        )
+
+    return ReconcileDecision(
+        action="manual_reconcile",
+        reason="unknown_authority_mode",
+        authoritative_side="none",
+    )
+
+
+def decide_stale_mirror_action(
+    *,
+    stale_generation_gap: int,
+    policy_allow_stale: bool,
+    authority_mode: str = "local_first",
+) -> ReconcileDecision:
+    if stale_generation_gap <= 0:
+        return ReconcileDecision(
+            action="use_mirror",
+            reason="mirror_is_fresh",
+            authoritative_side="remote",
+        )
+
+    if not policy_allow_stale:
+        return ReconcileDecision(
+            action="block_stale_mirror",
+            reason="stale_not_allowed",
+            authoritative_side="local",
+        )
+
+    if authority_mode == "local_first":
+        return ReconcileDecision(
+            action="metadata_only",
+            reason="stale_mirror_local_first",
+            authoritative_side="local",
+        )
+
+    if authority_mode == "provider_first":
+        return ReconcileDecision(
+            action="use_stale_mirror",
+            reason="stale_mirror_provider_first",
+            authoritative_side="remote",
+        )
+
+    if authority_mode == "hybrid":
+        return ReconcileDecision(
+            action="manual_reconcile",
+            reason="stale_mirror_hybrid_requires_resolution",
+            authoritative_side="none",
+        )
+
+    return ReconcileDecision(
+        action="manual_reconcile",
+        reason="unknown_authority_mode",
+        authoritative_side="none",
+    )
+
+
+def decide_authority_transition(
+    *,
+    current_authority: str,
+    requested_authority: str,
+    quorum_granted: bool,
+) -> ReconcileDecision:
+    if current_authority == requested_authority:
+        return ReconcileDecision(
+            action="no_op",
+            reason="same_authority",
+            authoritative_side=current_authority,
+        )
+
+    if not quorum_granted:
+        return ReconcileDecision(
+            action="manual_reconcile",
+            reason="quorum_required_for_authority_transition",
+            authoritative_side=current_authority,
+        )
+
+    return ReconcileDecision(
+        action="promote_authority",
+        reason="authority_transition_granted",
+        authoritative_side=requested_authority,
+    )

--- a/tools/fabric/reconcile_deep_selftest.py
+++ b/tools/fabric/reconcile_deep_selftest.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import unittest
+
+from .reconcile import (
+    decide_authority_transition,
+    decide_stale_mirror_action,
+    decide_tombstone_action,
+)
+
+
+class ReconcileDeepSmokeTest(unittest.TestCase):
+    def test_unsigned_tombstone_is_rejected(self) -> None:
+        decision = decide_tombstone_action(
+            signed_tombstone=False,
+            local_dirty=False,
+            authority_mode="provider_first",
+        )
+        self.assertEqual(decision.action, "reject_tombstone")
+        self.assertEqual(decision.reason, "unsigned_tombstone")
+
+    def test_signed_tombstone_with_local_dirty_requires_manual_reconcile(self) -> None:
+        decision = decide_tombstone_action(
+            signed_tombstone=True,
+            local_dirty=True,
+            authority_mode="local_first",
+        )
+        self.assertEqual(decision.action, "manual_reconcile")
+        self.assertEqual(decision.reason, "local_dirty_remote_tombstone")
+
+    def test_stale_mirror_blocked_without_policy_allowance(self) -> None:
+        decision = decide_stale_mirror_action(
+            stale_generation_gap=3,
+            policy_allow_stale=False,
+            authority_mode="local_first",
+        )
+        self.assertEqual(decision.action, "block_stale_mirror")
+        self.assertEqual(decision.reason, "stale_not_allowed")
+
+    def test_local_first_with_stale_allowed_becomes_metadata_only(self) -> None:
+        decision = decide_stale_mirror_action(
+            stale_generation_gap=2,
+            policy_allow_stale=True,
+            authority_mode="local_first",
+        )
+        self.assertEqual(decision.action, "metadata_only")
+        self.assertEqual(decision.reason, "stale_mirror_local_first")
+
+    def test_authority_transition_requires_quorum(self) -> None:
+        decision = decide_authority_transition(
+            current_authority="local",
+            requested_authority="remote",
+            quorum_granted=False,
+        )
+        self.assertEqual(decision.action, "manual_reconcile")
+        self.assertEqual(decision.reason, "quorum_required_for_authority_transition")
+
+    def test_authority_transition_with_quorum_promotes(self) -> None:
+        decision = decide_authority_transition(
+            current_authority="local",
+            requested_authority="remote",
+            quorum_granted=True,
+        )
+        self.assertEqual(decision.action, "promote_authority")
+        self.assertEqual(decision.authoritative_side, "remote")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds deeper stale-mirror, tombstone, and authority-transition reconcile logic and tests on top of the harness-migration branch.