### PR TITLE
Draft: add fabric reconcile flow harness and CLI tests

### DIFF
--- a/tools/fabric/cli.py
+++ b/tools/fabric/cli.py
@@ -10,6 +10,7 @@ from .connectors.s3 import S3Executor
 from .events import EventSink
 from .integration_common import run_mount_and_connector_flow
 from .mount_agent import MountAgent, MountRequest
+from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
 from .retrieval_registry import RetrievalRegistry
 from .schema_refs import schema_paths
 from .validator import validate_file
@@ -70,6 +71,28 @@ def cmd_run_harness(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_run_tombstone_flow(args: argparse.Namespace) -> int:
+    result = run_tombstone_propagation_flow(
+        Path(args.root),
+        signed_tombstone=args.signed_tombstone,
+        local_dirty=args.local_dirty,
+        authority_mode=args.authority_mode,
+    )
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def cmd_run_authority_flow(args: argparse.Namespace) -> int:
+    result = run_authority_transition_flow(
+        Path(args.root),
+        current_authority=args.current_authority,
+        requested_authority=args.requested_authority,
+        quorum_granted=args.quorum_granted,
+    )
+    print(json.dumps(result, indent=2))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="fabric")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -98,6 +121,20 @@ def build_parser() -> argparse.ArgumentParser:
     harness.add_argument("connector", choices=["drive", "s3", "hyper"])
     harness.add_argument("--root", required=True)
     harness.set_defaults(func=cmd_run_harness)
+
+    tombstone = sub.add_parser("run-tombstone-flow")
+    tombstone.add_argument("--root", required=True)
+    tombstone.add_argument("--signed-tombstone", action="store_true")
+    tombstone.add_argument("--local-dirty", action="store_true")
+    tombstone.add_argument("--authority-mode", default="local_first", choices=["local_first", "provider_first", "hybrid"])
+    tombstone.set_defaults(func=cmd_run_tombstone_flow)
+
+    authority = sub.add_parser("run-authority-flow")
+    authority.add_argument("--root", required=True)
+    authority.add_argument("--current-authority", required=True)
+    authority.add_argument("--requested-authority", required=True)
+    authority.add_argument("--quorum-granted", action="store_true")
+    authority.set_defaults(func=cmd_run_authority_flow)
 
     return parser
 

--- a/tools/fabric/cli_reconcile_flow_selftest.py
+++ b/tools/fabric/cli_reconcile_flow_selftest.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+from .cli import cmd_run_authority_flow, cmd_run_tombstone_flow
+
+
+class CliReconcileFlowSmokeTest(unittest.TestCase):
+    def test_run_tombstone_flow(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rc = cmd_run_tombstone_flow(
+                argparse.Namespace(
+                    root=tmpdir,
+                    signed_tombstone=True,
+                    local_dirty=False,
+                    authority_mode="provider_first",
+                )
+            )
+            self.assertEqual(rc, 0)
+            self.assertTrue((Path(tmpdir) / "events.ndjson").exists())
+
+    def test_run_authority_flow(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rc = cmd_run_authority_flow(
+                argparse.Namespace(
+                    root=tmpdir,
+                    current_authority="local",
+                    requested_authority="remote",
+                    quorum_granted=True,
+                )
+            )
+            self.assertEqual(rc, 0)
+            self.assertTrue((Path(tmpdir) / "events.ndjson").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/fabric/reconcile_flow_harness.py
+++ b/tools/fabric/reconcile_flow_harness.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from .events import EventSink
+from .integration_common import run_mount_and_connector_flow
+from .connectors.s3 import S3Executor
+from .connectors.hyper import HyperExecutor
+from .reconcile import decide_authority_transition, decide_tombstone_action
+from .types import EvidenceEvent
+
+
+def _event_id(prefix: str, suffix: str) -> str:
+    return f"{prefix}:{suffix}"
+
+
+def _load_event_count(path: Path) -> int:
+    if not path.exists():
+        return 0
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    return len([line for line in lines if line])
+
+
+def run_tombstone_propagation_flow(
+    root: Path,
+    *,
+    signed_tombstone: bool,
+    local_dirty: bool,
+    authority_mode: str = "local_first",
+) -> dict[str, Any]:
+    result = run_mount_and_connector_flow(
+        root,
+        executor_cls=S3Executor,
+        connector_id="s3",
+        dataset_ref="ds/tombstone",
+        mount_name="demo-tombstone",
+        capacity_bytes=2048,
+    )
+    events_path = root / "events.ndjson"
+    sink = EventSink(events_path)
+    decision = decide_tombstone_action(
+        signed_tombstone=signed_tombstone,
+        local_dirty=local_dirty,
+        authority_mode=authority_mode,
+    )
+    sink.emit(
+        EvidenceEvent(
+            event_id=_event_id("reconcile", "tombstone"),
+            event_type="reconcile.tombstone.evaluated",
+            occurred_at="2026-04-17T00:00:00Z",
+            actor_ref="tester",
+            workspace_ref="ws/demo",
+            dataset_ref="ds/tombstone",
+            policy_bundle_ref="policy/default",
+            correlation_id="tombstone-flow",
+            payload={
+                "decision": asdict(decision),
+                "signed_tombstone": signed_tombstone,
+                "local_dirty": local_dirty,
+                "authority_mode": authority_mode,
+            },
+        )
+    )
+    result["reconcile_decision"] = asdict(decision)
+    result["event_count"] = _load_event_count(events_path)
+    return result
+
+
+def run_authority_transition_flow(
+    root: Path,
+    *,
+    current_authority: str,
+    requested_authority: str,
+    quorum_granted: bool,
+) -> dict[str, Any]:
+    result = run_mount_and_connector_flow(
+        root,
+        executor_cls=HyperExecutor,
+        connector_id="hyper",
+        dataset_ref="ds/authority",
+        mount_name="demo-authority",
+        capacity_bytes=4096,
+    )
+    events_path = root / "events.ndjson"
+    sink = EventSink(events_path)
+    decision = decide_authority_transition(
+        current_authority=current_authority,
+        requested_authority=requested_authority,
+        quorum_granted=quorum_granted,
+    )
+    sink.emit(
+        EvidenceEvent(
+            event_id=_event_id("reconcile", "authority"),
+            event_type="reconcile.authority_transition.evaluated",
+            occurred_at="2026-04-17T00:00:00Z",
+            actor_ref="tester",
+            workspace_ref="ws/demo",
+            dataset_ref="ds/authority",
+            policy_bundle_ref="policy/default",
+            correlation_id="authority-flow",
+            payload={
+                "decision": asdict(decision),
+                "current_authority": current_authority,
+                "requested_authority": requested_authority,
+                "quorum_granted": quorum_granted,
+            },
+        )
+    )
+    result["reconcile_decision"] = asdict(decision)
+    result["event_count"] = _load_event_count(events_path)
+    return result


### PR DESCRIPTION
Adds tombstone and authority reconcile flow harnesses plus CLI smoke tests on top of the current CLI harness branch.