### PR TITLE
Draft: add fabric reconcile matrix harness and tests

### DIFF
--- a/tools/fabric/reconcile_matrix_harness.py
+++ b/tools/fabric/reconcile_matrix_harness.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .reconcile import (
+    decide_authority_transition,
+    decide_stale_mirror_action,
+    decide_tombstone_action,
+)
+from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
+from .stale_mirror_flow_harness import run_stale_mirror_flow
+
+
+def run_reconcile_matrix(root: Path) -> dict[str, Any]:
+    root.mkdir(parents=True, exist_ok=True)
+
+    tombstone = run_tombstone_propagation_flow(
+        root / "tombstone",
+        signed_tombstone=True,
+        local_dirty=False,
+        authority_mode="provider_first",
+    )
+    stale = run_stale_mirror_flow(
+        root / "stale",
+        stale_generation_gap=3,
+        policy_allow_stale=True,
+        authority_mode="local_first",
+    )
+    authority = run_authority_transition_flow(
+        root / "authority",
+        current_authority="local",
+        requested_authority="remote",
+        quorum_granted=True,
+    )
+
+    direct_decisions = {
+        "tombstone": decide_tombstone_action(
+            signed_tombstone=True,
+            local_dirty=False,
+            authority_mode="provider_first",
+        ).__dict__,
+        "stale_mirror": decide_stale_mirror_action(
+            stale_generation_gap=3,
+            policy_allow_stale=True,
+            authority_mode="local_first",
+        ).__dict__,
+        "authority_transition": decide_authority_transition(
+            current_authority="local",
+            requested_authority="remote",
+            quorum_granted=True,
+        ).__dict__,
+    }
+
+    return {
+        "tombstone": tombstone,
+        "stale_mirror": stale,
+        "authority_transition": authority,
+        "direct_decisions": direct_decisions,
+    }

--- a/tools/fabric/reconcile_matrix_selftest.py
+++ b/tools/fabric/reconcile_matrix_selftest.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .reconcile_matrix_harness import run_reconcile_matrix
+
+
+class ReconcileMatrixSmokeTest(unittest.TestCase):
+    def test_reconcile_matrix_combines_tombstone_stale_and_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_reconcile_matrix(Path(tmpdir))
+            self.assertIn("tombstone", result)
+            self.assertIn("stale_mirror", result)
+            self.assertIn("authority_transition", result)
+            self.assertEqual(result["direct_decisions"]["tombstone"]["action"], "apply_tombstone")
+            self.assertEqual(result["direct_decisions"]["stale_mirror"]["action"], "metadata_only")
+            self.assertEqual(result["direct_decisions"]["authority_transition"]["action"], "promote_authority")
+            self.assertGreaterEqual(result["tombstone"]["event_count"], 2)
+            self.assertGreaterEqual(result["stale_mirror"]["event_count"], 2)
+            self.assertGreaterEqual(result["authority_transition"]["event_count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a combined reconcile matrix harness and smoke test on top of the current stale-mirror branch.