### PR TITLE
Draft: add fabric result labels for reconcile outcomes

### DIFF
--- a/tools/fabric/reconcile_flow_harness.py
+++ b/tools/fabric/reconcile_flow_harness.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -10,6 +9,7 @@ from .integration_common import run_mount_and_connector_flow
 from .connectors.s3 import S3Executor
 from .connectors.hyper import HyperExecutor
 from .reconcile import decide_authority_transition, decide_tombstone_action
+from .result_labels import label_for_authority_transition, label_for_tombstone
 from .types import EvidenceEvent
 
 
@@ -46,6 +46,7 @@ def run_tombstone_propagation_flow(
         local_dirty=local_dirty,
         authority_mode=authority_mode,
     )
+    label = label_for_tombstone(decision)
     sink.emit(
         EvidenceEvent(
             event_id=_event_id("reconcile", "tombstone"),
@@ -58,6 +59,7 @@ def run_tombstone_propagation_flow(
             correlation_id="tombstone-flow",
             payload={
                 "decision": asdict(decision),
+                "result_label": label.to_dict(),
                 "signed_tombstone": signed_tombstone,
                 "local_dirty": local_dirty,
                 "authority_mode": authority_mode,
@@ -65,6 +67,7 @@ def run_tombstone_propagation_flow(
         )
     )
     result["reconcile_decision"] = asdict(decision)
+    result["result_label"] = label.to_dict()
     result["event_count"] = _load_event_count(events_path)
     return result
 
@@ -91,6 +94,7 @@ def run_authority_transition_flow(
         requested_authority=requested_authority,
         quorum_granted=quorum_granted,
     )
+    label = label_for_authority_transition(decision)
     sink.emit(
         EvidenceEvent(
             event_id=_event_id("reconcile", "authority"),
@@ -103,6 +107,7 @@ def run_authority_transition_flow(
             correlation_id="authority-flow",
             payload={
                 "decision": asdict(decision),
+                "result_label": label.to_dict(),
                 "current_authority": current_authority,
                 "requested_authority": requested_authority,
                 "quorum_granted": quorum_granted,
@@ -110,5 +115,6 @@ def run_authority_transition_flow(
         )
     )
     result["reconcile_decision"] = asdict(decision)
+    result["result_label"] = label.to_dict()
     result["event_count"] = _load_event_count(events_path)
     return result

--- a/tools/fabric/reconcile_matrix_harness.py
+++ b/tools/fabric/reconcile_matrix_harness.py
@@ -9,6 +9,11 @@ from .reconcile import (
     decide_tombstone_action,
 )
 from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
+from .result_labels import (
+    label_for_authority_transition,
+    label_for_stale_mirror,
+    label_for_tombstone,
+)
 from .stale_mirror_flow_harness import run_stale_mirror_flow
 
 
@@ -34,22 +39,31 @@ def run_reconcile_matrix(root: Path) -> dict[str, Any]:
         quorum_granted=True,
     )
 
+    tombstone_decision = decide_tombstone_action(
+        signed_tombstone=True,
+        local_dirty=False,
+        authority_mode="provider_first",
+    )
+    stale_decision = decide_stale_mirror_action(
+        stale_generation_gap=3,
+        policy_allow_stale=True,
+        authority_mode="local_first",
+    )
+    authority_decision = decide_authority_transition(
+        current_authority="local",
+        requested_authority="remote",
+        quorum_granted=True,
+    )
+
     direct_decisions = {
-        "tombstone": decide_tombstone_action(
-            signed_tombstone=True,
-            local_dirty=False,
-            authority_mode="provider_first",
-        ).__dict__,
-        "stale_mirror": decide_stale_mirror_action(
-            stale_generation_gap=3,
-            policy_allow_stale=True,
-            authority_mode="local_first",
-        ).__dict__,
-        "authority_transition": decide_authority_transition(
-            current_authority="local",
-            requested_authority="remote",
-            quorum_granted=True,
-        ).__dict__,
+        "tombstone": tombstone_decision.__dict__,
+        "stale_mirror": stale_decision.__dict__,
+        "authority_transition": authority_decision.__dict__,
+    }
+    result_labels = {
+        "tombstone": label_for_tombstone(tombstone_decision).to_dict(),
+        "stale_mirror": label_for_stale_mirror(stale_decision).to_dict(),
+        "authority_transition": label_for_authority_transition(authority_decision).to_dict(),
     }
 
     return {
@@ -57,4 +71,5 @@ def run_reconcile_matrix(root: Path) -> dict[str, Any]:
         "stale_mirror": stale,
         "authority_transition": authority,
         "direct_decisions": direct_decisions,
+        "result_labels": result_labels,
     }

--- a/tools/fabric/result_label_flow_selftest.py
+++ b/tools/fabric/result_label_flow_selftest.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
+from .stale_mirror_flow_harness import run_stale_mirror_flow
+
+
+class ResultLabelFlowSmokeTest(unittest.TestCase):
+    def test_stale_mirror_flow_exposes_result_label(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_stale_mirror_flow(
+                Path(tmpdir),
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                authority_mode="local_first",
+            )
+            self.assertEqual(result["result_label"]["surface_state"], "remote_metadata_only")
+            self.assertEqual(result["result_label"]["freshness_class"], "bounded_stale")
+
+    def test_tombstone_flow_exposes_result_label(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_tombstone_propagation_flow(
+                Path(tmpdir),
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+            )
+            self.assertEqual(result["result_label"]["surface_state"], "tombstoned")
+            self.assertEqual(result["result_label"]["reconcile_state"], "resolved")
+
+    def test_authority_flow_exposes_result_label(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_authority_transition_flow(
+                Path(tmpdir),
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            )
+            self.assertEqual(result["result_label"]["surface_state"], "authority_transition_applied")
+            self.assertEqual(result["result_label"]["authority_state"], "remote_authoritative")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/fabric/result_labels.py
+++ b/tools/fabric/result_labels.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from .reconcile import ReconcileDecision
+
+
+@dataclass(frozen=True)
+class ResultLabel:
+    surface_state: str
+    freshness_class: str
+    authority_state: str
+    reconcile_state: str
+    operator_message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+def label_for_stale_mirror(decision: ReconcileDecision) -> ResultLabel:
+    if decision.action == "block_stale_mirror":
+        return ResultLabel(
+            surface_state="authoritative_local",
+            freshness_class="fresh",
+            authority_state="local_authoritative",
+            reconcile_state="blocked",
+            operator_message="Stale mirror blocked by policy.",
+        )
+    if decision.action == "metadata_only":
+        return ResultLabel(
+            surface_state="remote_metadata_only",
+            freshness_class="bounded_stale",
+            authority_state="local_authoritative",
+            reconcile_state="degraded_read",
+            operator_message="Mirror is stale; returning metadata only.",
+        )
+    if decision.action == "use_stale_mirror":
+        return ResultLabel(
+            surface_state="stale_mirror",
+            freshness_class="bounded_stale",
+            authority_state="remote_read_only",
+            reconcile_state="allowed",
+            operator_message="Using stale mirror per policy.",
+        )
+    if decision.action == "use_mirror":
+        return ResultLabel(
+            surface_state="stale_mirror",
+            freshness_class="fresh",
+            authority_state="remote_read_only",
+            reconcile_state="allowed",
+            operator_message="Mirror is fresh enough to use.",
+        )
+    return ResultLabel(
+        surface_state="manual_resolution_required",
+        freshness_class="unknown_stale",
+        authority_state="none",
+        reconcile_state="manual_reconcile_required",
+        operator_message="Manual reconcile required before using mirror data.",
+    )
+
+
+def label_for_tombstone(decision: ReconcileDecision) -> ResultLabel:
+    if decision.action == "apply_tombstone":
+        return ResultLabel(
+            surface_state="tombstoned",
+            freshness_class="fresh",
+            authority_state="remote_authoritative",
+            reconcile_state="resolved",
+            operator_message="Remote tombstone applied.",
+        )
+    if decision.action == "reject_tombstone":
+        return ResultLabel(
+            surface_state="authoritative_local",
+            freshness_class="fresh",
+            authority_state="local_authoritative",
+            reconcile_state="rejected",
+            operator_message="Unsigned tombstone rejected.",
+        )
+    return ResultLabel(
+        surface_state="manual_resolution_required",
+        freshness_class="unknown_stale",
+        authority_state="none",
+        reconcile_state="manual_reconcile_required",
+        operator_message="Manual reconcile required before tombstone handling.",
+    )
+
+
+def label_for_authority_transition(decision: ReconcileDecision) -> ResultLabel:
+    if decision.action == "promote_authority":
+        authority = f"{decision.authoritative_side}_authoritative"
+        return ResultLabel(
+            surface_state="authority_transition_applied",
+            freshness_class="fresh",
+            authority_state=authority,
+            reconcile_state="resolved",
+            operator_message="Authority transition applied.",
+        )
+    if decision.action == "no_op":
+        authority = f"{decision.authoritative_side}_authoritative"
+        return ResultLabel(
+            surface_state="authority_unchanged",
+            freshness_class="fresh",
+            authority_state=authority,
+            reconcile_state="no_op",
+            operator_message="Authority unchanged.",
+        )
+    authority = f"{decision.authoritative_side}_authoritative" if decision.authoritative_side != "none" else "none"
+    return ResultLabel(
+        surface_state="authority_transition_pending",
+        freshness_class="unknown_stale",
+        authority_state=authority,
+        reconcile_state="manual_reconcile_required",
+        operator_message="Manual reconcile required before authority transition.",
+    )

--- a/tools/fabric/stale_mirror_flow_harness.py
+++ b/tools/fabric/stale_mirror_flow_harness.py
@@ -8,6 +8,7 @@ from .events import EventSink
 from .integration_common import run_mount_and_connector_flow
 from .connectors.s3 import S3Executor
 from .reconcile import decide_stale_mirror_action
+from .result_labels import label_for_stale_mirror
 from .types import EvidenceEvent
 
 
@@ -33,6 +34,7 @@ def run_stale_mirror_flow(
         policy_allow_stale=policy_allow_stale,
         authority_mode=authority_mode,
     )
+    label = label_for_stale_mirror(decision)
     sink.emit(
         EvidenceEvent(
             event_id="reconcile:stale-mirror",
@@ -45,6 +47,7 @@ def run_stale_mirror_flow(
             correlation_id="stale-mirror-flow",
             payload={
                 "decision": asdict(decision),
+                "result_label": label.to_dict(),
                 "stale_generation_gap": stale_generation_gap,
                 "policy_allow_stale": policy_allow_stale,
                 "authority_mode": authority_mode,
@@ -53,5 +56,6 @@ def run_stale_mirror_flow(
     )
     event_lines = events_path.read_text(encoding="utf-8").strip().splitlines()
     result["reconcile_decision"] = asdict(decision)
+    result["result_label"] = label.to_dict()
     result["event_count"] = len([line for line in event_lines if line])
     return result


### PR DESCRIPTION
Adds a result-label mapper plus flow-level tests so stale-mirror, tombstone, and authority-transition decisions show up as explicit runtime outcomes.