### PR TITLE
Draft: add fabric runtime surface outcomes

### DIFF
--- a/tools/fabric/result_surface.py
+++ b/tools/fabric/result_surface.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class VisibleRuntimeOutcome:
+    flow_name: str
+    surface_state: str
+    freshness_class: str
+    authority_state: str
+    reconcile_state: str
+    operator_message: str
+    event_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def outcome_from_flow_result(flow_name: str, flow_result: dict[str, Any]) -> VisibleRuntimeOutcome:
+    label = flow_result["result_label"]
+    return VisibleRuntimeOutcome(
+        flow_name=flow_name,
+        surface_state=label["surface_state"],
+        freshness_class=label["freshness_class"],
+        authority_state=label["authority_state"],
+        reconcile_state=label["reconcile_state"],
+        operator_message=label["operator_message"],
+        event_count=int(flow_result.get("event_count", 0)),
+    )
+
+
+def outcomes_from_reconcile_matrix(matrix_result: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        "tombstone": outcome_from_flow_result("tombstone", matrix_result["tombstone"]).to_dict(),
+        "stale_mirror": outcome_from_flow_result("stale_mirror", matrix_result["stale_mirror"]).to_dict(),
+        "authority_transition": outcome_from_flow_result("authority_transition", matrix_result["authority_transition"]).to_dict(),
+    }

--- a/tools/fabric/result_surface_selftest.py
+++ b/tools/fabric/result_surface_selftest.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
+from .reconcile_matrix_harness import run_reconcile_matrix
+from .result_surface import outcome_from_flow_result, outcomes_from_reconcile_matrix
+from .stale_mirror_flow_harness import run_stale_mirror_flow
+
+
+class ResultSurfaceSmokeTest(unittest.TestCase):
+    def test_stale_mirror_surface(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow = run_stale_mirror_flow(
+                Path(tmpdir),
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                authority_mode="local_first",
+            )
+            surface = outcome_from_flow_result("stale_mirror", flow)
+            self.assertEqual(surface.surface_state, "remote_metadata_only")
+            self.assertEqual(surface.freshness_class, "bounded_stale")
+            self.assertEqual(surface.reconcile_state, "degraded_read")
+
+    def test_tombstone_surface(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow = run_tombstone_propagation_flow(
+                Path(tmpdir),
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+            )
+            surface = outcome_from_flow_result("tombstone", flow)
+            self.assertEqual(surface.surface_state, "tombstoned")
+            self.assertEqual(surface.authority_state, "remote_authoritative")
+            self.assertEqual(surface.reconcile_state, "resolved")
+
+    def test_authority_transition_surface(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow = run_authority_transition_flow(
+                Path(tmpdir),
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            )
+            surface = outcome_from_flow_result("authority_transition", flow)
+            self.assertEqual(surface.surface_state, "authority_transition_applied")
+            self.assertEqual(surface.authority_state, "remote_authoritative")
+
+    def test_reconcile_matrix_surfaces(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            matrix = run_reconcile_matrix(Path(tmpdir))
+            surfaces = outcomes_from_reconcile_matrix(matrix)
+            self.assertEqual(surfaces["tombstone"]["surface_state"], "tombstoned")
+            self.assertEqual(surfaces["stale_mirror"]["surface_state"], "remote_metadata_only")
+            self.assertEqual(surfaces["authority_transition"]["surface_state"], "authority_transition_applied")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a small runtime-surface helper and focused tests so stale-mirror, tombstone, authority-transition, and reconcile-matrix flows can be consumed as explicit operator-facing outcomes.