### PR TITLE
Draft: expose fabric planner surfaces through CLI

### DIFF
--- a/tools/fabric/cli.py
+++ b/tools/fabric/cli.py
@@ -10,6 +10,7 @@ from .connectors.s3 import S3Executor
 from .events import EventSink
 from .integration_common import run_mount_and_connector_flow
 from .mount_agent import MountAgent, MountRequest
+from .planner_surface import planner_outcome_from_runtime_surface, planner_outcomes_from_runtime_surface_matrix
 from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
 from .reconcile_matrix_harness import run_reconcile_matrix
 from .result_surface import outcome_from_flow_result, outcomes_from_reconcile_matrix
@@ -141,6 +142,47 @@ def cmd_show_surface(args: argparse.Namespace) -> int:
     return 2
 
 
+def cmd_show_planner_surface(args: argparse.Namespace) -> int:
+    root = Path(args.root)
+    if args.kind == "stale_mirror":
+        flow = run_stale_mirror_flow(
+            root,
+            stale_generation_gap=args.stale_generation_gap,
+            policy_allow_stale=args.policy_allow_stale,
+            authority_mode=args.authority_mode,
+        )
+        surface = outcome_from_flow_result("stale_mirror", flow)
+        print(json.dumps(planner_outcome_from_runtime_surface(surface).to_dict(), indent=2))
+        return 0
+    if args.kind == "tombstone":
+        flow = run_tombstone_propagation_flow(
+            root,
+            signed_tombstone=args.signed_tombstone,
+            local_dirty=args.local_dirty,
+            authority_mode=args.authority_mode,
+        )
+        surface = outcome_from_flow_result("tombstone", flow)
+        print(json.dumps(planner_outcome_from_runtime_surface(surface).to_dict(), indent=2))
+        return 0
+    if args.kind == "authority_transition":
+        flow = run_authority_transition_flow(
+            root,
+            current_authority=args.current_authority,
+            requested_authority=args.requested_authority,
+            quorum_granted=args.quorum_granted,
+        )
+        surface = outcome_from_flow_result("authority_transition", flow)
+        print(json.dumps(planner_outcome_from_runtime_surface(surface).to_dict(), indent=2))
+        return 0
+    if args.kind == "reconcile_matrix":
+        matrix = run_reconcile_matrix(root)
+        surfaces = outcomes_from_reconcile_matrix(matrix)
+        print(json.dumps(planner_outcomes_from_runtime_surface_matrix(surfaces), indent=2))
+        return 0
+    print(json.dumps({"error": f"unknown planner surface kind {args.kind!r}"}))
+    return 2
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="fabric")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -203,6 +245,19 @@ def build_parser() -> argparse.ArgumentParser:
     surface.add_argument("--requested-authority", default="remote")
     surface.add_argument("--quorum-granted", action="store_true")
     surface.set_defaults(func=cmd_show_surface)
+
+    planner = sub.add_parser("show-planner-surface")
+    planner.add_argument("kind", choices=["stale_mirror", "tombstone", "authority_transition", "reconcile_matrix"])
+    planner.add_argument("--root", required=True)
+    planner.add_argument("--stale-generation-gap", type=int, default=3)
+    planner.add_argument("--policy-allow-stale", action="store_true")
+    planner.add_argument("--signed-tombstone", action="store_true")
+    planner.add_argument("--local-dirty", action="store_true")
+    planner.add_argument("--authority-mode", default="local_first", choices=["local_first", "provider_first", "hybrid"])
+    planner.add_argument("--current-authority", default="local")
+    planner.add_argument("--requested-authority", default="remote")
+    planner.add_argument("--quorum-granted", action="store_true")
+    planner.set_defaults(func=cmd_show_planner_surface)
 
     return parser
 

--- a/tools/fabric/cli_planner_surface_selftest.py
+++ b/tools/fabric/cli_planner_surface_selftest.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+from .cli import cmd_show_planner_surface
+
+
+class CliPlannerSurfaceSmokeTest(unittest.TestCase):
+    def test_show_planner_surface_matrix(self) -> None:
+        cases = [
+            (
+                "stale_mirror",
+                argparse.Namespace(
+                    kind="stale_mirror",
+                    root=None,
+                    stale_generation_gap=3,
+                    policy_allow_stale=True,
+                    signed_tombstone=False,
+                    local_dirty=False,
+                    authority_mode="local_first",
+                    current_authority="local",
+                    requested_authority="remote",
+                    quorum_granted=False,
+                ),
+            ),
+            (
+                "tombstone",
+                argparse.Namespace(
+                    kind="tombstone",
+                    root=None,
+                    stale_generation_gap=3,
+                    policy_allow_stale=False,
+                    signed_tombstone=True,
+                    local_dirty=False,
+                    authority_mode="provider_first",
+                    current_authority="local",
+                    requested_authority="remote",
+                    quorum_granted=False,
+                ),
+            ),
+            (
+                "authority_transition",
+                argparse.Namespace(
+                    kind="authority_transition",
+                    root=None,
+                    stale_generation_gap=3,
+                    policy_allow_stale=False,
+                    signed_tombstone=False,
+                    local_dirty=False,
+                    authority_mode="local_first",
+                    current_authority="local",
+                    requested_authority="remote",
+                    quorum_granted=True,
+                ),
+            ),
+            (
+                "reconcile_matrix",
+                argparse.Namespace(
+                    kind="reconcile_matrix",
+                    root=None,
+                    stale_generation_gap=3,
+                    policy_allow_stale=True,
+                    signed_tombstone=True,
+                    local_dirty=False,
+                    authority_mode="provider_first",
+                    current_authority="local",
+                    requested_authority="remote",
+                    quorum_granted=True,
+                ),
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for idx, (_, ns) in enumerate(cases):
+                root = Path(tmpdir) / f"case-{idx}"
+                ns.root = str(root)
+                rc = cmd_show_planner_surface(ns)
+                self.assertEqual(rc, 0)
+                self.assertTrue(root.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/fabric/planner_surface.py
+++ b/tools/fabric/planner_surface.py
@@ -85,3 +85,23 @@ def planner_outcome_from_runtime_surface(surface: VisibleRuntimeOutcome) -> Plan
         operator_action="none",
         message="Surface can be served normally.",
     )
+
+
+def planner_outcome_from_surface_dict(flow_name: str, surface: dict[str, Any]) -> PlannerVisibleOutcome:
+    runtime = VisibleRuntimeOutcome(
+        flow_name=flow_name,
+        surface_state=surface["surface_state"],
+        freshness_class=surface["freshness_class"],
+        authority_state=surface["authority_state"],
+        reconcile_state=surface["reconcile_state"],
+        operator_message=surface["operator_message"],
+        event_count=int(surface.get("event_count", 0)),
+    )
+    return planner_outcome_from_runtime_surface(runtime)
+
+
+def planner_outcomes_from_runtime_surface_matrix(surface_matrix: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {
+        name: planner_outcome_from_surface_dict(name, surface).to_dict()
+        for name, surface in surface_matrix.items()
+    }

--- a/tools/fabric/planner_surface.py
+++ b/tools/fabric/planner_surface.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from .result_surface import VisibleRuntimeOutcome
+
+
+@dataclass(frozen=True)
+class PlannerVisibleOutcome:
+    flow_name: str
+    planner_mode: str
+    badge: str
+    freshness_hint: str
+    authority_hint: str
+    operator_action: str
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def planner_outcome_from_runtime_surface(surface: VisibleRuntimeOutcome) -> PlannerVisibleOutcome:
+    if surface.surface_state == "tombstoned":
+        return PlannerVisibleOutcome(
+            flow_name=surface.flow_name,
+            planner_mode="hide_from_results",
+            badge="tombstoned",
+            freshness_hint=surface.freshness_class,
+            authority_hint=surface.authority_state,
+            operator_action="no_read",
+            message="Content is tombstoned and should be hidden from result surfaces.",
+        )
+
+    if surface.surface_state == "remote_metadata_only":
+        return PlannerVisibleOutcome(
+            flow_name=surface.flow_name,
+            planner_mode="metadata_only",
+            badge="stale-mirror",
+            freshness_hint=surface.freshness_class,
+            authority_hint=surface.authority_state,
+            operator_action="offer_hydration_if_policy_allows",
+            message="Only metadata should be surfaced because the mirror is stale under local-first policy.",
+        )
+
+    if surface.surface_state == "stale_mirror":
+        return PlannerVisibleOutcome(
+            flow_name=surface.flow_name,
+            planner_mode="serve_with_stale_badge",
+            badge="stale-mirror",
+            freshness_hint=surface.freshness_class,
+            authority_hint=surface.authority_state,
+            operator_action="annotate_staleness",
+            message="Serve results with a stale badge and clear freshness annotation.",
+        )
+
+    if surface.surface_state == "authority_transition_applied":
+        return PlannerVisibleOutcome(
+            flow_name=surface.flow_name,
+            planner_mode="refresh_and_retry",
+            badge="authority-shift",
+            freshness_hint=surface.freshness_class,
+            authority_hint=surface.authority_state,
+            operator_action="refresh_indexes_and_retry",
+            message="Authority changed; refresh dependent state before serving results.",
+        )
+
+    if surface.reconcile_state == "manual_reconcile_required":
+        return PlannerVisibleOutcome(
+            flow_name=surface.flow_name,
+            planner_mode="block_until_manual_resolution",
+            badge="manual-reconcile",
+            freshness_hint=surface.freshness_class,
+            authority_hint=surface.authority_state,
+            operator_action="manual_resolution",
+            message="Manual reconcile is required before serving this surface.",
+        )
+
+    return PlannerVisibleOutcome(
+        flow_name=surface.flow_name,
+        planner_mode="serve_normally",
+        badge="normal",
+        freshness_hint=surface.freshness_class,
+        authority_hint=surface.authority_state,
+        operator_action="none",
+        message="Surface can be served normally.",
+    )


### PR DESCRIPTION
Adds a planner-surface mapper plus CLI smoke coverage so stale-mirror, tombstone, authority-transition, and reconcile-matrix outcomes can be consumed as planner-facing operator surfaces.