### PR TITLE
Draft: add result interface layer

### DIFF
--- a/tools/fabric/cli.py
+++ b/tools/fabric/cli.py
@@ -13,6 +13,7 @@ from .mount_agent import MountAgent, MountRequest
 from .planner_surface import planner_outcome_from_runtime_surface, planner_outcomes_from_runtime_surface_matrix
 from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
 from .reconcile_matrix_harness import run_reconcile_matrix
+from .result_interface import interface_from_serving_decision, interfaces_from_serving_matrix
 from .result_plan import serving_decision_from_planner_outcome, serving_decisions_from_planner_matrix
 from .result_surface import outcome_from_flow_result, outcomes_from_reconcile_matrix
 from .retrieval_registry import RetrievalRegistry
@@ -229,6 +230,55 @@ def cmd_show_result_plan(args: argparse.Namespace) -> int:
     return 2
 
 
+def cmd_show_result_interface(args: argparse.Namespace) -> int:
+    root = Path(args.root)
+    if args.kind == "stale_mirror":
+        flow = run_stale_mirror_flow(
+            root,
+            stale_generation_gap=args.stale_generation_gap,
+            policy_allow_stale=args.policy_allow_stale,
+            authority_mode=args.authority_mode,
+        )
+        surface = outcome_from_flow_result("stale_mirror", flow)
+        planner = planner_outcome_from_runtime_surface(surface)
+        decision = serving_decision_from_planner_outcome(planner)
+        print(json.dumps(interface_from_serving_decision(decision).to_dict(), indent=2))
+        return 0
+    if args.kind == "tombstone":
+        flow = run_tombstone_propagation_flow(
+            root,
+            signed_tombstone=args.signed_tombstone,
+            local_dirty=args.local_dirty,
+            authority_mode=args.authority_mode,
+        )
+        surface = outcome_from_flow_result("tombstone", flow)
+        planner = planner_outcome_from_runtime_surface(surface)
+        decision = serving_decision_from_planner_outcome(planner)
+        print(json.dumps(interface_from_serving_decision(decision).to_dict(), indent=2))
+        return 0
+    if args.kind == "authority_transition":
+        flow = run_authority_transition_flow(
+            root,
+            current_authority=args.current_authority,
+            requested_authority=args.requested_authority,
+            quorum_granted=args.quorum_granted,
+        )
+        surface = outcome_from_flow_result("authority_transition", flow)
+        planner = planner_outcome_from_runtime_surface(surface)
+        decision = serving_decision_from_planner_outcome(planner)
+        print(json.dumps(interface_from_serving_decision(decision).to_dict(), indent=2))
+        return 0
+    if args.kind == "reconcile_matrix":
+        matrix = run_reconcile_matrix(root)
+        surfaces = outcomes_from_reconcile_matrix(matrix)
+        planners = planner_outcomes_from_runtime_surface_matrix(surfaces)
+        decisions = serving_decisions_from_planner_matrix(planners)
+        print(json.dumps(interfaces_from_serving_matrix(decisions), indent=2))
+        return 0
+    print(json.dumps({"error": f"unknown result interface kind {args.kind!r}"}))
+    return 2
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="fabric")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -317,6 +367,19 @@ def build_parser() -> argparse.ArgumentParser:
     result_plan.add_argument("--requested-authority", default="remote")
     result_plan.add_argument("--quorum-granted", action="store_true")
     result_plan.set_defaults(func=cmd_show_result_plan)
+
+    result_interface = sub.add_parser("show-result-interface")
+    result_interface.add_argument("kind", choices=["stale_mirror", "tombstone", "authority_transition", "reconcile_matrix"])
+    result_interface.add_argument("--root", required=True)
+    result_interface.add_argument("--stale-generation-gap", type=int, default=3)
+    result_interface.add_argument("--policy-allow-stale", action="store_true")
+    result_interface.add_argument("--signed-tombstone", action="store_true")
+    result_interface.add_argument("--local-dirty", action="store_true")
+    result_interface.add_argument("--authority-mode", default="local_first", choices=["local_first", "provider_first", "hybrid"])
+    result_interface.add_argument("--current-authority", default="local")
+    result_interface.add_argument("--requested-authority", default="remote")
+    result_interface.add_argument("--quorum-granted", action="store_true")
+    result_interface.set_defaults(func=cmd_show_result_interface)
 
     return parser
 

--- a/tools/fabric/cli.py
+++ b/tools/fabric/cli.py
@@ -15,6 +15,7 @@ from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone
 from .reconcile_matrix_harness import run_reconcile_matrix
 from .result_interface import interface_from_serving_decision, interfaces_from_serving_matrix
 from .result_plan import serving_decision_from_planner_outcome, serving_decisions_from_planner_matrix
+from .result_render import render_block_from_interface, render_blocks_from_interface_matrix
 from .result_surface import outcome_from_flow_result, outcomes_from_reconcile_matrix
 from .retrieval_registry import RetrievalRegistry
 from .schema_refs import schema_paths
@@ -279,6 +280,59 @@ def cmd_show_result_interface(args: argparse.Namespace) -> int:
     return 2
 
 
+def cmd_show_result_render(args: argparse.Namespace) -> int:
+    root = Path(args.root)
+    if args.kind == "stale_mirror":
+        flow = run_stale_mirror_flow(
+            root,
+            stale_generation_gap=args.stale_generation_gap,
+            policy_allow_stale=args.policy_allow_stale,
+            authority_mode=args.authority_mode,
+        )
+        surface = outcome_from_flow_result("stale_mirror", flow)
+        planner = planner_outcome_from_runtime_surface(surface)
+        decision = serving_decision_from_planner_outcome(planner)
+        interface = interface_from_serving_decision(decision)
+        print(json.dumps(render_block_from_interface(interface).to_dict(), indent=2))
+        return 0
+    if args.kind == "tombstone":
+        flow = run_tombstone_propagation_flow(
+            root,
+            signed_tombstone=args.signed_tombstone,
+            local_dirty=args.local_dirty,
+            authority_mode=args.authority_mode,
+        )
+        surface = outcome_from_flow_result("tombstone", flow)
+        planner = planner_outcome_from_runtime_surface(surface)
+        decision = serving_decision_from_planner_outcome(planner)
+        interface = interface_from_serving_decision(decision)
+        print(json.dumps(render_block_from_interface(interface).to_dict(), indent=2))
+        return 0
+    if args.kind == "authority_transition":
+        flow = run_authority_transition_flow(
+            root,
+            current_authority=args.current_authority,
+            requested_authority=args.requested_authority,
+            quorum_granted=args.quorum_granted,
+        )
+        surface = outcome_from_flow_result("authority_transition", flow)
+        planner = planner_outcome_from_runtime_surface(surface)
+        decision = serving_decision_from_planner_outcome(planner)
+        interface = interface_from_serving_decision(decision)
+        print(json.dumps(render_block_from_interface(interface).to_dict(), indent=2))
+        return 0
+    if args.kind == "reconcile_matrix":
+        matrix = run_reconcile_matrix(root)
+        surfaces = outcomes_from_reconcile_matrix(matrix)
+        planners = planner_outcomes_from_runtime_surface_matrix(surfaces)
+        decisions = serving_decisions_from_planner_matrix(planners)
+        interfaces = interfaces_from_serving_matrix(decisions)
+        print(json.dumps(render_blocks_from_interface_matrix(interfaces), indent=2))
+        return 0
+    print(json.dumps({"error": f"unknown result render kind {args.kind!r}"}))
+    return 2
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="fabric")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -380,6 +434,19 @@ def build_parser() -> argparse.ArgumentParser:
     result_interface.add_argument("--requested-authority", default="remote")
     result_interface.add_argument("--quorum-granted", action="store_true")
     result_interface.set_defaults(func=cmd_show_result_interface)
+
+    result_render = sub.add_parser("show-result-render")
+    result_render.add_argument("kind", choices=["stale_mirror", "tombstone", "authority_transition", "reconcile_matrix"])
+    result_render.add_argument("--root", required=True)
+    result_render.add_argument("--stale-generation-gap", type=int, default=3)
+    result_render.add_argument("--policy-allow-stale", action="store_true")
+    result_render.add_argument("--signed-tombstone", action="store_true")
+    result_render.add_argument("--local-dirty", action="store_true")
+    result_render.add_argument("--authority-mode", default="local_first", choices=["local_first", "provider_first", "hybrid"])
+    result_render.add_argument("--current-authority", default="local")
+    result_render.add_argument("--requested-authority", default="remote")
+    result_render.add_argument("--quorum-granted", action="store_true")
+    result_render.set_defaults(func=cmd_show_result_render)
 
     return parser
 

--- a/tools/fabric/result_interface.py
+++ b/tools/fabric/result_interface.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from .result_plan import ResultServingDecision
+
+
+@dataclass(frozen=True)
+class ResultInterfaceView:
+    flow_name: str
+    display_state: str
+    headline: str
+    detail: str
+    badges: list[str]
+    content_visible: bool
+    metadata_visible: bool
+    next_action: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def interface_from_serving_decision(decision: ResultServingDecision) -> ResultInterfaceView:
+    if decision.serve_mode == "omit":
+        return ResultInterfaceView(
+            flow_name=decision.flow_name,
+            display_state="hidden",
+            headline="Content omitted",
+            detail=decision.message,
+            badges=decision.badges,
+            content_visible=False,
+            metadata_visible=False,
+            next_action=decision.required_actions[0] if decision.required_actions else "none",
+        )
+
+    if decision.serve_mode == "metadata_only":
+        return ResultInterfaceView(
+            flow_name=decision.flow_name,
+            display_state="metadata_only",
+            headline="Metadata only",
+            detail=decision.message,
+            badges=decision.badges,
+            content_visible=False,
+            metadata_visible=True,
+            next_action=decision.required_actions[0] if decision.required_actions else "none",
+        )
+
+    if decision.serve_mode == "defer_until_refresh":
+        return ResultInterfaceView(
+            flow_name=decision.flow_name,
+            display_state="pending_refresh",
+            headline="Refresh required",
+            detail=decision.message,
+            badges=decision.badges,
+            content_visible=False,
+            metadata_visible=True,
+            next_action=decision.required_actions[0] if decision.required_actions else "none",
+        )
+
+    if decision.serve_mode == "blocked":
+        return ResultInterfaceView(
+            flow_name=decision.flow_name,
+            display_state="blocked",
+            headline="Manual resolution required",
+            detail=decision.message,
+            badges=decision.badges,
+            content_visible=False,
+            metadata_visible=True,
+            next_action=decision.required_actions[0] if decision.required_actions else "none",
+        )
+
+    if decision.serve_mode == "serve_with_annotation":
+        return ResultInterfaceView(
+            flow_name=decision.flow_name,
+            display_state="annotated",
+            headline="Serving with annotation",
+            detail=decision.message,
+            badges=decision.badges,
+            content_visible=True,
+            metadata_visible=True,
+            next_action=decision.required_actions[0] if decision.required_actions else "none",
+        )
+
+    return ResultInterfaceView(
+        flow_name=decision.flow_name,
+        display_state="visible",
+        headline="Serving normally",
+        detail=decision.message,
+        badges=decision.badges,
+        content_visible=decision.include_content,
+        metadata_visible=decision.include_metadata,
+        next_action=decision.required_actions[0] if decision.required_actions else "none",
+    )
+
+
+def interfaces_from_serving_matrix(serving_matrix: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    views: dict[str, dict[str, Any]] = {}
+    for flow_name, payload in serving_matrix.items():
+        decision = ResultServingDecision(
+            flow_name=flow_name,
+            serve_mode=payload["serve_mode"],
+            include_content=bool(payload["include_content"]),
+            include_metadata=bool(payload["include_metadata"]),
+            badges=list(payload["badges"]),
+            required_actions=list(payload["required_actions"]),
+            message=payload["message"],
+        )
+        views[flow_name] = interface_from_serving_decision(decision).to_dict()
+    return views

--- a/tools/fabric/result_interface_selftest.py
+++ b/tools/fabric/result_interface_selftest.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+from .cli import cmd_show_result_interface
+from .planner_surface import planner_outcome_from_runtime_surface
+from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
+from .result_interface import interface_from_serving_decision, interfaces_from_serving_matrix
+from .result_plan import serving_decision_from_planner_outcome, serving_decisions_from_planner_matrix
+from .result_surface import outcome_from_flow_result, outcomes_from_reconcile_matrix
+from .reconcile_matrix_harness import run_reconcile_matrix
+from .stale_mirror_flow_harness import run_stale_mirror_flow
+
+
+class ResultInterfaceSmokeTest(unittest.TestCase):
+    def test_direct_result_interface_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stale = run_stale_mirror_flow(
+                Path(tmpdir) / "stale",
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                authority_mode="local_first",
+            )
+            tombstone = run_tombstone_propagation_flow(
+                Path(tmpdir) / "tombstone",
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+            )
+            authority = run_authority_transition_flow(
+                Path(tmpdir) / "authority",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            )
+
+            stale_interface = interface_from_serving_decision(
+                serving_decision_from_planner_outcome(
+                    planner_outcome_from_runtime_surface(outcome_from_flow_result("stale_mirror", stale))
+                )
+            )
+            tombstone_interface = interface_from_serving_decision(
+                serving_decision_from_planner_outcome(
+                    planner_outcome_from_runtime_surface(outcome_from_flow_result("tombstone", tombstone))
+                )
+            )
+            authority_interface = interface_from_serving_decision(
+                serving_decision_from_planner_outcome(
+                    planner_outcome_from_runtime_surface(outcome_from_flow_result("authority_transition", authority))
+                )
+            )
+
+            self.assertEqual(stale_interface.display_state, "metadata_only")
+            self.assertFalse(stale_interface.content_visible)
+            self.assertEqual(tombstone_interface.display_state, "hidden")
+            self.assertFalse(tombstone_interface.metadata_visible)
+            self.assertEqual(authority_interface.display_state, "pending_refresh")
+
+    def test_matrix_interface_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            matrix = run_reconcile_matrix(Path(tmpdir))
+            interfaces = interfaces_from_serving_matrix(
+                serving_decisions_from_planner_matrix(
+                    {
+                        name: {
+                            "flow_name": name,
+                            "planner_mode": planner_outcome_from_runtime_surface(
+                                outcome_from_flow_result(name, matrix[name]) if name != "authority_transition" else outcome_from_flow_result(name, matrix[name])
+                            ).planner_mode,
+                            "badge": planner_outcome_from_runtime_surface(
+                                outcome_from_flow_result(name, matrix[name]) if name != "authority_transition" else outcome_from_flow_result(name, matrix[name])
+                            ).badge,
+                            "freshness_hint": planner_outcome_from_runtime_surface(
+                                outcome_from_flow_result(name, matrix[name]) if name != "authority_transition" else outcome_from_flow_result(name, matrix[name])
+                            ).freshness_hint,
+                            "authority_hint": planner_outcome_from_runtime_surface(
+                                outcome_from_flow_result(name, matrix[name]) if name != "authority_transition" else outcome_from_flow_result(name, matrix[name])
+                            ).authority_hint,
+                            "operator_action": planner_outcome_from_runtime_surface(
+                                outcome_from_flow_result(name, matrix[name]) if name != "authority_transition" else outcome_from_flow_result(name, matrix[name])
+                            ).operator_action,
+                            "message": planner_outcome_from_runtime_surface(
+                                outcome_from_flow_result(name, matrix[name]) if name != "authority_transition" else outcome_from_flow_result(name, matrix[name])
+                            ).message,
+                        }
+                        for name in ["tombstone", "stale_mirror", "authority_transition"]
+                    }
+                )
+            )
+            self.assertEqual(interfaces["tombstone"]["display_state"], "hidden")
+            self.assertEqual(interfaces["stale_mirror"]["display_state"], "metadata_only")
+            self.assertEqual(interfaces["authority_transition"]["display_state"], "pending_refresh")
+
+    def test_cli_show_result_interface(self) -> None:
+        cases = [
+            argparse.Namespace(
+                kind="stale_mirror",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                signed_tombstone=False,
+                local_dirty=False,
+                authority_mode="local_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=False,
+            ),
+            argparse.Namespace(
+                kind="tombstone",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=False,
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=False,
+            ),
+            argparse.Namespace(
+                kind="authority_transition",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=False,
+                signed_tombstone=False,
+                local_dirty=False,
+                authority_mode="local_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            ),
+            argparse.Namespace(
+                kind="reconcile_matrix",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for idx, ns in enumerate(cases):
+                ns.root = str(Path(tmpdir) / f"case-{idx}")
+                rc = cmd_show_result_interface(ns)
+                self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/fabric/result_render.py
+++ b/tools/fabric/result_render.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from .result_interface import ResultInterfaceView
+
+
+@dataclass(frozen=True)
+class RenderBlock:
+    flow_name: str
+    variant: str
+    status_tone: str
+    headline: str
+    subheadline: str
+    body_lines: list[str]
+    badges: list[str]
+    affordances: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def render_block_from_interface(view: ResultInterfaceView) -> RenderBlock:
+    if view.display_state == "hidden":
+        return RenderBlock(
+            flow_name=view.flow_name,
+            variant="banner",
+            status_tone="critical",
+            headline=view.headline,
+            subheadline="Result is hidden from the surface.",
+            body_lines=[view.detail],
+            badges=view.badges,
+            affordances=[view.next_action],
+        )
+
+    if view.display_state == "metadata_only":
+        return RenderBlock(
+            flow_name=view.flow_name,
+            variant="card",
+            status_tone="warning",
+            headline=view.headline,
+            subheadline="Only metadata is available.",
+            body_lines=[view.detail],
+            badges=view.badges,
+            affordances=[view.next_action],
+        )
+
+    if view.display_state == "pending_refresh":
+        return RenderBlock(
+            flow_name=view.flow_name,
+            variant="card",
+            status_tone="info",
+            headline=view.headline,
+            subheadline="Serving is deferred until refresh.",
+            body_lines=[view.detail],
+            badges=view.badges,
+            affordances=[view.next_action],
+        )
+
+    if view.display_state == "blocked":
+        return RenderBlock(
+            flow_name=view.flow_name,
+            variant="banner",
+            status_tone="critical",
+            headline=view.headline,
+            subheadline="Manual resolution is required.",
+            body_lines=[view.detail],
+            badges=view.badges,
+            affordances=[view.next_action],
+        )
+
+    if view.display_state == "annotated":
+        return RenderBlock(
+            flow_name=view.flow_name,
+            variant="card",
+            status_tone="warning",
+            headline=view.headline,
+            subheadline="Serving with visible annotations.",
+            body_lines=[view.detail],
+            badges=view.badges,
+            affordances=[view.next_action],
+        )
+
+    return RenderBlock(
+        flow_name=view.flow_name,
+        variant="card",
+        status_tone="normal",
+        headline=view.headline,
+        subheadline="Serving normally.",
+        body_lines=[view.detail],
+        badges=view.badges,
+        affordances=[view.next_action],
+    )
+
+
+def render_blocks_from_interface_matrix(interface_matrix: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    blocks: dict[str, dict[str, Any]] = {}
+    for flow_name, payload in interface_matrix.items():
+        view = ResultInterfaceView(
+            flow_name=flow_name,
+            display_state=payload["display_state"],
+            headline=payload["headline"],
+            detail=payload["detail"],
+            badges=list(payload["badges"]),
+            content_visible=bool(payload["content_visible"]),
+            metadata_visible=bool(payload["metadata_visible"]),
+            next_action=payload["next_action"],
+        )
+        blocks[flow_name] = render_block_from_interface(view).to_dict()
+    return blocks

--- a/tools/fabric/result_render_selftest.py
+++ b/tools/fabric/result_render_selftest.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+from .cli import cmd_show_result_render
+from .planner_surface import planner_outcome_from_runtime_surface
+from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
+from .result_interface import interface_from_serving_decision, interfaces_from_serving_matrix
+from .result_plan import serving_decision_from_planner_outcome, serving_decisions_from_planner_matrix
+from .result_render import render_block_from_interface, render_blocks_from_interface_matrix
+from .result_surface import outcome_from_flow_result, outcomes_from_reconcile_matrix
+from .reconcile_matrix_harness import run_reconcile_matrix
+from .stale_mirror_flow_harness import run_stale_mirror_flow
+
+
+class ResultRenderSmokeTest(unittest.TestCase):
+    def test_direct_result_render_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stale = run_stale_mirror_flow(
+                Path(tmpdir) / "stale",
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                authority_mode="local_first",
+            )
+            tombstone = run_tombstone_propagation_flow(
+                Path(tmpdir) / "tombstone",
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+            )
+            authority = run_authority_transition_flow(
+                Path(tmpdir) / "authority",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            )
+
+            stale_render = render_block_from_interface(
+                interface_from_serving_decision(
+                    serving_decision_from_planner_outcome(
+                        planner_outcome_from_runtime_surface(outcome_from_flow_result("stale_mirror", stale))
+                    )
+                )
+            )
+            tombstone_render = render_block_from_interface(
+                interface_from_serving_decision(
+                    serving_decision_from_planner_outcome(
+                        planner_outcome_from_runtime_surface(outcome_from_flow_result("tombstone", tombstone))
+                    )
+                )
+            )
+            authority_render = render_block_from_interface(
+                interface_from_serving_decision(
+                    serving_decision_from_planner_outcome(
+                        planner_outcome_from_runtime_surface(outcome_from_flow_result("authority_transition", authority))
+                    )
+                )
+            )
+
+            self.assertEqual(stale_render.variant, "card")
+            self.assertEqual(stale_render.status_tone, "warning")
+            self.assertEqual(tombstone_render.variant, "banner")
+            self.assertEqual(tombstone_render.status_tone, "critical")
+            self.assertEqual(authority_render.status_tone, "info")
+
+    def test_matrix_result_render_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            matrix = run_reconcile_matrix(Path(tmpdir))
+            renders = render_blocks_from_interface_matrix(
+                interfaces_from_serving_matrix(
+                    serving_decisions_from_planner_matrix(
+                        {
+                            name: serving_decision_from_planner_outcome(
+                                planner_outcome_from_runtime_surface(outcome_from_flow_result(name, matrix[name]))
+                            ).to_dict()
+                            for name in ["tombstone", "stale_mirror", "authority_transition"]
+                        }
+                    )
+                )
+            )
+            self.assertEqual(renders["stale_mirror"]["status_tone"], "warning")
+            self.assertEqual(renders["tombstone"]["status_tone"], "critical")
+            self.assertEqual(renders["authority_transition"]["status_tone"], "info")
+
+    def test_cli_show_result_render(self) -> None:
+        cases = [
+            argparse.Namespace(
+                kind="stale_mirror",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                signed_tombstone=False,
+                local_dirty=False,
+                authority_mode="local_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=False,
+            ),
+            argparse.Namespace(
+                kind="tombstone",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=False,
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=False,
+            ),
+            argparse.Namespace(
+                kind="authority_transition",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=False,
+                signed_tombstone=False,
+                local_dirty=False,
+                authority_mode="local_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            ),
+            argparse.Namespace(
+                kind="reconcile_matrix",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for idx, ns in enumerate(cases):
+                ns.root = str(Path(tmpdir) / f"case-{idx}")
+                rc = cmd_show_result_render(ns)
+                self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a result interface mapper and smoke coverage on top of the current serving-test branch.