### PR TITLE
Draft: add fabric result view layer

### DIFF
--- a/tools/fabric/result_view.py
+++ b/tools/fabric/result_view.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from .result_render import RenderBlock
+
+
+@dataclass(frozen=True)
+class ResultViewModel:
+    flow_name: str
+    container: str
+    emphasis: str
+    title: str
+    subtitle: str
+    body: list[str]
+    chips: list[str]
+    primary_action: str
+    show_content: bool
+    show_metadata: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def view_from_render_block(block: RenderBlock) -> ResultViewModel:
+    if block.variant == "banner":
+        return ResultViewModel(
+            flow_name=block.flow_name,
+            container="alert_strip",
+            emphasis=block.status_tone,
+            title=block.headline,
+            subtitle=block.subheadline,
+            body=block.body_lines,
+            chips=block.badges,
+            primary_action=block.affordances[0] if block.affordances else "none",
+            show_content=False,
+            show_metadata=False,
+        )
+
+    if block.status_tone == "warning":
+        return ResultViewModel(
+            flow_name=block.flow_name,
+            container="detail_card",
+            emphasis="warning",
+            title=block.headline,
+            subtitle=block.subheadline,
+            body=block.body_lines,
+            chips=block.badges,
+            primary_action=block.affordances[0] if block.affordances else "none",
+            show_content=False,
+            show_metadata=True,
+        )
+
+    if block.status_tone == "info":
+        return ResultViewModel(
+            flow_name=block.flow_name,
+            container="detail_card",
+            emphasis="info",
+            title=block.headline,
+            subtitle=block.subheadline,
+            body=block.body_lines,
+            chips=block.badges,
+            primary_action=block.affordances[0] if block.affordances else "none",
+            show_content=False,
+            show_metadata=True,
+        )
+
+    return ResultViewModel(
+        flow_name=block.flow_name,
+        container="detail_card",
+        emphasis="normal",
+        title=block.headline,
+        subtitle=block.subheadline,
+        body=block.body_lines,
+        chips=block.badges,
+        primary_action=block.affordances[0] if block.affordances else "none",
+        show_content=True,
+        show_metadata=True,
+    )
+
+
+def views_from_render_matrix(render_matrix: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    views: dict[str, dict[str, Any]] = {}
+    for flow_name, payload in render_matrix.items():
+        block = RenderBlock(
+            flow_name=flow_name,
+            variant=payload["variant"],
+            status_tone=payload["status_tone"],
+            headline=payload["headline"],
+            subheadline=payload["subheadline"],
+            body_lines=list(payload["body_lines"]),
+            badges=list(payload["badges"]),
+            affordances=list(payload["affordances"]),
+        )
+        views[flow_name] = view_from_render_block(block).to_dict()
+    return views

--- a/tools/fabric/result_view_selftest.py
+++ b/tools/fabric/result_view_selftest.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .planner_surface import planner_outcome_from_runtime_surface, planner_outcomes_from_runtime_surface_matrix
+from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
+from .reconcile_matrix_harness import run_reconcile_matrix
+from .result_interface import interface_from_serving_decision, interfaces_from_serving_matrix
+from .result_plan import serving_decision_from_planner_outcome, serving_decisions_from_planner_matrix
+from .result_render import render_block_from_interface, render_blocks_from_interface_matrix
+from .result_surface import outcome_from_flow_result, outcomes_from_reconcile_matrix
+from .result_view import view_from_render_block, views_from_render_matrix
+from .stale_mirror_flow_harness import run_stale_mirror_flow
+
+
+class ResultViewSmokeTest(unittest.TestCase):
+    def test_direct_result_view_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stale = run_stale_mirror_flow(
+                Path(tmpdir) / "stale",
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                authority_mode="local_first",
+            )
+            tombstone = run_tombstone_propagation_flow(
+                Path(tmpdir) / "tombstone",
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+            )
+            authority = run_authority_transition_flow(
+                Path(tmpdir) / "authority",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            )
+
+            stale_view = view_from_render_block(
+                render_block_from_interface(
+                    interface_from_serving_decision(
+                        serving_decision_from_planner_outcome(
+                            planner_outcome_from_runtime_surface(outcome_from_flow_result("stale_mirror", stale))
+                        )
+                    )
+                )
+            )
+            tombstone_view = view_from_render_block(
+                render_block_from_interface(
+                    interface_from_serving_decision(
+                        serving_decision_from_planner_outcome(
+                            planner_outcome_from_runtime_surface(outcome_from_flow_result("tombstone", tombstone))
+                        )
+                    )
+                )
+            )
+            authority_view = view_from_render_block(
+                render_block_from_interface(
+                    interface_from_serving_decision(
+                        serving_decision_from_planner_outcome(
+                            planner_outcome_from_runtime_surface(outcome_from_flow_result("authority_transition", authority))
+                        )
+                    )
+                )
+            )
+
+            self.assertEqual(stale_view.container, "detail_card")
+            self.assertFalse(stale_view.show_content)
+            self.assertEqual(tombstone_view.container, "alert_strip")
+            self.assertFalse(tombstone_view.show_metadata)
+            self.assertEqual(authority_view.emphasis, "info")
+
+    def test_matrix_result_view_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            matrix = run_reconcile_matrix(Path(tmpdir))
+            views = views_from_render_matrix(
+                render_blocks_from_interface_matrix(
+                    interfaces_from_serving_matrix(
+                        serving_decisions_from_planner_matrix(
+                            {
+                                name: serving_decision_from_planner_outcome(
+                                    planner_outcome_from_runtime_surface(outcome_from_flow_result(name, matrix[name]))
+                                ).to_dict()
+                                for name in ["tombstone", "stale_mirror", "authority_transition"]
+                            }
+                        )
+                    )
+                )
+            )
+            self.assertEqual(views["stale_mirror"]["container"], "detail_card")
+            self.assertEqual(views["tombstone"]["container"], "alert_strip")
+            self.assertEqual(views["authority_transition"]["emphasis"], "info")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a thin result-view adapter plus focused smoke coverage on top of the current result-render branch.