### PR TITLE
Draft: expose fabric result previews through CLI

### DIFF
--- a/tools/fabric/result_preview_cli.py
+++ b/tools/fabric/result_preview_cli.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .planner_surface import planner_outcome_from_runtime_surface, planner_outcomes_from_runtime_surface_matrix
+from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
+from .reconcile_matrix_harness import run_reconcile_matrix
+from .result_card import card_from_view, cards_from_view_matrix
+from .result_interface import interface_from_serving_decision, interfaces_from_serving_matrix
+from .result_plan import serving_decision_from_planner_outcome, serving_decisions_from_planner_matrix
+from .result_preview import preview_from_card, previews_from_card_matrix
+from .result_render import render_block_from_interface, render_blocks_from_interface_matrix
+from .result_surface import outcome_from_flow_result, outcomes_from_reconcile_matrix
+from .result_view import view_from_render_block, views_from_render_matrix
+from .stale_mirror_flow_harness import run_stale_mirror_flow
+
+
+def cmd_show_result_preview(args: argparse.Namespace) -> int:
+    root = Path(args.root)
+    if args.kind == "stale_mirror":
+        flow = run_stale_mirror_flow(
+            root,
+            stale_generation_gap=args.stale_generation_gap,
+            policy_allow_stale=args.policy_allow_stale,
+            authority_mode=args.authority_mode,
+        )
+        surface = outcome_from_flow_result("stale_mirror", flow)
+        planner = planner_outcome_from_runtime_surface(surface)
+        decision = serving_decision_from_planner_outcome(planner)
+        interface = interface_from_serving_decision(decision)
+        block = render_block_from_interface(interface)
+        view = view_from_render_block(block)
+        card = card_from_view(view)
+        print(json.dumps(preview_from_card(card).to_dict(), indent=2))
+        return 0
+    if args.kind == "tombstone":
+        flow = run_tombstone_propagation_flow(
+            root,
+            signed_tombstone=args.signed_tombstone,
+            local_dirty=args.local_dirty,
+            authority_mode=args.authority_mode,
+        )
+        surface = outcome_from_flow_result("tombstone", flow)
+        planner = planner_outcome_from_runtime_surface(surface)
+        decision = serving_decision_from_planner_outcome(planner)
+        interface = interface_from_serving_decision(decision)
+        block = render_block_from_interface(interface)
+        view = view_from_render_block(block)
+        card = card_from_view(view)
+        print(json.dumps(preview_from_card(card).to_dict(), indent=2))
+        return 0
+    if args.kind == "authority_transition":
+        flow = run_authority_transition_flow(
+            root,
+            current_authority=args.current_authority,
+            requested_authority=args.requested_authority,
+            quorum_granted=args.quorum_granted,
+        )
+        surface = outcome_from_flow_result("authority_transition", flow)
+        planner = planner_outcome_from_runtime_surface(surface)
+        decision = serving_decision_from_planner_outcome(planner)
+        interface = interface_from_serving_decision(decision)
+        block = render_block_from_interface(interface)
+        view = view_from_render_block(block)
+        card = card_from_view(view)
+        print(json.dumps(preview_from_card(card).to_dict(), indent=2))
+        return 0
+    if args.kind == "reconcile_matrix":
+        matrix = run_reconcile_matrix(root)
+        surfaces = outcomes_from_reconcile_matrix(matrix)
+        planners = planner_outcomes_from_runtime_surface_matrix(surfaces)
+        decisions = serving_decisions_from_planner_matrix(planners)
+        interfaces = interfaces_from_serving_matrix(decisions)
+        blocks = render_blocks_from_interface_matrix(interfaces)
+        views = views_from_render_matrix(blocks)
+        cards = cards_from_view_matrix(views)
+        print(json.dumps(previews_from_card_matrix(cards), indent=2))
+        return 0
+    print(json.dumps({"error": f"unknown result preview kind {args.kind!r}"}))
+    return 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="fabric-preview")
+    parser.add_argument("kind", choices=["stale_mirror", "tombstone", "authority_transition", "reconcile_matrix"])
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--stale-generation-gap", type=int, default=3)
+    parser.add_argument("--policy-allow-stale", action="store_true")
+    parser.add_argument("--signed-tombstone", action="store_true")
+    parser.add_argument("--local-dirty", action="store_true")
+    parser.add_argument("--authority-mode", default="local_first", choices=["local_first", "provider_first", "hybrid"])
+    parser.add_argument("--current-authority", default="local")
+    parser.add_argument("--requested-authority", default="remote")
+    parser.add_argument("--quorum-granted", action="store_true")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return cmd_show_result_preview(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/fabric/result_preview_cli_selftest.py
+++ b/tools/fabric/result_preview_cli_selftest.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+from .result_preview_cli import cmd_show_result_preview
+
+
+class ResultPreviewCliSmokeTest(unittest.TestCase):
+    def test_show_result_preview(self) -> None:
+        cases = [
+            argparse.Namespace(
+                kind="stale_mirror",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                signed_tombstone=False,
+                local_dirty=False,
+                authority_mode="local_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=False,
+            ),
+            argparse.Namespace(
+                kind="tombstone",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=False,
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=False,
+            ),
+            argparse.Namespace(
+                kind="authority_transition",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=False,
+                signed_tombstone=False,
+                local_dirty=False,
+                authority_mode="local_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            ),
+            argparse.Namespace(
+                kind="reconcile_matrix",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for idx, ns in enumerate(cases):
+                ns.root = str(Path(tmpdir) / f"case-{idx}")
+                rc = cmd_show_result_preview(ns)
+                self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a dedicated CLI entrypoint plus smoke coverage on top of the current result preview layer.