### PR TITLE
Draft: add fabric result HTML consumer

### DIFF
--- a/tools/fabric/result_html.py
+++ b/tools/fabric/result_html.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from html import escape
+
+from .result_preview import ResultPreview
+
+
+def html_from_preview(preview: ResultPreview) -> str:
+    classes = [
+        "result-preview",
+        preview.layout,
+        f"tone-{preview.visual_tone}",
+        f"visibility-{preview.visibility}",
+    ]
+    chips = "".join(
+        f'<li class="chip">{escape(chip)}</li>' for chip in preview.chips
+    )
+    lines = "".join(
+        f'<li class="summary-line">{escape(line)}</li>' for line in preview.summary_lines
+    )
+    action = escape(preview.action_label)
+    return (
+        f'<article class="{" ".join(classes)}" data-flow="{escape(preview.flow_name)}">'
+        f'<header><h2>{escape(preview.title)}</h2><p>{escape(preview.subtitle)}</p></header>'
+        f'<ul class="summary">{lines}</ul>'
+        f'<ul class="chips">{chips}</ul>'
+        f'<footer><button>{action}</button></footer>'
+        '</article>'
+    )
+
+
+
+def html_from_preview_matrix(preview_matrix: dict[str, dict[str, object]]) -> str:
+    items: list[str] = []
+    for flow_name, payload in preview_matrix.items():
+        preview = ResultPreview(
+            flow_name=flow_name,
+            layout=str(payload["layout"]),
+            title=str(payload["title"]),
+            subtitle=str(payload["subtitle"]),
+            summary_lines=list(payload["summary_lines"]),
+            chips=list(payload["chips"]),
+            action_label=str(payload["action_label"]),
+            visual_tone=str(payload["visual_tone"]),
+            visibility=str(payload["visibility"]),
+        )
+        items.append(html_from_preview(preview))
+    return '<section class="result-preview-grid">' + "".join(items) + '</section>'

--- a/tools/fabric/result_html_cli.py
+++ b/tools/fabric/result_html_cli.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .planner_surface import planner_outcome_from_runtime_surface, planner_outcomes_from_runtime_surface_matrix
+from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
+from .reconcile_matrix_harness import run_reconcile_matrix
+from .result_card import card_from_view, cards_from_view_matrix
+from .result_html import html_from_preview, html_from_preview_matrix
+from .result_interface import interface_from_serving_decision, interfaces_from_serving_matrix
+from .result_plan import serving_decision_from_planner_outcome, serving_decisions_from_planner_matrix
+from .result_preview import preview_from_card, previews_from_card_matrix
+from .result_render import render_block_from_interface, render_blocks_from_interface_matrix
+from .result_surface import outcome_from_flow_result, outcomes_from_reconcile_matrix
+from .result_view import view_from_render_block, views_from_render_matrix
+from .stale_mirror_flow_harness import run_stale_mirror_flow
+
+
+def cmd_show_result_html(args: argparse.Namespace) -> int:
+    root = Path(args.root)
+    if args.kind == "stale_mirror":
+        flow = run_stale_mirror_flow(
+            root,
+            stale_generation_gap=args.stale_generation_gap,
+            policy_allow_stale=args.policy_allow_stale,
+            authority_mode=args.authority_mode,
+        )
+        preview = preview_from_card(
+            card_from_view(
+                view_from_render_block(
+                    render_block_from_interface(
+                        interface_from_serving_decision(
+                            serving_decision_from_planner_outcome(
+                                planner_outcome_from_runtime_surface(outcome_from_flow_result("stale_mirror", flow))
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        print(html_from_preview(preview))
+        return 0
+    if args.kind == "tombstone":
+        flow = run_tombstone_propagation_flow(
+            root,
+            signed_tombstone=args.signed_tombstone,
+            local_dirty=args.local_dirty,
+            authority_mode=args.authority_mode,
+        )
+        preview = preview_from_card(
+            card_from_view(
+                view_from_render_block(
+                    render_block_from_interface(
+                        interface_from_serving_decision(
+                            serving_decision_from_planner_outcome(
+                                planner_outcome_from_runtime_surface(outcome_from_flow_result("tombstone", flow))
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        print(html_from_preview(preview))
+        return 0
+    if args.kind == "authority_transition":
+        flow = run_authority_transition_flow(
+            root,
+            current_authority=args.current_authority,
+            requested_authority=args.requested_authority,
+            quorum_granted=args.quorum_granted,
+        )
+        preview = preview_from_card(
+            card_from_view(
+                view_from_render_block(
+                    render_block_from_interface(
+                        interface_from_serving_decision(
+                            serving_decision_from_planner_outcome(
+                                planner_outcome_from_runtime_surface(outcome_from_flow_result("authority_transition", flow))
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        print(html_from_preview(preview))
+        return 0
+    if args.kind == "reconcile_matrix":
+        matrix = run_reconcile_matrix(root)
+        surfaces = outcomes_from_reconcile_matrix(matrix)
+        planners = planner_outcomes_from_runtime_surface_matrix(surfaces)
+        decisions = serving_decisions_from_planner_matrix(planners)
+        interfaces = interfaces_from_serving_matrix(decisions)
+        renders = render_blocks_from_interface_matrix(interfaces)
+        views = views_from_render_matrix(renders)
+        cards = cards_from_view_matrix(views)
+        previews = previews_from_card_matrix(cards)
+        print(html_from_preview_matrix(previews))
+        return 0
+    return 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="fabric-html")
+    parser.add_argument("kind", choices=["stale_mirror", "tombstone", "authority_transition", "reconcile_matrix"])
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--stale-generation-gap", type=int, default=3)
+    parser.add_argument("--policy-allow-stale", action="store_true")
+    parser.add_argument("--signed-tombstone", action="store_true")
+    parser.add_argument("--local-dirty", action="store_true")
+    parser.add_argument("--authority-mode", default="local_first", choices=["local_first", "provider_first", "hybrid"])
+    parser.add_argument("--current-authority", default="local")
+    parser.add_argument("--requested-authority", default="remote")
+    parser.add_argument("--quorum-granted", action="store_true")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return cmd_show_result_html(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/fabric/result_html_selftest.py
+++ b/tools/fabric/result_html_selftest.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+from .planner_surface import planner_outcome_from_runtime_surface, planner_outcomes_from_runtime_surface_matrix
+from .reconcile_flow_harness import run_authority_transition_flow, run_tombstone_propagation_flow
+from .reconcile_matrix_harness import run_reconcile_matrix
+from .result_card import card_from_view, cards_from_view_matrix
+from .result_html import html_from_preview, html_from_preview_matrix
+from .result_html_cli import cmd_show_result_html
+from .result_interface import interface_from_serving_decision, interfaces_from_serving_matrix
+from .result_plan import serving_decision_from_planner_outcome, serving_decisions_from_planner_matrix
+from .result_preview import preview_from_card, previews_from_card_matrix
+from .result_render import render_block_from_interface, render_blocks_from_interface_matrix
+from .result_surface import outcome_from_flow_result, outcomes_from_reconcile_matrix
+from .result_view import view_from_render_block, views_from_render_matrix
+from .stale_mirror_flow_harness import run_stale_mirror_flow
+
+
+class ResultHtmlSmokeTest(unittest.TestCase):
+    def test_direct_result_html_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stale = run_stale_mirror_flow(
+                Path(tmpdir) / "stale",
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                authority_mode="local_first",
+            )
+            tombstone = run_tombstone_propagation_flow(
+                Path(tmpdir) / "tombstone",
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+            )
+            authority = run_authority_transition_flow(
+                Path(tmpdir) / "authority",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            )
+
+            def build_html(flow_name: str, flow: dict) -> str:
+                preview = preview_from_card(
+                    card_from_view(
+                        view_from_render_block(
+                            render_block_from_interface(
+                                interface_from_serving_decision(
+                                    serving_decision_from_planner_outcome(
+                                        planner_outcome_from_runtime_surface(outcome_from_flow_result(flow_name, flow))
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+                return html_from_preview(preview)
+
+            stale_html = build_html("stale_mirror", stale)
+            tombstone_html = build_html("tombstone", tombstone)
+            authority_html = build_html("authority_transition", authority)
+
+            self.assertIn("metadata_panel", stale_html)
+            self.assertIn("visibility-metadata_only", stale_html)
+            self.assertIn("inline_alert", tombstone_html)
+            self.assertIn("visibility-hidden", tombstone_html)
+            self.assertIn("tone-info", authority_html)
+
+    def test_matrix_result_html_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            matrix = run_reconcile_matrix(Path(tmpdir))
+            previews = previews_from_card_matrix(
+                cards_from_view_matrix(
+                    views_from_render_matrix(
+                        render_blocks_from_interface_matrix(
+                            interfaces_from_serving_matrix(
+                                serving_decisions_from_planner_matrix(
+                                    {
+                                        name: serving_decision_from_planner_outcome(
+                                            planner_outcome_from_runtime_surface(outcome_from_flow_result(name, matrix[name]))
+                                        ).to_dict()
+                                        for name in ["tombstone", "stale_mirror", "authority_transition"]
+                                    }
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+            html = html_from_preview_matrix(previews)
+            self.assertIn("result-preview-grid", html)
+            self.assertIn("metadata_panel", html)
+            self.assertIn("inline_alert", html)
+
+    def test_cli_show_result_html(self) -> None:
+        cases = [
+            argparse.Namespace(
+                kind="stale_mirror",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                signed_tombstone=False,
+                local_dirty=False,
+                authority_mode="local_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=False,
+            ),
+            argparse.Namespace(
+                kind="tombstone",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=False,
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=False,
+            ),
+            argparse.Namespace(
+                kind="authority_transition",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=False,
+                signed_tombstone=False,
+                local_dirty=False,
+                authority_mode="local_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            ),
+            argparse.Namespace(
+                kind="reconcile_matrix",
+                root=None,
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for idx, ns in enumerate(cases):
+                ns.root = str(Path(tmpdir) / f"case-{idx}")
+                rc = cmd_show_result_html(ns)
+                self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a thin HTML consumer plus dedicated CLI entrypoint and focused smoke coverage on top of the current presentation cleanup branch.