### PR TITLE
Draft: add unified fabric output CLI

### DIFF
--- a/tools/fabric/result_output_cli.py
+++ b/tools/fabric/result_output_cli.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+
+from .result_html_cli import cmd_show_result_html
+from .result_page_cli import cmd_show_result_page
+from .result_preview_cli import cmd_show_result_preview
+
+
+_OUTPUT_MODES = {
+    "preview": cmd_show_result_preview,
+    "html": cmd_show_result_html,
+    "page": cmd_show_result_page,
+}
+
+
+def cmd_show_result_output(args: argparse.Namespace) -> int:
+    handler = _OUTPUT_MODES.get(args.output_mode)
+    if handler is None:
+        return 2
+    return handler(args)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="fabric-output")
+    parser.add_argument("output_mode", choices=sorted(_OUTPUT_MODES))
+    parser.add_argument("kind", choices=["stale_mirror", "tombstone", "authority_transition", "reconcile_matrix"])
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--title", default="Fabric Result Preview")
+    parser.add_argument("--stale-generation-gap", type=int, default=3)
+    parser.add_argument("--policy-allow-stale", action="store_true")
+    parser.add_argument("--signed-tombstone", action="store_true")
+    parser.add_argument("--local-dirty", action="store_true")
+    parser.add_argument("--authority-mode", default="local_first", choices=["local_first", "provider_first", "hybrid"])
+    parser.add_argument("--current-authority", default="local")
+    parser.add_argument("--requested-authority", default="remote")
+    parser.add_argument("--quorum-granted", action="store_true")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return cmd_show_result_output(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/fabric/result_output_cli_selftest.py
+++ b/tools/fabric/result_output_cli_selftest.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+from .result_output_cli import cmd_show_result_output
+
+
+class ResultOutputCliSmokeTest(unittest.TestCase):
+    def test_unified_output_cli(self) -> None:
+        cases = [
+            argparse.Namespace(
+                output_mode="preview",
+                kind="stale_mirror",
+                root=None,
+                title="Fabric Result Preview",
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                signed_tombstone=False,
+                local_dirty=False,
+                authority_mode="local_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=False,
+            ),
+            argparse.Namespace(
+                output_mode="html",
+                kind="tombstone",
+                root=None,
+                title="Fabric Result Preview",
+                stale_generation_gap=3,
+                policy_allow_stale=False,
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=False,
+            ),
+            argparse.Namespace(
+                output_mode="page",
+                kind="authority_transition",
+                root=None,
+                title="Fabric Result Preview",
+                stale_generation_gap=3,
+                policy_allow_stale=False,
+                signed_tombstone=False,
+                local_dirty=False,
+                authority_mode="local_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            ),
+            argparse.Namespace(
+                output_mode="page",
+                kind="reconcile_matrix",
+                root=None,
+                title="Fabric Result Preview",
+                stale_generation_gap=3,
+                policy_allow_stale=True,
+                signed_tombstone=True,
+                local_dirty=False,
+                authority_mode="provider_first",
+                current_authority="local",
+                requested_authority="remote",
+                quorum_granted=True,
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for idx, ns in enumerate(cases):
+                ns.root = str(Path(tmpdir) / f"case-{idx}")
+                rc = cmd_show_result_output(ns)
+                self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds one delegating CLI for preview, HTML, and page outputs plus focused smoke coverage on top of the current output cleanup branch.