### PR TITLE
protocol(workspace-fabric): add v0 mount registration slice

### DIFF
--- a/protocol/workspace-fabric/v0/ACCEPTANCE.md
+++ b/protocol/workspace-fabric/v0/ACCEPTANCE.md
@@ -1,0 +1,42 @@
+# Acceptance gates
+
+A conforming v0 implementation should satisfy the following checks.
+
+## Registration
+
+1. A local TopoLVM-backed mount can register as `local_first`.
+2. Dataset bindings are validated before activation.
+3. Index bindings are validated before activation.
+4. Adapter roles are validated before activation.
+5. A lease is issued only after policy and quorum checks complete.
+
+## Authority and reconcile
+
+6. Unsigned tombstones are rejected.
+7. Signed tombstones do not silently override local dirty state.
+8. Local dirty plus remote delete enters `RECONCILE_REQUIRED`.
+9. Stale mirrors under `local_first` degrade to metadata-only unless policy explicitly allows more.
+10. Authority transitions require quorum unless the requested authority is already current.
+
+## Adapter role safety
+
+11. Hyper-style feeds do not become mutable workspace authority by default.
+12. S3/MinIO roles default to snapshot/replica rather than mutable authority.
+13. Drive defaults to compatibility mirror rather than source of truth.
+14. rsync is treated as transport/bootstrap, not as an authority root.
+
+## Evidence
+
+15. Registration emits an evidence event.
+16. Lease issuance emits an evidence event.
+17. Authority transition requests emit an evidence event.
+18. Tombstone decisions emit an evidence event.
+19. Reconcile-required states emit an evidence event.
+
+## Minimum worked examples
+
+20. Local-first TopoLVM + Xapian index + Hyper topic registration.
+21. Provider-first remote authority with signed tombstone application.
+22. Local-first stale remote mirror with metadata-only result posture.
+23. Authority transition request that fails without quorum.
+24. Authority transition request that succeeds with quorum.

--- a/protocol/workspace-fabric/v0/ADAPTERS.md
+++ b/protocol/workspace-fabric/v0/ADAPTERS.md
@@ -1,0 +1,91 @@
+# Adapter role matrix
+
+## TopoLVM / local block-backed workspace
+
+Role: authoritative local persistence plane.
+
+Allowed authority:
+- yes, default
+- best fit for `local_first`
+
+Best use:
+- primary workspace mount
+- authoritative local dataset storage
+- authoritative local indexes
+
+## Hypercore / Dat-style append-only feed
+
+Role: topic distribution and append-only replay/snapshot dissemination.
+
+Allowed authority:
+- not default mutable workspace authority
+- acceptable for append-only event and topic surfaces when explicitly scoped
+
+Best use:
+- `topic_distribution`
+- replay streams
+- snapshot advertisements
+- evidence/event feeds
+
+## MinIO / S3
+
+Role: object snapshot replica, cold export, archive.
+
+Allowed authority:
+- only under explicit `provider_first` or approved hybrid policy
+
+Best use:
+- `object_snapshot_replica`
+- `cold_archive`
+- restore source for snapshots
+
+## rsync
+
+Role: bulk sync and bootstrap transport.
+
+Allowed authority:
+- no implicit authority
+- transport only
+
+Best use:
+- `bulk_sync`
+- migration/bootstrap
+- cold import/export
+
+## Google Drive API
+
+Role: compatibility mirror and collaboration ingress/egress.
+
+Allowed authority:
+- not by default
+- only if explicitly promoted and policy/quorum approved
+
+Best use:
+- `compatibility_mirror`
+- `collaboration_ingress`
+- controlled document interchange
+
+## Index engines
+
+### Xapian
+Role: lexical search index.
+Best fit: authoritative_local or derived_cache.
+
+### Tantivy
+Role: fast local search index.
+Best fit: derived_cache or authoritative_local under explicit policy.
+
+### SQLite FTS
+Role: embedded metadata/control-plane lookup.
+Best fit: lightweight local search and metadata indexing.
+
+## Default profile
+
+```yaml
+authority_mode: local_first
+require_signed_tombstones: true
+stale_mirror_policy: metadata_only
+remote_authority_promotion: quorum_required
+authoritative_remote_indexes: disabled_by_default
+preview_visibility_on_conflict: metadata_only
+```

--- a/protocol/workspace-fabric/v0/FIXTURE.md
+++ b/protocol/workspace-fabric/v0/FIXTURE.md
@@ -1,0 +1,136 @@
+# Fixture
+
+## Mount registration request
+
+```yaml
+api_version: sourceos.fabric.mount/v0.1
+kind: MountRegistrationRequest
+
+workspace:
+  cell: cell-alpha
+  id: ws-research
+  principal: operator.local
+
+mount:
+  id: topo-main
+  backend: topolvm
+  resolved_handle: /var/lib/sourceos/workspaces/ws-research
+  authority_mode: local_first
+  durability_class: local_persistent
+  replay_mode: append_only_evidence
+  visibility_default: private
+
+datasets:
+  - id: ds-notes
+    role: primary
+    indexes:
+      - id: idx-notes-xapian
+        engine: xapian
+        mode: authoritative_local
+      - id: idx-notes-vec
+        engine: tantivy
+        mode: derived_cache
+
+adapters:
+  - kind: hypercore
+    role: topic_distribution
+    topics: [notes.events, notes.snapshots]
+  - kind: s3
+    role: object_snapshot_replica
+    bucket: ws-research-snapshots
+  - kind: drive
+    role: compatibility_mirror
+    folder_id: drive-folder-123
+  - kind: rsync
+    role: bulk_sync
+    endpoint: rsync://backup/ws-research
+
+policy:
+  bundle: policy/default
+  quorum_profile: local-owner-plus-1
+  require_signed_tombstones: true
+  stale_mirror_policy: metadata_only
+
+lease_request:
+  ttl: 24h
+  renewable: true
+```
+
+## Lease response
+
+```yaml
+api_version: sourceos.fabric.mount/v0.1
+kind: MountRegistrationLease
+
+status: active
+
+lease:
+  id: lease-01JABCXYZ
+  issued_at: 2026-04-18T23:00:00Z
+  expires_at: 2026-04-19T23:00:00Z
+  renewable: true
+
+workspace:
+  cell: cell-alpha
+  id: ws-research
+
+mount:
+  id: topo-main
+  authority_mode: local_first
+  backend: topolvm
+  status: active
+
+approved:
+  datasets: [ds-notes]
+  indexes: [idx-notes-xapian, idx-notes-vec]
+  adapters:
+    - hypercore:topic_distribution
+    - s3:object_snapshot_replica
+    - drive:compatibility_mirror
+    - rsync:bulk_sync
+
+evidence:
+  stream: /cells/cell-alpha/evidence/mount-registration
+  correlation_id: reg-topo-main-20260418-001
+```
+
+## Evidence event envelope
+
+```yaml
+event_id: ev-01JABCXYZ
+event_type: mount.registration.proposed
+occurred_at: 2026-04-18T23:00:00Z
+
+actor_ref: operator.local
+workspace_ref: ws-research
+mount_ref: topo-main
+dataset_ref: ds-notes
+policy_bundle_ref: policy/default
+correlation_id: reg-topo-main-20260418-001
+
+payload:
+  authority_mode: local_first
+  backend: topolvm
+  adapters:
+    - hypercore:topic_distribution
+    - s3:object_snapshot_replica
+  status: proposed
+```
+
+## Error registry
+
+```text
+E_PATH_ESCAPE
+E_BACKEND_UNSUPPORTED
+E_AUTHORITY_MODE_INVALID
+E_QUORUM_REQUIRED
+E_POLICY_DENIED
+E_TOMBSTONE_UNSIGNED
+E_TOMBSTONE_CONFLICT_LOCAL_DIRTY
+E_INDEX_ROLE_CONFLICT
+E_STALE_MIRROR_BLOCKED
+E_LEASE_EXPIRED
+E_ADAPTER_ROLE_INVALID
+E_DATASET_BINDING_INVALID
+E_REPLAY_STREAM_MISSING
+```

--- a/protocol/workspace-fabric/v0/README.md
+++ b/protocol/workspace-fabric/v0/README.md
@@ -1,0 +1,86 @@
+# workspace-fabric v0
+
+Status: draft protocol surface.
+
+This slice defines the first governed contract for local-first workspace mounts in the fabric.
+It treats a workspace mount as a governed object rather than an untyped filesystem path.
+
+## Scope
+
+In scope for v0:
+- mount registration handshake
+- authority mode declaration
+- dataset and index binding
+- adapter role declaration
+- policy and quorum gating
+- lease issuance
+- evidence emission
+
+Out of scope for v0:
+- full sync protocol implementation
+- full UI implementation
+- cryptographic signature format details beyond required fields
+- billing or tenancy accounting
+
+## Core entities
+
+- **Cell**: namespace root
+- **Workspace**: operational boundary for a user or project
+- **Mount**: governed attachment to local or remote storage
+- **Dataset**: logical content domain
+- **Index**: authoritative or derived lookup structure
+- **Adapter**: bounded integration role such as topic distribution, object snapshot, or compatibility mirror
+- **Lease**: time-bounded registration authorization
+
+## Canonical namespace
+
+```text
+/cells/<cell>/workspaces/<workspace>/mounts/<mount>/
+/cells/<cell>/datasets/<dataset>/indexes/<index>/
+/cells/<cell>/topics/<topic>/
+/cells/<cell>/evidence/<stream>/
+```
+
+## Authority modes
+
+- `local_first`
+- `provider_first`
+- `hybrid`
+
+Default posture: `local_first`.
+
+## Lifecycle
+
+```text
+DISCOVERED
+  -> PROPOSED
+  -> POLICY_EVALUATING
+  -> QUORUM_EVALUATING
+  -> LEASE_ISSUED
+  -> ACTIVE
+  -> DEGRADED
+  -> RECONCILE_REQUIRED
+  -> REVOKED | TOMBSTONED
+```
+
+## Required protocol rules
+
+- unsigned tombstones are rejected
+- local dirty plus remote delete forces reconcile
+- stale remote mirrors under local-first degrade to metadata-only unless policy explicitly allows more
+- authority transitions require quorum unless the request is a no-op
+- index authority must be declared, not inferred from engine type
+
+## Proof-slice intent
+
+This protocol slice is the first implementation-facing target for:
+- local TopoLVM-backed mounts
+- Hyper-style topic replication
+- S3/MinIO snapshot replicas
+- rsync bootstrap/bulk sync
+- Google Drive compatibility mirrors
+
+See companion files:
+- `ACCEPTANCE.md`
+- `FIXTURE.md`
+- `ADAPTERS.md`


### PR DESCRIPTION
Adds the first governed workspace-fabric protocol surface under `protocol/workspace-fabric/v0/`.

Files:
- `README.md`
- `ACCEPTANCE.md`
- `FIXTURE.md`
- `ADAPTERS.md`

Scope:
- mount registration handshake
- authority mode declaration
- dataset/index binding
- adapter role matrix
- lease and evidence fixture surface

Intent:
Move the local-first workspace-storage stream into the repo as a compact, implementation-facing protocol slice rather than leaving it only in design discussion.