### PR TITLE
protocol(workspace-fabric): add schemas and fixture validation

### DIFF
--- a/protocol/workspace-fabric/v0/README.md
+++ b/protocol/workspace-fabric/v0/README.md
@@ -15,6 +15,8 @@ In scope for v0:
 - policy and quorum gating
 - lease issuance
 - evidence emission
+- machine-readable request, lease, and evidence schemas
+- lightweight fixture validation
 
 Out of scope for v0:
 - full sync protocol implementation
@@ -80,7 +82,23 @@ This protocol slice is the first implementation-facing target for:
 - rsync bootstrap/bulk sync
 - Google Drive compatibility mirrors
 
-See companion files:
+## Companion files
+
+Narrative and acceptance:
 - `ACCEPTANCE.md`
 - `FIXTURE.md`
 - `ADAPTERS.md`
+- `VALIDATION.md`
+
+Machine-readable schemas:
+- `mount-registration-request.schema.json`
+- `mount-registration-lease.schema.json`
+- `evidence-event.schema.json`
+
+Fixtures:
+- `fixtures/mount-registration-request.example.json`
+- `fixtures/mount-registration-lease.example.json`
+- `fixtures/evidence-event.example.json`
+
+Validation entrypoint:
+- `python3 tools/validate_workspace_fabric_fixtures.py`

--- a/protocol/workspace-fabric/v0/VALIDATION.md
+++ b/protocol/workspace-fabric/v0/VALIDATION.md
@@ -1,0 +1,15 @@
+# Workspace Fabric Validation
+
+Current lightweight validation path:
+
+```bash
+python3 tools/validate_workspace_fabric_fixtures.py
+```
+
+This check currently validates:
+- the request fixture top-level and nested required fields
+- the lease fixture top-level and nested required fields
+- the evidence-event fixture top-level required fields
+- workspace, mount, authority, dataset, and adapter consistency across fixtures
+
+It is intentionally minimal and dependency-free so the protocol slice can be checked in a bare workspace before a fuller schema-validation stack exists.

--- a/protocol/workspace-fabric/v0/evidence-event.schema.json
+++ b/protocol/workspace-fabric/v0/evidence-event.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/evidence-event.schema.json",
+  "title": "WorkspaceFabricEvidenceEvent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id",
+    "event_type",
+    "occurred_at",
+    "actor_ref",
+    "workspace_ref",
+    "mount_ref",
+    "dataset_ref",
+    "policy_bundle_ref",
+    "correlation_id",
+    "payload"
+  ],
+  "properties": {
+    "event_id": {"type": "string", "minLength": 1},
+    "event_type": {"type": "string", "minLength": 1},
+    "occurred_at": {"type": "string", "minLength": 1},
+    "actor_ref": {"type": "string", "minLength": 1},
+    "workspace_ref": {"type": "string", "minLength": 1},
+    "mount_ref": {"type": "string", "minLength": 1},
+    "dataset_ref": {"type": "string", "minLength": 1},
+    "policy_bundle_ref": {"type": "string", "minLength": 1},
+    "correlation_id": {"type": "string", "minLength": 1},
+    "payload": {"type": "object"}
+  }
+}

--- a/protocol/workspace-fabric/v0/fixtures/evidence-event.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/evidence-event.example.json
@@ -1,0 +1,20 @@
+{
+  "event_id": "ev-01JABCXYZ",
+  "event_type": "mount.registration.proposed",
+  "occurred_at": "2026-04-18T23:00:00Z",
+  "actor_ref": "operator.local",
+  "workspace_ref": "ws-research",
+  "mount_ref": "topo-main",
+  "dataset_ref": "ds-notes",
+  "policy_bundle_ref": "policy/default",
+  "correlation_id": "reg-topo-main-20260418-001",
+  "payload": {
+    "authority_mode": "local_first",
+    "backend": "topolvm",
+    "adapters": [
+      "hypercore:topic_distribution",
+      "s3:object_snapshot_replica"
+    ],
+    "status": "proposed"
+  }
+}

--- a/protocol/workspace-fabric/v0/fixtures/mount-registration-lease.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/mount-registration-lease.example.json
@@ -1,0 +1,35 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "MountRegistrationLease",
+  "status": "active",
+  "lease": {
+    "id": "lease-01JABCXYZ",
+    "issued_at": "2026-04-18T23:00:00Z",
+    "expires_at": "2026-04-19T23:00:00Z",
+    "renewable": true
+  },
+  "workspace": {
+    "cell": "cell-alpha",
+    "id": "ws-research"
+  },
+  "mount": {
+    "id": "topo-main",
+    "authority_mode": "local_first",
+    "backend": "topolvm",
+    "status": "active"
+  },
+  "approved": {
+    "datasets": ["ds-notes"],
+    "indexes": ["idx-notes-xapian", "idx-notes-vec"],
+    "adapters": [
+      "hypercore:topic_distribution",
+      "s3:object_snapshot_replica",
+      "drive:compatibility_mirror",
+      "rsync:bulk_sync"
+    ]
+  },
+  "evidence": {
+    "stream": "/cells/cell-alpha/evidence/mount-registration",
+    "correlation_id": "reg-topo-main-20260418-001"
+  }
+}

--- a/protocol/workspace-fabric/v0/fixtures/mount-registration-request.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/mount-registration-request.example.json
@@ -1,0 +1,68 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "MountRegistrationRequest",
+  "workspace": {
+    "cell": "cell-alpha",
+    "id": "ws-research",
+    "principal": "operator.local"
+  },
+  "mount": {
+    "id": "topo-main",
+    "backend": "topolvm",
+    "resolved_handle": "/var/lib/sourceos/workspaces/ws-research",
+    "authority_mode": "local_first",
+    "durability_class": "local_persistent",
+    "replay_mode": "append_only_evidence",
+    "visibility_default": "private"
+  },
+  "datasets": [
+    {
+      "id": "ds-notes",
+      "role": "primary",
+      "indexes": [
+        {
+          "id": "idx-notes-xapian",
+          "engine": "xapian",
+          "mode": "authoritative_local"
+        },
+        {
+          "id": "idx-notes-vec",
+          "engine": "tantivy",
+          "mode": "derived_cache"
+        }
+      ]
+    }
+  ],
+  "adapters": [
+    {
+      "kind": "hypercore",
+      "role": "topic_distribution",
+      "topics": ["notes.events", "notes.snapshots"]
+    },
+    {
+      "kind": "s3",
+      "role": "object_snapshot_replica",
+      "bucket": "ws-research-snapshots"
+    },
+    {
+      "kind": "drive",
+      "role": "compatibility_mirror",
+      "folder_id": "drive-folder-123"
+    },
+    {
+      "kind": "rsync",
+      "role": "bulk_sync",
+      "endpoint": "rsync://backup/ws-research"
+    }
+  ],
+  "policy": {
+    "bundle": "policy/default",
+    "quorum_profile": "local-owner-plus-1",
+    "require_signed_tombstones": true,
+    "stale_mirror_policy": "metadata_only"
+  },
+  "lease_request": {
+    "ttl": "24h",
+    "renewable": true
+  }
+}

--- a/protocol/workspace-fabric/v0/mount-registration-lease.schema.json
+++ b/protocol/workspace-fabric/v0/mount-registration-lease.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/mount-registration-lease.schema.json",
+  "title": "MountRegistrationLease",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "kind",
+    "status",
+    "lease",
+    "workspace",
+    "mount",
+    "approved",
+    "evidence"
+  ],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "MountRegistrationLease"},
+    "status": {"enum": ["active", "degraded", "revoked", "tombstoned"]},
+    "lease": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "issued_at", "expires_at", "renewable"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "issued_at": {"type": "string", "minLength": 1},
+        "expires_at": {"type": "string", "minLength": 1},
+        "renewable": {"type": "boolean"}
+      }
+    },
+    "workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cell", "id"],
+      "properties": {
+        "cell": {"type": "string", "minLength": 1},
+        "id": {"type": "string", "minLength": 1}
+      }
+    },
+    "mount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "authority_mode", "backend", "status"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "authority_mode": {"enum": ["local_first", "provider_first", "hybrid"]},
+        "backend": {"type": "string", "minLength": 1},
+        "status": {"type": "string", "minLength": 1}
+      }
+    },
+    "approved": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["datasets", "indexes", "adapters"],
+      "properties": {
+        "datasets": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "indexes": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "adapters": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stream", "correlation_id"],
+      "properties": {
+        "stream": {"type": "string", "minLength": 1},
+        "correlation_id": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/protocol/workspace-fabric/v0/mount-registration-request.schema.json
+++ b/protocol/workspace-fabric/v0/mount-registration-request.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/mount-registration-request.schema.json",
+  "title": "MountRegistrationRequest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "kind",
+    "workspace",
+    "mount",
+    "datasets",
+    "adapters",
+    "policy",
+    "lease_request"
+  ],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "MountRegistrationRequest"},
+    "workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cell", "id", "principal"],
+      "properties": {
+        "cell": {"type": "string", "minLength": 1},
+        "id": {"type": "string", "minLength": 1},
+        "principal": {"type": "string", "minLength": 1}
+      }
+    },
+    "mount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "backend",
+        "resolved_handle",
+        "authority_mode",
+        "durability_class",
+        "replay_mode",
+        "visibility_default"
+      ],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "backend": {"type": "string", "minLength": 1},
+        "resolved_handle": {"type": "string", "minLength": 1},
+        "authority_mode": {"enum": ["local_first", "provider_first", "hybrid"]},
+        "durability_class": {"type": "string", "minLength": 1},
+        "replay_mode": {"type": "string", "minLength": 1},
+        "visibility_default": {"type": "string", "minLength": 1}
+      }
+    },
+    "datasets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "role", "indexes"],
+        "properties": {
+          "id": {"type": "string", "minLength": 1},
+          "role": {"type": "string", "minLength": 1},
+          "indexes": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["id", "engine", "mode"],
+              "properties": {
+                "id": {"type": "string", "minLength": 1},
+                "engine": {"type": "string", "minLength": 1},
+                "mode": {
+                  "enum": [
+                    "authoritative_local",
+                    "authoritative_remote",
+                    "derived_cache",
+                    "ephemeral"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "adapters": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "role"],
+        "properties": {
+          "kind": {"type": "string", "minLength": 1},
+          "role": {
+            "enum": [
+              "topic_distribution",
+              "object_snapshot_replica",
+              "compatibility_mirror",
+              "bulk_sync",
+              "collaboration_ingress",
+              "cold_archive"
+            ]
+          },
+          "topics": {"type": "array", "items": {"type": "string", "minLength": 1}},
+          "bucket": {"type": "string"},
+          "folder_id": {"type": "string"},
+          "endpoint": {"type": "string"}
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bundle", "quorum_profile", "require_signed_tombstones", "stale_mirror_policy"],
+      "properties": {
+        "bundle": {"type": "string", "minLength": 1},
+        "quorum_profile": {"type": "string", "minLength": 1},
+        "require_signed_tombstones": {"type": "boolean"},
+        "stale_mirror_policy": {"type": "string", "minLength": 1}
+      }
+    },
+    "lease_request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ttl", "renewable"],
+      "properties": {
+        "ttl": {"type": "string", "minLength": 1},
+        "renewable": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/tools/validate_workspace_fabric_fixtures.py
+++ b/tools/validate_workspace_fabric_fixtures.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+WF = ROOT / "protocol" / "workspace-fabric" / "v0"
+FIX = WF / "fixtures"
+
+REQUEST = FIX / "mount-registration-request.example.json"
+LEASE = FIX / "mount-registration-lease.example.json"
+EVENT = FIX / "evidence-event.example.json"
+
+REQ_SCHEMA = WF / "mount-registration-request.schema.json"
+LEASE_SCHEMA = WF / "mount-registration-lease.schema.json"
+EVENT_SCHEMA = WF / "evidence-event.schema.json"
+
+
+def load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def require_keys(obj: dict, keys: list[str], label: str) -> None:
+    missing = [k for k in keys if k not in obj]
+    if missing:
+        raise SystemExit(f"{label} missing keys: {missing}")
+
+
+def main() -> int:
+    for path in [REQUEST, LEASE, EVENT, REQ_SCHEMA, LEASE_SCHEMA, EVENT_SCHEMA]:
+        if not path.exists():
+            raise SystemExit(f"missing required file: {path}")
+
+    req = load(REQUEST)
+    lease = load(LEASE)
+    event = load(EVENT)
+    req_schema = load(REQ_SCHEMA)
+    lease_schema = load(LEASE_SCHEMA)
+    event_schema = load(EVENT_SCHEMA)
+
+    require_keys(req, req_schema["required"], "request fixture")
+    require_keys(lease, lease_schema["required"], "lease fixture")
+    require_keys(event, event_schema["required"], "event fixture")
+
+    require_keys(req["workspace"], ["cell", "id", "principal"], "request.workspace")
+    require_keys(req["mount"], ["id", "backend", "authority_mode"], "request.mount")
+    require_keys(lease["workspace"], ["cell", "id"], "lease.workspace")
+    require_keys(lease["mount"], ["id", "backend", "authority_mode"], "lease.mount")
+    require_keys(event, ["workspace_ref", "mount_ref", "dataset_ref", "correlation_id"], "event envelope")
+
+    if req["workspace"]["id"] != lease["workspace"]["id"]:
+        raise SystemExit("workspace id mismatch between request and lease")
+    if req["mount"]["id"] != lease["mount"]["id"]:
+        raise SystemExit("mount id mismatch between request and lease")
+    if req["mount"]["authority_mode"] != lease["mount"]["authority_mode"]:
+        raise SystemExit("authority mode mismatch between request and lease")
+    if event["workspace_ref"] != req["workspace"]["id"]:
+        raise SystemExit("event workspace_ref does not match request workspace id")
+    if event["mount_ref"] != req["mount"]["id"]:
+        raise SystemExit("event mount_ref does not match request mount id")
+
+    dataset_ids = [d["id"] for d in req["datasets"]]
+    if event["dataset_ref"] not in dataset_ids:
+        raise SystemExit("event dataset_ref not found in request datasets")
+    if lease["approved"]["datasets"][0] not in dataset_ids:
+        raise SystemExit("lease approved dataset not found in request datasets")
+
+    request_adapter_roles = {f"{a['kind']}:{a['role']}" for a in req["adapters"]}
+    lease_adapter_roles = set(lease["approved"]["adapters"])
+    if not lease_adapter_roles.issubset(request_adapter_roles):
+        raise SystemExit("lease adapter approvals are not a subset of request adapters")
+
+    print("workspace-fabric fixtures: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds the next implementation-facing tranche for `protocol/workspace-fabric/v0/`.

Files:
- request / lease / evidence JSON Schemas
- JSON fixture examples
- `VALIDATION.md`
- `tools/validate_workspace_fabric_fixtures.py`
- README update to point at schemas, fixtures, and validation

Intent:
Move the workspace-fabric slice from prose and fixture prose into machine-readable schemas plus a lightweight validation path.