### PR TITLE
protocol(workspace-fabric): add lifecycle schemas and fixtures

### DIFF
--- a/protocol/workspace-fabric/v0/README.md
+++ b/protocol/workspace-fabric/v0/README.md
@@ -14,8 +14,10 @@ In scope for v0:
 - adapter role declaration
 - policy and quorum gating
 - lease issuance
+- lease renewal and revocation requests
+- authority-transition request and decision artifacts
 - evidence emission
-- machine-readable request, lease, and evidence schemas
+- machine-readable request, lease, evidence, and lifecycle schemas
 - lightweight fixture validation
 
 Out of scope for v0:
@@ -94,11 +96,19 @@ Machine-readable schemas:
 - `mount-registration-request.schema.json`
 - `mount-registration-lease.schema.json`
 - `evidence-event.schema.json`
+- `lease-renewal-request.schema.json`
+- `lease-revocation-request.schema.json`
+- `authority-transition-request.schema.json`
+- `authority-transition-decision.schema.json`
 
 Fixtures:
 - `fixtures/mount-registration-request.example.json`
 - `fixtures/mount-registration-lease.example.json`
 - `fixtures/evidence-event.example.json`
+- `fixtures/lease-renewal-request.example.json`
+- `fixtures/lease-revocation-request.example.json`
+- `fixtures/authority-transition-request.example.json`
+- `fixtures/authority-transition-decision.example.json`
 
 Validation entrypoint:
 - `python3 tools/validate_workspace_fabric_fixtures.py`

--- a/protocol/workspace-fabric/v0/VALIDATION.md
+++ b/protocol/workspace-fabric/v0/VALIDATION.md
@@ -7,9 +7,13 @@ python3 tools/validate_workspace_fabric_fixtures.py
 ```
 
 This check currently validates:
-- the request fixture top-level and nested required fields
-- the lease fixture top-level and nested required fields
-- the evidence-event fixture top-level required fields
-- workspace, mount, authority, dataset, and adapter consistency across fixtures
+- the mount registration request fixture shape
+- the mount registration lease fixture shape
+- the evidence-event fixture shape
+- the lease renewal request fixture shape
+- the lease revocation request fixture shape
+- the authority-transition request fixture shape
+- the authority-transition decision fixture shape
+- workspace, mount, authority, dataset, adapter, lease, quorum, and correlation consistency across the fixtures
 
 It is intentionally minimal and dependency-free so the protocol slice can be checked in a bare workspace before a fuller schema-validation stack exists.

--- a/protocol/workspace-fabric/v0/authority-transition-decision.schema.json
+++ b/protocol/workspace-fabric/v0/authority-transition-decision.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/authority-transition-decision.schema.json",
+  "title": "MountAuthorityTransitionDecision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "kind",
+    "workspace_ref",
+    "mount_ref",
+    "decision_status",
+    "current_authority",
+    "resulting_authority",
+    "quorum_granted",
+    "policy_bundle_ref",
+    "correlation_id"
+  ],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "MountAuthorityTransitionDecision"},
+    "workspace_ref": {"type": "string", "minLength": 1},
+    "mount_ref": {"type": "string", "minLength": 1},
+    "decision_status": {"enum": ["approved", "rejected", "no_op"]},
+    "current_authority": {"enum": ["local_first", "provider_first", "hybrid"]},
+    "resulting_authority": {"enum": ["local_first", "provider_first", "hybrid"]},
+    "quorum_granted": {"type": "boolean"},
+    "policy_bundle_ref": {"type": "string", "minLength": 1},
+    "correlation_id": {"type": "string", "minLength": 1}
+  }
+}

--- a/protocol/workspace-fabric/v0/authority-transition-request.schema.json
+++ b/protocol/workspace-fabric/v0/authority-transition-request.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/authority-transition-request.schema.json",
+  "title": "MountAuthorityTransitionRequest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "kind",
+    "workspace_ref",
+    "mount_ref",
+    "current_authority",
+    "requested_authority",
+    "reason",
+    "quorum_profile",
+    "correlation_id"
+  ],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "MountAuthorityTransitionRequest"},
+    "workspace_ref": {"type": "string", "minLength": 1},
+    "mount_ref": {"type": "string", "minLength": 1},
+    "current_authority": {"enum": ["local_first", "provider_first", "hybrid"]},
+    "requested_authority": {"enum": ["local_first", "provider_first", "hybrid"]},
+    "reason": {"type": "string", "minLength": 1},
+    "quorum_profile": {"type": "string", "minLength": 1},
+    "correlation_id": {"type": "string", "minLength": 1}
+  }
+}

--- a/protocol/workspace-fabric/v0/fixtures/authority-transition-decision.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/authority-transition-decision.example.json
@@ -1,0 +1,12 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "MountAuthorityTransitionDecision",
+  "workspace_ref": "ws-research",
+  "mount_ref": "topo-main",
+  "decision_status": "approved",
+  "current_authority": "local_first",
+  "resulting_authority": "provider_first",
+  "quorum_granted": true,
+  "policy_bundle_ref": "policy/default",
+  "correlation_id": "reg-topo-main-20260418-003"
+}

--- a/protocol/workspace-fabric/v0/fixtures/authority-transition-request.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/authority-transition-request.example.json
@@ -1,0 +1,11 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "MountAuthorityTransitionRequest",
+  "workspace_ref": "ws-research",
+  "mount_ref": "topo-main",
+  "current_authority": "local_first",
+  "requested_authority": "provider_first",
+  "reason": "remote_document_space_promotion",
+  "quorum_profile": "local-owner-plus-1",
+  "correlation_id": "reg-topo-main-20260418-003"
+}

--- a/protocol/workspace-fabric/v0/fixtures/lease-renewal-request.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/lease-renewal-request.example.json
@@ -1,0 +1,9 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "MountLeaseRenewalRequest",
+  "workspace_ref": "ws-research",
+  "mount_ref": "topo-main",
+  "lease_id": "lease-01JABCXYZ",
+  "requested_ttl": "24h",
+  "correlation_id": "reg-topo-main-20260418-001"
+}

--- a/protocol/workspace-fabric/v0/fixtures/lease-revocation-request.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/lease-revocation-request.example.json
@@ -1,0 +1,10 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "MountLeaseRevocationRequest",
+  "workspace_ref": "ws-research",
+  "mount_ref": "topo-main",
+  "lease_id": "lease-01JABCXYZ",
+  "requested_by": "operator.local",
+  "reason": "manual_revoke_for_authority_reset",
+  "correlation_id": "reg-topo-main-20260418-002"
+}

--- a/protocol/workspace-fabric/v0/lease-renewal-request.schema.json
+++ b/protocol/workspace-fabric/v0/lease-renewal-request.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/lease-renewal-request.schema.json",
+  "title": "MountLeaseRenewalRequest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "kind",
+    "workspace_ref",
+    "mount_ref",
+    "lease_id",
+    "requested_ttl",
+    "correlation_id"
+  ],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "MountLeaseRenewalRequest"},
+    "workspace_ref": {"type": "string", "minLength": 1},
+    "mount_ref": {"type": "string", "minLength": 1},
+    "lease_id": {"type": "string", "minLength": 1},
+    "requested_ttl": {"type": "string", "minLength": 1},
+    "correlation_id": {"type": "string", "minLength": 1}
+  }
+}

--- a/protocol/workspace-fabric/v0/lease-revocation-request.schema.json
+++ b/protocol/workspace-fabric/v0/lease-revocation-request.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/lease-revocation-request.schema.json",
+  "title": "MountLeaseRevocationRequest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "kind",
+    "workspace_ref",
+    "mount_ref",
+    "lease_id",
+    "requested_by",
+    "reason",
+    "correlation_id"
+  ],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "MountLeaseRevocationRequest"},
+    "workspace_ref": {"type": "string", "minLength": 1},
+    "mount_ref": {"type": "string", "minLength": 1},
+    "lease_id": {"type": "string", "minLength": 1},
+    "requested_by": {"type": "string", "minLength": 1},
+    "reason": {"type": "string", "minLength": 1},
+    "correlation_id": {"type": "string", "minLength": 1}
+  }
+}

--- a/tools/validate_workspace_fabric_fixtures.py
+++ b/tools/validate_workspace_fabric_fixtures.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 WF = ROOT / "protocol" / "workspace-fabric" / "v0"
@@ -12,10 +11,18 @@ FIX = WF / "fixtures"
 REQUEST = FIX / "mount-registration-request.example.json"
 LEASE = FIX / "mount-registration-lease.example.json"
 EVENT = FIX / "evidence-event.example.json"
+RENEWAL = FIX / "lease-renewal-request.example.json"
+REVOCATION = FIX / "lease-revocation-request.example.json"
+AUTH_REQ = FIX / "authority-transition-request.example.json"
+AUTH_DEC = FIX / "authority-transition-decision.example.json"
 
 REQ_SCHEMA = WF / "mount-registration-request.schema.json"
 LEASE_SCHEMA = WF / "mount-registration-lease.schema.json"
 EVENT_SCHEMA = WF / "evidence-event.schema.json"
+RENEWAL_SCHEMA = WF / "lease-renewal-request.schema.json"
+REVOCATION_SCHEMA = WF / "lease-revocation-request.schema.json"
+AUTH_REQ_SCHEMA = WF / "authority-transition-request.schema.json"
+AUTH_DEC_SCHEMA = WF / "authority-transition-decision.schema.json"
 
 
 def load(path: Path) -> dict:
@@ -29,20 +36,49 @@ def require_keys(obj: dict, keys: list[str], label: str) -> None:
 
 
 def main() -> int:
-    for path in [REQUEST, LEASE, EVENT, REQ_SCHEMA, LEASE_SCHEMA, EVENT_SCHEMA]:
+    required_paths = [
+        REQUEST,
+        LEASE,
+        EVENT,
+        RENEWAL,
+        REVOCATION,
+        AUTH_REQ,
+        AUTH_DEC,
+        REQ_SCHEMA,
+        LEASE_SCHEMA,
+        EVENT_SCHEMA,
+        RENEWAL_SCHEMA,
+        REVOCATION_SCHEMA,
+        AUTH_REQ_SCHEMA,
+        AUTH_DEC_SCHEMA,
+    ]
+    for path in required_paths:
         if not path.exists():
             raise SystemExit(f"missing required file: {path}")
 
     req = load(REQUEST)
     lease = load(LEASE)
     event = load(EVENT)
+    renewal = load(RENEWAL)
+    revocation = load(REVOCATION)
+    auth_req = load(AUTH_REQ)
+    auth_dec = load(AUTH_DEC)
+
     req_schema = load(REQ_SCHEMA)
     lease_schema = load(LEASE_SCHEMA)
     event_schema = load(EVENT_SCHEMA)
+    renewal_schema = load(RENEWAL_SCHEMA)
+    revocation_schema = load(REVOCATION_SCHEMA)
+    auth_req_schema = load(AUTH_REQ_SCHEMA)
+    auth_dec_schema = load(AUTH_DEC_SCHEMA)
 
     require_keys(req, req_schema["required"], "request fixture")
     require_keys(lease, lease_schema["required"], "lease fixture")
     require_keys(event, event_schema["required"], "event fixture")
+    require_keys(renewal, renewal_schema["required"], "renewal fixture")
+    require_keys(revocation, revocation_schema["required"], "revocation fixture")
+    require_keys(auth_req, auth_req_schema["required"], "authority request fixture")
+    require_keys(auth_dec, auth_dec_schema["required"], "authority decision fixture")
 
     require_keys(req["workspace"], ["cell", "id", "principal"], "request.workspace")
     require_keys(req["mount"], ["id", "backend", "authority_mode"], "request.mount")
@@ -71,6 +107,31 @@ def main() -> int:
     lease_adapter_roles = set(lease["approved"]["adapters"])
     if not lease_adapter_roles.issubset(request_adapter_roles):
         raise SystemExit("lease adapter approvals are not a subset of request adapters")
+
+    for name, obj in [("renewal", renewal), ("revocation", revocation), ("authority request", auth_req), ("authority decision", auth_dec)]:
+        if obj["workspace_ref"] != req["workspace"]["id"]:
+            raise SystemExit(f"{name} workspace_ref does not match request workspace id")
+        if obj["mount_ref"] != req["mount"]["id"]:
+            raise SystemExit(f"{name} mount_ref does not match request mount id")
+
+    if renewal["lease_id"] != lease["lease"]["id"]:
+        raise SystemExit("renewal lease_id does not match lease fixture")
+    if revocation["lease_id"] != lease["lease"]["id"]:
+        raise SystemExit("revocation lease_id does not match lease fixture")
+
+    if auth_req["current_authority"] != req["mount"]["authority_mode"]:
+        raise SystemExit("authority request current_authority does not match request authority mode")
+    if auth_req["requested_authority"] == auth_req["current_authority"]:
+        raise SystemExit("authority request requested_authority must differ from current_authority in this fixture")
+    if auth_dec["current_authority"] != auth_req["current_authority"]:
+        raise SystemExit("authority decision current_authority does not match authority request")
+    if auth_dec["correlation_id"] != auth_req["correlation_id"]:
+        raise SystemExit("authority decision correlation_id does not match authority request")
+    if auth_dec["decision_status"] == "approved":
+        if not auth_dec["quorum_granted"]:
+            raise SystemExit("approved authority decision must grant quorum")
+        if auth_dec["resulting_authority"] != auth_req["requested_authority"]:
+            raise SystemExit("approved authority decision resulting_authority does not match requested_authority")
 
     print("workspace-fabric fixtures: OK")
     return 0


### PR DESCRIPTION
Adds the next machine-readable lifecycle tranche for `protocol/workspace-fabric/v0/`.

Files:
- lifecycle schemas for lease renewal, lease revocation, and authority-transition request/decision
- JSON fixtures for those lifecycle artifacts
- validator update to check lifecycle consistency against the existing request/lease/evidence fixtures
- validation note update
- README update to point at the expanded lifecycle surface

Intent:
Move the workspace-fabric protocol slice beyond registration-only semantics and into lease/authority lifecycle semantics with lightweight executable validation.