### PR TITLE
feat(emvi): add proof-slice demo runner

### DIFF
--- a/protocol/emvi-proof-slice/v0/DEMO.md
+++ b/protocol/emvi-proof-slice/v0/DEMO.md
@@ -1,0 +1,12 @@
+# Proof Slice Demo Runner
+
+Minimal current path:
+
+```bash
+python3 tools/validate_emvi_proof_slice_fixtures.py && \
+python3 tools/run_emvi_proof_slice_demo.py --output artifacts/workspace/emvi-proof-slice-demo.json
+```
+
+This does **not** execute the real shell or service families yet.
+It composes the governed fixture inputs into one concrete demo artifact so that
+implementation can converge on a stable output shape before the full runtime exists.

--- a/tools/run_emvi_proof_slice_demo.py
+++ b/tools/run_emvi_proof_slice_demo.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Generate a minimal EMVI proof-slice demo artifact from merged fixtures.
+
+This is intentionally lightweight and stdlib-only. It does not execute the real
+shell or services; it composes the already-governed fixture inputs into a single
+artifact so downstream implementation has a stable shape to target.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTO = ROOT / "protocol" / "emvi-proof-slice" / "v0"
+ACTIONSPEC_PATH = PROTO / "fixtures" / "actionspec.example.json"
+EVENTS_PATH = PROTO / "fixtures" / "events.example.jsonl"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+def build_demo_artifact() -> dict[str, Any]:
+    actionspec = load_json(ACTIONSPEC_PATH)
+    events = load_jsonl(EVENTS_PATH)
+    return {
+        "kind": "EMVIProofSliceDemoArtifact",
+        "generatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "protocolRef": "protocol/emvi-proof-slice/v0",
+        "actionSpec": actionspec,
+        "events": events,
+        "summary": {
+            "eventCount": len(events),
+            "targetIds": sorted({tid for row in events for tid in row.get("target_ids", [])}),
+            "serviceFamilies": sorted({row.get("service_family", "") for row in events if row.get("service_family")}),
+            "correlationIds": sorted({row.get("correlation_id", "") for row in events if row.get("correlation_id")}),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", default="-", help="Output path or '-' for stdout")
+    args = parser.parse_args()
+
+    artifact = build_demo_artifact()
+    payload = json.dumps(artifact, indent=2, sort_keys=True) + "\n"
+    if args.output == "-":
+        print(payload, end="")
+    else:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(payload, encoding="utf-8")
+        print(f"OK: wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a minimal stdlib-only demo runner for the merged EMVI proof-slice protocol fixtures
- add a short usage note showing the validate-then-run path

## Files added
- `tools/run_emvi_proof_slice_demo.py`
- `protocol/emvi-proof-slice/v0/DEMO.md`

## Intent
This PR is a small implementation-facing increment that does not fight the current repo shape. The EMVI docs subtree and proof-slice protocol scaffold are already on `main`; this branch simply adds a concrete artifact generator that consumes those merged fixtures and produces one stable demo artifact shape for downstream implementation.

## Non-goals
- does not execute the real shell or service families yet
- does not patch the docs portal index
- does not change the merged proof-slice protocol contracts

## Follow-up
- add a tiny CI or runner hook for this demo path if the repo wants it
- start replacing the synthetic demo composition with real proof-slice execution
