### PR TITLE
protocol(workspace-fabric): add reconcile schemas and fixtures

### DIFF
--- a/protocol/workspace-fabric/v0/README.md
+++ b/protocol/workspace-fabric/v0/README.md
@@ -16,8 +16,11 @@ In scope for v0:
 - lease issuance
 - lease renewal and revocation requests
 - authority-transition request and decision artifacts
+- tombstone decision artifacts
+- reconcile-required artifacts
+- lifecycle transition artifacts
 - evidence emission
-- machine-readable request, lease, evidence, and lifecycle schemas
+- machine-readable request, lease, evidence, lifecycle, and reconcile schemas
 - lightweight fixture validation
 
 Out of scope for v0:
@@ -100,6 +103,9 @@ Machine-readable schemas:
 - `lease-revocation-request.schema.json`
 - `authority-transition-request.schema.json`
 - `authority-transition-decision.schema.json`
+- `tombstone-decision.schema.json`
+- `reconcile-required.schema.json`
+- `lifecycle-transition.schema.json`
 
 Fixtures:
 - `fixtures/mount-registration-request.example.json`
@@ -109,6 +115,9 @@ Fixtures:
 - `fixtures/lease-revocation-request.example.json`
 - `fixtures/authority-transition-request.example.json`
 - `fixtures/authority-transition-decision.example.json`
+- `fixtures/tombstone-decision.example.json`
+- `fixtures/reconcile-required.example.json`
+- `fixtures/transition.example.json`
 
 Validation entrypoint:
 - `python3 tools/validate_workspace_fabric_fixtures.py`

--- a/protocol/workspace-fabric/v0/VALIDATION.md
+++ b/protocol/workspace-fabric/v0/VALIDATION.md
@@ -14,6 +14,9 @@ This check currently validates:
 - the lease revocation request fixture shape
 - the authority-transition request fixture shape
 - the authority-transition decision fixture shape
-- workspace, mount, authority, dataset, adapter, lease, quorum, and correlation consistency across the fixtures
+- the tombstone decision fixture shape
+- the reconcile-required fixture shape
+- the lifecycle transition fixture shape
+- workspace, mount, authority, dataset, adapter, lease, quorum, state, and correlation consistency across the fixtures
 
 It is intentionally minimal and dependency-free so the protocol slice can be checked in a bare workspace before a fuller schema-validation stack exists.

--- a/protocol/workspace-fabric/v0/fixtures/reconcile-required.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/reconcile-required.example.json
@@ -1,0 +1,10 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "MountReconcileRequired",
+  "workspace_ref": "ws-research",
+  "mount_ref": "topo-main",
+  "reason_code": "local_dirty_remote_delete",
+  "authority_mode": "local_first",
+  "resulting_state": "RECONCILE_REQUIRED",
+  "correlation_id": "reg-topo-main-20260418-005"
+}

--- a/protocol/workspace-fabric/v0/fixtures/tombstone-decision.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/tombstone-decision.example.json
@@ -1,0 +1,12 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "MountTombstoneDecision",
+  "workspace_ref": "ws-research",
+  "mount_ref": "topo-main",
+  "signed_tombstone": true,
+  "local_dirty": false,
+  "decision_status": "applied",
+  "resulting_state": "tombstoned",
+  "policy_bundle_ref": "policy/default",
+  "correlation_id": "reg-topo-main-20260418-004"
+}

--- a/protocol/workspace-fabric/v0/fixtures/transition.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/transition.example.json
@@ -1,0 +1,10 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "MountLifecycleTransition",
+  "workspace_ref": "ws-research",
+  "mount_ref": "topo-main",
+  "from_state": "ACTIVE",
+  "to_state": "DEGRADED",
+  "reason": "transition_example",
+  "correlation_id": "reg-topo-main-20260418-005"
+}

--- a/protocol/workspace-fabric/v0/lifecycle-transition.schema.json
+++ b/protocol/workspace-fabric/v0/lifecycle-transition.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/lifecycle-transition.schema.json",
+  "title": "MountLifecycleTransition",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "kind",
+    "workspace_ref",
+    "mount_ref",
+    "from_state",
+    "to_state",
+    "reason",
+    "correlation_id"
+  ],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "MountLifecycleTransition"},
+    "workspace_ref": {"type": "string", "minLength": 1},
+    "mount_ref": {"type": "string", "minLength": 1},
+    "from_state": {
+      "enum": [
+        "DISCOVERED",
+        "PROPOSED",
+        "POLICY_EVALUATING",
+        "QUORUM_EVALUATING",
+        "LEASE_ISSUED",
+        "ACTIVE",
+        "DEGRADED",
+        "RECONCILE_REQUIRED",
+        "REVOKED",
+        "TOMBSTONED"
+      ]
+    },
+    "to_state": {
+      "enum": [
+        "DISCOVERED",
+        "PROPOSED",
+        "POLICY_EVALUATING",
+        "QUORUM_EVALUATING",
+        "LEASE_ISSUED",
+        "ACTIVE",
+        "DEGRADED",
+        "RECONCILE_REQUIRED",
+        "REVOKED",
+        "TOMBSTONED"
+      ]
+    },
+    "reason": {"type": "string", "minLength": 1},
+    "correlation_id": {"type": "string", "minLength": 1}
+  }
+}

--- a/protocol/workspace-fabric/v0/reconcile-required.schema.json
+++ b/protocol/workspace-fabric/v0/reconcile-required.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/reconcile-required.schema.json",
+  "title": "MountReconcileRequired",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "kind",
+    "workspace_ref",
+    "mount_ref",
+    "reason_code",
+    "authority_mode",
+    "resulting_state",
+    "correlation_id"
+  ],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "MountReconcileRequired"},
+    "workspace_ref": {"type": "string", "minLength": 1},
+    "mount_ref": {"type": "string", "minLength": 1},
+    "reason_code": {
+      "enum": [
+        "local_dirty_remote_delete",
+        "authority_conflict",
+        "stale_mirror_blocked",
+        "signed_tombstone_requires_resolution"
+      ]
+    },
+    "authority_mode": {"enum": ["local_first", "provider_first", "hybrid"]},
+    "resulting_state": {"const": "RECONCILE_REQUIRED"},
+    "correlation_id": {"type": "string", "minLength": 1}
+  }
+}

--- a/protocol/workspace-fabric/v0/tombstone-decision.schema.json
+++ b/protocol/workspace-fabric/v0/tombstone-decision.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/tombstone-decision.schema.json",
+  "title": "MountTombstoneDecision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "kind",
+    "workspace_ref",
+    "mount_ref",
+    "signed_tombstone",
+    "local_dirty",
+    "decision_status",
+    "resulting_state",
+    "policy_bundle_ref",
+    "correlation_id"
+  ],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "MountTombstoneDecision"},
+    "workspace_ref": {"type": "string", "minLength": 1},
+    "mount_ref": {"type": "string", "minLength": 1},
+    "signed_tombstone": {"type": "boolean"},
+    "local_dirty": {"type": "boolean"},
+    "decision_status": {"enum": ["applied", "rejected", "manual_reconcile_required"]},
+    "resulting_state": {"enum": ["tombstoned", "active", "reconcile_required"]},
+    "policy_bundle_ref": {"type": "string", "minLength": 1},
+    "correlation_id": {"type": "string", "minLength": 1}
+  }
+}

--- a/tools/validate_workspace_fabric_fixtures.py
+++ b/tools/validate_workspace_fabric_fixtures.py
@@ -15,6 +15,9 @@ RENEWAL = FIX / "lease-renewal-request.example.json"
 REVOCATION = FIX / "lease-revocation-request.example.json"
 AUTH_REQ = FIX / "authority-transition-request.example.json"
 AUTH_DEC = FIX / "authority-transition-decision.example.json"
+TOMBSTONE = FIX / "tombstone-decision.example.json"
+RECONCILE = FIX / "reconcile-required.example.json"
+TRANSITION = FIX / "transition.example.json"
 
 REQ_SCHEMA = WF / "mount-registration-request.schema.json"
 LEASE_SCHEMA = WF / "mount-registration-lease.schema.json"
@@ -23,6 +26,9 @@ RENEWAL_SCHEMA = WF / "lease-renewal-request.schema.json"
 REVOCATION_SCHEMA = WF / "lease-revocation-request.schema.json"
 AUTH_REQ_SCHEMA = WF / "authority-transition-request.schema.json"
 AUTH_DEC_SCHEMA = WF / "authority-transition-decision.schema.json"
+TOMBSTONE_SCHEMA = WF / "tombstone-decision.schema.json"
+RECONCILE_SCHEMA = WF / "reconcile-required.schema.json"
+TRANSITION_SCHEMA = WF / "lifecycle-transition.schema.json"
 
 
 def load(path: Path) -> dict:
@@ -44,6 +50,9 @@ def main() -> int:
         REVOCATION,
         AUTH_REQ,
         AUTH_DEC,
+        TOMBSTONE,
+        RECONCILE,
+        TRANSITION,
         REQ_SCHEMA,
         LEASE_SCHEMA,
         EVENT_SCHEMA,
@@ -51,6 +60,9 @@ def main() -> int:
         REVOCATION_SCHEMA,
         AUTH_REQ_SCHEMA,
         AUTH_DEC_SCHEMA,
+        TOMBSTONE_SCHEMA,
+        RECONCILE_SCHEMA,
+        TRANSITION_SCHEMA,
     ]
     for path in required_paths:
         if not path.exists():
@@ -63,6 +75,9 @@ def main() -> int:
     revocation = load(REVOCATION)
     auth_req = load(AUTH_REQ)
     auth_dec = load(AUTH_DEC)
+    tombstone = load(TOMBSTONE)
+    reconcile = load(RECONCILE)
+    transition = load(TRANSITION)
 
     req_schema = load(REQ_SCHEMA)
     lease_schema = load(LEASE_SCHEMA)
@@ -71,6 +86,9 @@ def main() -> int:
     revocation_schema = load(REVOCATION_SCHEMA)
     auth_req_schema = load(AUTH_REQ_SCHEMA)
     auth_dec_schema = load(AUTH_DEC_SCHEMA)
+    tombstone_schema = load(TOMBSTONE_SCHEMA)
+    reconcile_schema = load(RECONCILE_SCHEMA)
+    transition_schema = load(TRANSITION_SCHEMA)
 
     require_keys(req, req_schema["required"], "request fixture")
     require_keys(lease, lease_schema["required"], "lease fixture")
@@ -79,6 +97,9 @@ def main() -> int:
     require_keys(revocation, revocation_schema["required"], "revocation fixture")
     require_keys(auth_req, auth_req_schema["required"], "authority request fixture")
     require_keys(auth_dec, auth_dec_schema["required"], "authority decision fixture")
+    require_keys(tombstone, tombstone_schema["required"], "tombstone decision fixture")
+    require_keys(reconcile, reconcile_schema["required"], "reconcile-required fixture")
+    require_keys(transition, transition_schema["required"], "transition fixture")
 
     require_keys(req["workspace"], ["cell", "id", "principal"], "request.workspace")
     require_keys(req["mount"], ["id", "backend", "authority_mode"], "request.mount")
@@ -108,7 +129,15 @@ def main() -> int:
     if not lease_adapter_roles.issubset(request_adapter_roles):
         raise SystemExit("lease adapter approvals are not a subset of request adapters")
 
-    for name, obj in [("renewal", renewal), ("revocation", revocation), ("authority request", auth_req), ("authority decision", auth_dec)]:
+    for name, obj in [
+        ("renewal", renewal),
+        ("revocation", revocation),
+        ("authority request", auth_req),
+        ("authority decision", auth_dec),
+        ("tombstone decision", tombstone),
+        ("reconcile-required", reconcile),
+        ("transition", transition),
+    ]:
         if obj["workspace_ref"] != req["workspace"]["id"]:
             raise SystemExit(f"{name} workspace_ref does not match request workspace id")
         if obj["mount_ref"] != req["mount"]["id"]:
@@ -132,6 +161,15 @@ def main() -> int:
             raise SystemExit("approved authority decision must grant quorum")
         if auth_dec["resulting_authority"] != auth_req["requested_authority"]:
             raise SystemExit("approved authority decision resulting_authority does not match requested_authority")
+
+    if tombstone["signed_tombstone"] and not tombstone["local_dirty"]:
+        if tombstone["decision_status"] == "applied" and tombstone["resulting_state"] != "tombstoned":
+            raise SystemExit("applied tombstone must result in tombstoned state in this fixture")
+
+    if reconcile["resulting_state"] != "RECONCILE_REQUIRED":
+        raise SystemExit("reconcile fixture must result in RECONCILE_REQUIRED")
+    if transition["to_state"] == "RECONCILE_REQUIRED" and reconcile["correlation_id"] != transition["correlation_id"]:
+        raise SystemExit("transition and reconcile fixture should share correlation_id in this fixture")
 
     print("workspace-fabric fixtures: OK")
     return 0


### PR DESCRIPTION
Adds the next machine-readable reconcile tranche for `protocol/workspace-fabric/v0/`.

Files:
- `tombstone-decision.schema.json`
- `reconcile-required.schema.json`
- `lifecycle-transition.schema.json`
- matching JSON fixtures
- validator update for reconcile/tombstone/transition consistency
- `VALIDATION.md` and `README.md` refresh

Intent:
Move the workspace-fabric slice beyond registration and lifecycle requests into reconcile/tombstone/state-transition semantics with lightweight executable validation.