### PR TITLE
feat(oprisk): add lightweight record-shape validation lane

### DIFF
--- a/registry/software_oprisk/SCHEMA_ALIGNMENT.md
+++ b/registry/software_oprisk/SCHEMA_ALIGNMENT.md
@@ -1,0 +1,33 @@
+# Schema Alignment
+
+This note documents how the normalized registry outputs in `registry/software_oprisk/` align to the typed contract lane.
+
+## Current typed contracts
+
+The current machine-readable contract surfaces live in `SourceOS-Linux/sourceos-spec` and now include:
+
+- `SoftwareOperationalIncident`
+- `UpstreamWatchItem`
+- `ReserveScenarioReport`
+
+## Registry output mapping
+
+### `outage_corpus*.jsonl`
+Each record SHOULD align to `SoftwareOperationalIncident`.
+
+### `upstream_watch*.jsonl`
+Each record SHOULD align to `UpstreamWatchItem`.
+
+### future reserve outputs
+Any reserve, scenario, or avoided-loss outputs SHOULD align to `ReserveScenarioReport` or a successor contract in the same family.
+
+## Current validation posture
+
+The first validation layer in this repository is intentionally lightweight.
+It checks:
+
+- required keys by normalized record type;
+- URN-prefix discipline;
+- minimum list-shape expectations for `sourceRefs` and `signals`.
+
+Full schema validation remains a follow-on step and SHOULD eventually bind directly to the canonical typed contract artifacts in `SourceOS-Linux/sourceos-spec`.

--- a/registry/software_oprisk/schema_targets.yaml
+++ b/registry/software_oprisk/schema_targets.yaml
@@ -1,0 +1,35 @@
+schema_targets:
+  outage_corpus:
+    normalized_type: SoftwareOperationalIncident
+    schema_id: https://schemas.srcos.ai/v2/SoftwareOperationalIncident.json
+    source_repo: SourceOS-Linux/sourceos-spec
+    source_path: schemas/SoftwareOperationalIncident.json
+    example_path: examples/softwareoperationalincident.json
+
+  upstream_watch:
+    normalized_type: UpstreamWatchItem
+    schema_id: https://schemas.srcos.ai/v2/UpstreamWatchItem.json
+    source_repo: SourceOS-Linux/sourceos-spec
+    source_path: schemas/UpstreamWatchItem.json
+    example_path: examples/upstreamwatchitem.json
+
+  reserve_report:
+    normalized_type: ReserveScenarioReport
+    schema_id: https://schemas.srcos.ai/v2/ReserveScenarioReport.json
+    source_repo: SourceOS-Linux/sourceos-spec
+    source_path: schemas/ReserveScenarioReport.json
+    example_path: examples/reservescenarioreport.json
+
+  scenario_run:
+    normalized_type: SoftwareOperationalScenarioRun
+    schema_id: https://schemas.srcos.ai/v2/SoftwareOperationalScenarioRun.json
+    source_repo: SourceOS-Linux/sourceos-spec
+    source_path: schemas/SoftwareOperationalScenarioRun.json
+    example_path: examples/softwareoperationalscenariorun.json
+
+  analysis_bundle:
+    normalized_type: SoftwareOperationalAnalysisBundle
+    schema_id: https://schemas.srcos.ai/v2/SoftwareOperationalAnalysisBundle.json
+    source_repo: SourceOS-Linux/sourceos-spec
+    source_path: schemas/SoftwareOperationalAnalysisBundle.json
+    example_path: examples/softwareoperationalanalysisbundle.json

--- a/tools/oprisk/check_schema_bindings.py
+++ b/tools/oprisk/check_schema_bindings.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Check local bindings from the software operational-risk registry lane to canonical schemas.
+
+This helper does not perform full JSON Schema validation. Instead, it verifies that the
+current canonical schema targets declared in `schema_registry.py` resolve cleanly against
+an available local checkout of `SourceOS-Linux/sourceos-spec`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .schema_registry import SCHEMA_TARGETS
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--contracts-root",
+        required=True,
+        help="Path to a local checkout of SourceOS-Linux/sourceos-spec",
+    )
+    parser.add_argument(
+        "--target",
+        choices=sorted(SCHEMA_TARGETS.keys()),
+        help="Optional single schema target to check",
+    )
+    return parser.parse_args()
+
+
+def check_target(contracts_root: Path, name: str, meta: Dict[str, Any]) -> Dict[str, Any]:
+    schema_path = contracts_root / meta["source_path"]
+    example_path = contracts_root / meta["example_path"]
+    return {
+        "target": name,
+        "normalized_type": meta["normalized_type"],
+        "schema_id": meta["schema_id"],
+        "schema_exists": schema_path.exists(),
+        "schema_path": str(schema_path),
+        "example_exists": example_path.exists(),
+        "example_path": str(example_path),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    contracts_root = Path(args.contracts_root)
+    names = [args.target] if args.target else list(SCHEMA_TARGETS.keys())
+
+    results = [check_target(contracts_root, name, SCHEMA_TARGETS[name]) for name in names]
+    summary = {
+        "contracts_root": str(contracts_root),
+        "checked": len(results),
+        "all_bound": all(item["schema_exists"] and item["example_exists"] for item in results),
+        "results": results,
+    }
+    print(json.dumps(summary, indent=2))
+    return 0 if summary["all_bound"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/oprisk/jsonl_shape_checks.py
+++ b/tools/oprisk/jsonl_shape_checks.py
@@ -1,0 +1,65 @@
+"""Helpers for lightweight validation of normalized software operational-risk records.
+
+This module intentionally avoids external dependencies and focuses on the minimum
+shape guarantees needed by the first harvester lane.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .record_shapes import REQUIRED_KEYS, URN_PREFIXES
+
+
+def validate_record_shape(payload: Dict[str, Any]) -> List[str]:
+    """Return a list of validation errors for a normalized record payload."""
+    errors: List[str] = []
+    obj_type = payload.get("type")
+    if obj_type not in REQUIRED_KEYS:
+        return [f"unknown type: {obj_type!r}"]
+
+    for key in REQUIRED_KEYS[obj_type]:
+        if key not in payload:
+            errors.append(f"missing required key: {key}")
+
+    record_id = payload.get("id")
+    prefix = URN_PREFIXES[obj_type]
+    if not isinstance(record_id, str):
+        errors.append("id must be a string")
+    elif not record_id.startswith(prefix):
+        errors.append(f"id must start with {prefix}")
+
+    if obj_type == "SoftwareOperationalIncident":
+        refs = payload.get("sourceRefs")
+        if not isinstance(refs, list) or not refs:
+            errors.append("sourceRefs must be a non-empty list")
+
+    if obj_type == "UpstreamWatchItem":
+        signals = payload.get("signals")
+        if not isinstance(signals, list) or not signals:
+            errors.append("signals must be a non-empty list")
+
+    return errors
+
+
+def summarize_validation(payloads: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return a compact validation summary for a list of normalized records."""
+    summary = {
+        "checked": 0,
+        "valid": 0,
+        "invalid": 0,
+        "errors": [],
+    }
+    for payload in payloads:
+        summary["checked"] += 1
+        errors = validate_record_shape(payload)
+        if errors:
+            summary["invalid"] += 1
+            summary["errors"].append({
+                "id": payload.get("id"),
+                "type": payload.get("type"),
+                "errors": errors,
+            })
+        else:
+            summary["valid"] += 1
+    return summary

--- a/tools/oprisk/schema_binding_usage.md
+++ b/tools/oprisk/schema_binding_usage.md
@@ -1,0 +1,39 @@
+# Canonical Schema Binding Checks
+
+This note explains how to verify that the software operational-risk registry lane is pointing at the intended canonical schema artifacts.
+
+## Purpose
+
+The lightweight validation lane now has two layers:
+
+1. local shape validation of normalized JSONL outputs;
+2. local binding checks against the canonical schema and example paths declared in `SourceOS-Linux/sourceos-spec`.
+
+## Usage
+
+```bash
+python tools/oprisk/check_schema_bindings.py \
+  --contracts-root /path/to/sourceos-spec
+```
+
+To check a single target:
+
+```bash
+python tools/oprisk/check_schema_bindings.py \
+  --contracts-root /path/to/sourceos-spec \
+  --target outage_corpus
+```
+
+## What this does
+
+It verifies that each declared schema target in `schema_registry.py` resolves to:
+
+- a canonical schema file;
+- and a corresponding example payload
+
+inside a local checkout of `SourceOS-Linux/sourceos-spec`.
+
+## What this does not do
+
+This helper does **not** perform full JSON Schema validation of registry outputs.
+That remains a follow-on step once schema loading is bound directly into the validation path.

--- a/tools/oprisk/schema_registry.py
+++ b/tools/oprisk/schema_registry.py
@@ -1,0 +1,43 @@
+"""Canonical schema target metadata for the software operational risk lane.
+
+This module mirrors the registry YAML so automation code can reference the intended
+canonical schema artifacts without hard-coding source repo paths inline.
+"""
+
+SCHEMA_TARGETS = {
+    "outage_corpus": {
+        "normalized_type": "SoftwareOperationalIncident",
+        "schema_id": "https://schemas.srcos.ai/v2/SoftwareOperationalIncident.json",
+        "source_repo": "SourceOS-Linux/sourceos-spec",
+        "source_path": "schemas/SoftwareOperationalIncident.json",
+        "example_path": "examples/softwareoperationalincident.json",
+    },
+    "upstream_watch": {
+        "normalized_type": "UpstreamWatchItem",
+        "schema_id": "https://schemas.srcos.ai/v2/UpstreamWatchItem.json",
+        "source_repo": "SourceOS-Linux/sourceos-spec",
+        "source_path": "schemas/UpstreamWatchItem.json",
+        "example_path": "examples/upstreamwatchitem.json",
+    },
+    "reserve_report": {
+        "normalized_type": "ReserveScenarioReport",
+        "schema_id": "https://schemas.srcos.ai/v2/ReserveScenarioReport.json",
+        "source_repo": "SourceOS-Linux/sourceos-spec",
+        "source_path": "schemas/ReserveScenarioReport.json",
+        "example_path": "examples/reservescenarioreport.json",
+    },
+    "scenario_run": {
+        "normalized_type": "SoftwareOperationalScenarioRun",
+        "schema_id": "https://schemas.srcos.ai/v2/SoftwareOperationalScenarioRun.json",
+        "source_repo": "SourceOS-Linux/sourceos-spec",
+        "source_path": "schemas/SoftwareOperationalScenarioRun.json",
+        "example_path": "examples/softwareoperationalscenariorun.json",
+    },
+    "analysis_bundle": {
+        "normalized_type": "SoftwareOperationalAnalysisBundle",
+        "schema_id": "https://schemas.srcos.ai/v2/SoftwareOperationalAnalysisBundle.json",
+        "source_repo": "SourceOS-Linux/sourceos-spec",
+        "source_path": "schemas/SoftwareOperationalAnalysisBundle.json",
+        "example_path": "examples/softwareoperationalanalysisbundle.json",
+    },
+}

--- a/tools/oprisk/validate_jsonl_shapes.py
+++ b/tools/oprisk/validate_jsonl_shapes.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Validate normalized software operational-risk JSONL files with lightweight shape checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .jsonl_shape_checks import summarize_validation
+
+
+def load_jsonl(path: Path) -> List[Dict[str, Any]]:
+    payloads: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, raw in enumerate(handle, start=1):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_no}: invalid JSON: {exc}") from exc
+            if not isinstance(payload, dict):
+                raise ValueError(f"{path}:{line_no}: expected top-level object")
+            payloads.append(payload)
+    return payloads
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", help="One or more JSONL files to validate")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    payloads: List[Dict[str, Any]] = []
+    for raw_path in args.paths:
+        payloads.extend(load_jsonl(Path(raw_path)))
+
+    summary = summarize_validation(payloads)
+    if summary["invalid"]:
+        print(json.dumps(summary, indent=2), file=sys.stderr)
+        return 1
+
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a lightweight validation/alignment layer for the software operational risk registry outputs:

- `tools/oprisk/jsonl_shape_checks.py`
- `registry/software_oprisk/SCHEMA_ALIGNMENT.md`

## Why here

Before writing, the current upstream `main` head was re-checked. The first harvester and registry lane already merged via PR #97, so this PR extends that lane with additive validation and schema-alignment artifacts instead of trying to mutate the merged branch.

## Purpose

This is intentionally not full schema validation yet. It adds:

- required-key checks by normalized record type
- URN-prefix checks
- minimum list-shape checks for `sourceRefs` and `signals`
- an explicit mapping from registry outputs to the typed contracts now present in `SourceOS-Linux/sourceos-spec`

## Follow-on

- bind validation directly to the canonical typed schemas
- add provider-specific fetchers/adapters
- surface validation summaries in trust reports and topology reasoning
