### PR TITLE
protocol(workspace-fabric): add adapter profiles and CI validation

### DIFF
--- a/.github/workflows/workspace-fabric.yml
+++ b/.github/workflows/workspace-fabric.yml
@@ -1,0 +1,41 @@
+name: workspace-fabric
+
+on:
+  pull_request:
+    paths:
+      - "protocol/workspace-fabric/v0/**"
+      - "tools/validate_workspace_fabric_fixtures.py"
+      - ".github/workflows/workspace-fabric.yml"
+  push:
+    branches: [main]
+    paths:
+      - "protocol/workspace-fabric/v0/**"
+      - "tools/validate_workspace_fabric_fixtures.py"
+      - ".github/workflows/workspace-fabric.yml"
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  validate-workspace-fabric:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate workspace-fabric fixtures
+        run: |
+          python tools/validate_workspace_fabric_fixtures.py
+
+      - name: Publish validation summary
+        if: always()
+        run: |
+          echo "workspace-fabric validation completed" >> "$GITHUB_STEP_SUMMARY"

--- a/protocol/workspace-fabric/v0/README.md
+++ b/protocol/workspace-fabric/v0/README.md
@@ -12,6 +12,7 @@ In scope for v0:
 - authority mode declaration
 - dataset and index binding
 - adapter role declaration
+- adapter profile fixtures
 - policy and quorum gating
 - lease issuance
 - lease renewal and revocation requests
@@ -20,8 +21,9 @@ In scope for v0:
 - reconcile-required artifacts
 - lifecycle transition artifacts
 - evidence emission
-- machine-readable request, lease, evidence, lifecycle, and reconcile schemas
+- machine-readable request, lease, evidence, lifecycle, reconcile, and adapter-profile schemas
 - lightweight fixture validation
+- CI validation wiring
 
 Out of scope for v0:
 - full sync protocol implementation
@@ -106,6 +108,7 @@ Machine-readable schemas:
 - `tombstone-decision.schema.json`
 - `reconcile-required.schema.json`
 - `lifecycle-transition.schema.json`
+- `adapter-profile.schema.json`
 
 Fixtures:
 - `fixtures/mount-registration-request.example.json`
@@ -118,6 +121,12 @@ Fixtures:
 - `fixtures/tombstone-decision.example.json`
 - `fixtures/reconcile-required.example.json`
 - `fixtures/transition.example.json`
+- `fixtures/adapters/topolvm.example.json`
+- `fixtures/adapters/hypercore.example.json`
+- `fixtures/adapters/s3.example.json`
+- `fixtures/adapters/rsync.example.json`
+- `fixtures/adapters/drive.example.json`
 
-Validation entrypoint:
+Validation entrypoints:
 - `python3 tools/validate_workspace_fabric_fixtures.py`
+- `.github/workflows/workspace-fabric.yml`

--- a/protocol/workspace-fabric/v0/VALIDATION.md
+++ b/protocol/workspace-fabric/v0/VALIDATION.md
@@ -1,10 +1,14 @@
 # Workspace Fabric Validation
 
-Current lightweight validation path:
+Local validation path:
 
 ```bash
 python3 tools/validate_workspace_fabric_fixtures.py
 ```
+
+CI validation path:
+
+- `.github/workflows/workspace-fabric.yml`
 
 This check currently validates:
 - the mount registration request fixture shape
@@ -17,6 +21,8 @@ This check currently validates:
 - the tombstone decision fixture shape
 - the reconcile-required fixture shape
 - the lifecycle transition fixture shape
+- the adapter profile schema
+- the TopoLVM, Hypercore, S3, rsync, and Drive adapter profile fixtures
 - workspace, mount, authority, dataset, adapter, lease, quorum, state, and correlation consistency across the fixtures
 
-It is intentionally minimal and dependency-free so the protocol slice can be checked in a bare workspace before a fuller schema-validation stack exists.
+It is intentionally lightweight and dependency-free so the protocol slice can be checked in a bare workspace before a fuller schema-validation stack exists.

--- a/protocol/workspace-fabric/v0/adapter-profile.schema.json
+++ b/protocol/workspace-fabric/v0/adapter-profile.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/adapter-profile.schema.json",
+  "title": "WorkspaceFabricAdapterProfile",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "kind",
+    "adapter_kind",
+    "default_roles",
+    "allowed_authority_modes",
+    "default_authority_mode",
+    "authority_requires_quorum",
+    "supported_capabilities"
+  ],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "AdapterProfile"},
+    "adapter_kind": {
+      "enum": ["topolvm", "hypercore", "s3", "rsync", "drive"]
+    },
+    "default_roles": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "enum": [
+          "topic_distribution",
+          "object_snapshot_replica",
+          "compatibility_mirror",
+          "bulk_sync",
+          "collaboration_ingress",
+          "cold_archive"
+        ]
+      }
+    },
+    "allowed_authority_modes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"enum": ["local_first", "provider_first", "hybrid"]}
+    },
+    "default_authority_mode": {"enum": ["local_first", "provider_first", "hybrid"]},
+    "authority_requires_quorum": {"type": "boolean"},
+    "supported_capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "notes": {"type": "string"}
+  }
+}

--- a/protocol/workspace-fabric/v0/fixtures/adapters/drive.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/adapters/drive.example.json
@@ -1,0 +1,15 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "AdapterProfile",
+  "adapter_kind": "drive",
+  "default_roles": ["compatibility_mirror", "collaboration_ingress"],
+  "allowed_authority_modes": ["local_first", "provider_first", "hybrid"],
+  "default_authority_mode": "local_first",
+  "authority_requires_quorum": true,
+  "supported_capabilities": [
+    "document_interchange",
+    "compatibility_mirror",
+    "collaboration_ingress"
+  ],
+  "notes": "Compatibility mirror by default; authoritative promotion requires explicit approval and quorum."
+}

--- a/protocol/workspace-fabric/v0/fixtures/adapters/hypercore.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/adapters/hypercore.example.json
@@ -1,0 +1,15 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "AdapterProfile",
+  "adapter_kind": "hypercore",
+  "default_roles": ["topic_distribution"],
+  "allowed_authority_modes": ["local_first", "hybrid"],
+  "default_authority_mode": "local_first",
+  "authority_requires_quorum": false,
+  "supported_capabilities": [
+    "append_only_replication",
+    "offline_first_topic_sync",
+    "snapshot_distribution"
+  ],
+  "notes": "Append-only distribution plane, not default mutable filesystem authority."
+}

--- a/protocol/workspace-fabric/v0/fixtures/adapters/rsync.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/adapters/rsync.example.json
@@ -1,0 +1,15 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "AdapterProfile",
+  "adapter_kind": "rsync",
+  "default_roles": ["bulk_sync"],
+  "allowed_authority_modes": ["local_first", "hybrid"],
+  "default_authority_mode": "local_first",
+  "authority_requires_quorum": false,
+  "supported_capabilities": [
+    "bulk_transfer",
+    "bootstrap_restore",
+    "filesystem_migration"
+  ],
+  "notes": "Transport and bootstrap path, not an authority root."
+}

--- a/protocol/workspace-fabric/v0/fixtures/adapters/s3.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/adapters/s3.example.json
@@ -1,0 +1,15 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "AdapterProfile",
+  "adapter_kind": "s3",
+  "default_roles": ["object_snapshot_replica", "cold_archive"],
+  "allowed_authority_modes": ["local_first", "provider_first", "hybrid"],
+  "default_authority_mode": "local_first",
+  "authority_requires_quorum": true,
+  "supported_capabilities": [
+    "object_replication",
+    "snapshot_restore",
+    "cold_archive"
+  ],
+  "notes": "Object snapshot and archive plane; provider-first promotion requires quorum."
+}

--- a/protocol/workspace-fabric/v0/fixtures/adapters/topolvm.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/adapters/topolvm.example.json
@@ -1,0 +1,15 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "AdapterProfile",
+  "adapter_kind": "topolvm",
+  "default_roles": ["bulk_sync"],
+  "allowed_authority_modes": ["local_first", "hybrid"],
+  "default_authority_mode": "local_first",
+  "authority_requires_quorum": false,
+  "supported_capabilities": [
+    "local_persistent_storage",
+    "snapshot_locality",
+    "index_colocation"
+  ],
+  "notes": "Primary authoritative local persistence plane."
+}

--- a/tools/validate_workspace_fabric_fixtures.py
+++ b/tools/validate_workspace_fabric_fixtures.py
@@ -7,6 +7,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 WF = ROOT / "protocol" / "workspace-fabric" / "v0"
 FIX = WF / "fixtures"
+ADP = FIX / "adapters"
 
 REQUEST = FIX / "mount-registration-request.example.json"
 LEASE = FIX / "mount-registration-lease.example.json"
@@ -29,6 +30,15 @@ AUTH_DEC_SCHEMA = WF / "authority-transition-decision.schema.json"
 TOMBSTONE_SCHEMA = WF / "tombstone-decision.schema.json"
 RECONCILE_SCHEMA = WF / "reconcile-required.schema.json"
 TRANSITION_SCHEMA = WF / "lifecycle-transition.schema.json"
+ADAPTER_PROFILE_SCHEMA = WF / "adapter-profile.schema.json"
+
+ADAPTER_FIXTURES = {
+    "topolvm": ADP / "topolvm.example.json",
+    "hypercore": ADP / "hypercore.example.json",
+    "s3": ADP / "s3.example.json",
+    "rsync": ADP / "rsync.example.json",
+    "drive": ADP / "drive.example.json",
+}
 
 
 def load(path: Path) -> dict:
@@ -63,6 +73,8 @@ def main() -> int:
         TOMBSTONE_SCHEMA,
         RECONCILE_SCHEMA,
         TRANSITION_SCHEMA,
+        ADAPTER_PROFILE_SCHEMA,
+        *ADAPTER_FIXTURES.values(),
     ]
     for path in required_paths:
         if not path.exists():
@@ -89,6 +101,8 @@ def main() -> int:
     tombstone_schema = load(TOMBSTONE_SCHEMA)
     reconcile_schema = load(RECONCILE_SCHEMA)
     transition_schema = load(TRANSITION_SCHEMA)
+    adapter_profile_schema = load(ADAPTER_PROFILE_SCHEMA)
+    adapter_profiles = {name: load(path) for name, path in ADAPTER_FIXTURES.items()}
 
     require_keys(req, req_schema["required"], "request fixture")
     require_keys(lease, lease_schema["required"], "lease fixture")
@@ -100,6 +114,9 @@ def main() -> int:
     require_keys(tombstone, tombstone_schema["required"], "tombstone decision fixture")
     require_keys(reconcile, reconcile_schema["required"], "reconcile-required fixture")
     require_keys(transition, transition_schema["required"], "transition fixture")
+
+    for name, profile in adapter_profiles.items():
+        require_keys(profile, adapter_profile_schema["required"], f"adapter profile {name}")
 
     require_keys(req["workspace"], ["cell", "id", "principal"], "request.workspace")
     require_keys(req["mount"], ["id", "backend", "authority_mode"], "request.mount")
@@ -170,6 +187,27 @@ def main() -> int:
         raise SystemExit("reconcile fixture must result in RECONCILE_REQUIRED")
     if transition["to_state"] == "RECONCILE_REQUIRED" and reconcile["correlation_id"] != transition["correlation_id"]:
         raise SystemExit("transition and reconcile fixture should share correlation_id in this fixture")
+
+    profile_names = set(adapter_profiles.keys())
+    if profile_names != {"topolvm", "hypercore", "s3", "rsync", "drive"}:
+        raise SystemExit(f"unexpected adapter profile set: {sorted(profile_names)}")
+
+    for name, profile in adapter_profiles.items():
+        if profile["default_authority_mode"] not in profile["allowed_authority_modes"]:
+            raise SystemExit(f"adapter profile {name} default_authority_mode not in allowed_authority_modes")
+
+    if adapter_profiles["topolvm"]["default_authority_mode"] != "local_first":
+        raise SystemExit("topolvm must default to local_first")
+    if "topic_distribution" not in adapter_profiles["hypercore"]["default_roles"]:
+        raise SystemExit("hypercore must advertise topic_distribution")
+    if "object_snapshot_replica" not in adapter_profiles["s3"]["default_roles"]:
+        raise SystemExit("s3 must advertise object_snapshot_replica")
+    if "bulk_sync" not in adapter_profiles["rsync"]["default_roles"]:
+        raise SystemExit("rsync must advertise bulk_sync")
+    if "compatibility_mirror" not in adapter_profiles["drive"]["default_roles"]:
+        raise SystemExit("drive must advertise compatibility_mirror")
+    if adapter_profiles["drive"]["default_authority_mode"] == "provider_first":
+        raise SystemExit("drive must not default to provider_first")
 
     print("workspace-fabric fixtures: OK")
     return 0


### PR DESCRIPTION
Adds the next implementation-facing tranche for `protocol/workspace-fabric/v0/`.

Files:
- `adapter-profile.schema.json`
- adapter profile fixtures for TopoLVM, Hypercore, S3, rsync, and Drive
- `.github/workflows/workspace-fabric.yml`
- validator extension for adapter profile coverage
- `VALIDATION.md` and `README.md` refresh

Intent:
Move the workspace-fabric slice from local-only fixture checks into adapter-specific profile coverage and automated validation in CI.