### PR TITLE
feat(emvi): add proof-slice smoke runner

### DIFF
--- a/protocol/emvi-proof-slice/v0/SMOKE.md
+++ b/protocol/emvi-proof-slice/v0/SMOKE.md
@@ -1,0 +1,20 @@
+# Proof Slice Smoke Runner
+
+Current lightweight path:
+
+```bash
+python3 tools/run_emvi_proof_slice_smoke.py
+```
+
+Outputs:
+- `artifacts/workspace/emvi-proof-slice/<timestamp>/demo-artifact.json`
+- `artifacts/workspace/emvi-proof-slice/<timestamp>/run-manifest.json`
+- copied fixture inputs for the run
+
+Behavior:
+1. validate merged fixtures via `tools/validate_emvi_proof_slice_fixtures.py`
+2. compose the demo artifact from the governed fixture inputs
+3. emit a small artifact bundle under `artifacts/workspace/`
+
+This remains synthetic by design. It gives the repo a stable execution-shaped
+artifact to target before the real proof-slice runtime exists.

--- a/protocol/emvi-proof-slice/v0/schemas/demo-artifact.schema.json
+++ b/protocol/emvi-proof-slice/v0/schemas/demo-artifact.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sociosphere.io/protocol/emvi-proof-slice/v0/schemas/demo-artifact.schema.json",
+  "title": "EMVI Proof Slice Demo Artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "generatedAt",
+    "protocolRef",
+    "actionSpec",
+    "events",
+    "summary"
+  ],
+  "properties": {
+    "kind": {"type": "string", "const": "EMVIProofSliceDemoArtifact"},
+    "generatedAt": {"type": "string", "format": "date-time"},
+    "protocolRef": {"type": "string"},
+    "actionSpec": {"type": "object"},
+    "events": {
+      "type": "array",
+      "items": {"type": "object"}
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["eventCount", "targetIds", "serviceFamilies", "correlationIds"],
+      "properties": {
+        "eventCount": {"type": "integer", "minimum": 0},
+        "targetIds": {"type": "array", "items": {"type": "string"}},
+        "serviceFamilies": {"type": "array", "items": {"type": "string"}},
+        "correlationIds": {"type": "array", "items": {"type": "string"}}
+      }
+    }
+  }
+}

--- a/tools/run_emvi_proof_slice_smoke.py
+++ b/tools/run_emvi_proof_slice_smoke.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Run a lightweight EMVI proof-slice smoke flow.
+
+This validates the merged proof-slice fixtures, composes the demo artifact from
+those fixtures, and emits a structured artifact bundle under artifacts/workspace.
+It is intentionally stdlib-only and does not attempt to execute the real shell or
+service families yet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTO = ROOT / "protocol" / "emvi-proof-slice" / "v0"
+ARTIFACT_ROOT = ROOT / "artifacts" / "workspace" / "emvi-proof-slice"
+VALIDATOR = ROOT / "tools" / "validate_emvi_proof_slice_fixtures.py"
+DEMO_RUNNER = ROOT / "tools" / "run_emvi_proof_slice_demo.py"
+
+
+def load_module(path: Path, module_name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def now_slug() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace(":", "-")
+
+
+def run_validation() -> None:
+    cp = subprocess.run([sys.executable, str(VALIDATOR)], cwd=str(ROOT), text=True)
+    if cp.returncode != 0:
+        raise SystemExit(cp.returncode)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", default="auto", help="Artifact directory or 'auto'")
+    args = parser.parse_args()
+
+    run_validation()
+
+    demo_mod = load_module(DEMO_RUNNER, "emvi_proof_slice_demo")
+    artifact = demo_mod.build_demo_artifact()
+
+    if args.output_dir == "auto":
+        out_dir = ARTIFACT_ROOT / now_slug()
+    else:
+        out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    artifact_path = out_dir / "demo-artifact.json"
+    write_json(artifact_path, artifact)
+
+    fixture_actionspec = PROTO / "fixtures" / "actionspec.example.json"
+    fixture_events = PROTO / "fixtures" / "events.example.jsonl"
+    shutil.copy2(fixture_actionspec, out_dir / fixture_actionspec.name)
+    shutil.copy2(fixture_events, out_dir / fixture_events.name)
+
+    manifest = {
+        "kind": "EMVIProofSliceSmokeRun",
+        "generatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "protocolRef": "protocol/emvi-proof-slice/v0",
+        "artifactPath": str(artifact_path.relative_to(ROOT)),
+        "copiedFixtures": [
+            str((out_dir / fixture_actionspec.name).relative_to(ROOT)),
+            str((out_dir / fixture_events.name).relative_to(ROOT)),
+        ],
+        "summary": artifact.get("summary", {}),
+    }
+    write_json(out_dir / "run-manifest.json", manifest)
+
+    print(f"OK: EMVI proof-slice smoke artifact bundle written to {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a stdlib-only smoke runner for the already-merged EMVI proof-slice protocol fixtures
- add a schema for the emitted demo artifact
- add a short run note explaining the current validate → emit-artifact path

## Files added
- `tools/run_emvi_proof_slice_smoke.py`
- `protocol/emvi-proof-slice/v0/schemas/demo-artifact.schema.json`
- `protocol/emvi-proof-slice/v0/SMOKE.md`

## Intent
This is a small implementation-facing increment that builds on the proof-slice protocol already on `main`. It does not mutate the merged protocol contracts; it gives the repo a stable smoke path that validates fixtures and emits one concrete artifact bundle under `artifacts/workspace/`.

## Non-goals
- does not patch the docs portal index
- does not execute the real shell or service families yet
- does not replace the merged validator or proof-slice protocol docs

## Follow-up
- optionally wire this smoke path into `tools/runner/runner.py` or a CI lane once the repo wants it
- replace the synthetic composition with real proof-slice execution in later increments
