### PR TITLE
feat(emvi): expose proof-slice smoke path in portal and workspace tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ merge-order:
 	python3 engines/propagation_engine.py merge-order
 
 # --- workspace runner targets ---
-.PHONY: workspace-list lock-verify lock-update inventory topology-check
+.PHONY: workspace-list lock-verify lock-update inventory topology-check proof-slice-smoke
 
 workspace-list:
 	python3 tools/runner/runner.py list
@@ -94,6 +94,9 @@ inventory:
 
 topology-check:
 	python3 tools/check_topology.py
+
+proof-slice-smoke:
+	python3 tools/runner/proof_slice_smoke.py
 
 # --- hygiene targets ---
 .PHONY: hygiene-check

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@
 
 ## Architecture
 - [Agentic workbench protocol v0](../protocol/agentic-workbench/v0/README.md)
+- [EMVI operator shell architecture](architecture/emvi/README.md)
+- [EMVI proof slice protocol v0](../protocol/emvi-proof-slice/v0/README.md)
 - [UI workbench app README](../apps/ui-workbench/README.md)
 - [Overview](architecture/overview.md)
 - [Upstream bindings — edge capabilities](architecture/upstream-bindings-edge-capabilities.md)

--- a/tools/runner/proof_slice_smoke.py
+++ b/tools/runner/proof_slice_smoke.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Workspace wrapper for the EMVI proof-slice smoke path.
+
+This keeps the EMVI smoke flow close to the canonical workspace runner/tooling
+surface even before `tools/runner/runner.py` gets a dedicated subcommand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = ROOT / "tools" / "validate_emvi_proof_slice_fixtures.py"
+SMOKE = ROOT / "tools" / "run_emvi_proof_slice_smoke.py"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", default="auto", help="Artifact output directory or 'auto'")
+    args = parser.parse_args()
+
+    cp = subprocess.run([sys.executable, str(VALIDATOR)], cwd=str(ROOT), text=True)
+    if cp.returncode != 0:
+        return cp.returncode
+
+    cmd = [sys.executable, str(SMOKE)]
+    if args.output_dir:
+        cmd.extend(["--output-dir", args.output_dir])
+    return subprocess.run(cmd, cwd=str(ROOT), text=True).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- expose the merged EMVI architecture subtree and proof-slice protocol from the main docs portal
- add a first-class `proof-slice-smoke` Make target
- add a small workspace wrapper under `tools/runner/` for the merged proof-slice smoke flow

## Files changed
- `docs/README.md`
- `Makefile`
- `tools/runner/proof_slice_smoke.py`

## Intent
This PR does not fight the repo’s current shape. The EMVI docs subtree and proof-slice protocol are already on `main`; this branch simply makes them discoverable from the docs portal and callable from the workspace tool surface without changing the merged proof-slice contracts.

## Non-goals
- does not change the already-merged EMVI architecture bundle
- does not change the already-merged proof-slice protocol contracts
- does not yet wire a dedicated subcommand into `tools/runner/runner.py`

## Follow-up
- optionally fold the wrapper into `tools/runner/runner.py` once the repo wants a dedicated subcommand
- advance the smoke path toward real proof-slice execution in later increments
