### PR TITLE
protocol(workspace-fabric): add policy and quorum decision schemas

### DIFF
--- a/protocol/workspace-fabric/v0/README.md
+++ b/protocol/workspace-fabric/v0/README.md
@@ -14,6 +14,8 @@ In scope for v0:
 - adapter role declaration
 - adapter profile fixtures
 - policy and quorum gating
+- policy decision artifacts
+- quorum decision artifacts
 - lease issuance
 - lease renewal and revocation requests
 - authority-transition request and decision artifacts
@@ -21,7 +23,7 @@ In scope for v0:
 - reconcile-required artifacts
 - lifecycle transition artifacts
 - evidence emission
-- machine-readable request, lease, evidence, lifecycle, reconcile, and adapter-profile schemas
+- machine-readable request, lease, evidence, lifecycle, reconcile, adapter-profile, policy, and quorum schemas
 - lightweight fixture validation
 - CI validation wiring
 
@@ -105,6 +107,8 @@ Machine-readable schemas:
 - `lease-revocation-request.schema.json`
 - `authority-transition-request.schema.json`
 - `authority-transition-decision.schema.json`
+- `policy-decision.schema.json`
+- `quorum-decision.schema.json`
 - `tombstone-decision.schema.json`
 - `reconcile-required.schema.json`
 - `lifecycle-transition.schema.json`
@@ -118,6 +122,8 @@ Fixtures:
 - `fixtures/lease-revocation-request.example.json`
 - `fixtures/authority-transition-request.example.json`
 - `fixtures/authority-transition-decision.example.json`
+- `fixtures/policy-decision.example.json`
+- `fixtures/quorum-decision.example.json`
 - `fixtures/tombstone-decision.example.json`
 - `fixtures/reconcile-required.example.json`
 - `fixtures/transition.example.json`

--- a/protocol/workspace-fabric/v0/VALIDATION.md
+++ b/protocol/workspace-fabric/v0/VALIDATION.md
@@ -18,11 +18,13 @@ This check currently validates:
 - the lease revocation request fixture shape
 - the authority-transition request fixture shape
 - the authority-transition decision fixture shape
+- the policy-decision fixture shape
+- the quorum-decision fixture shape
 - the tombstone decision fixture shape
 - the reconcile-required fixture shape
 - the lifecycle transition fixture shape
 - the adapter profile schema
 - the TopoLVM, Hypercore, S3, rsync, and Drive adapter profile fixtures
-- workspace, mount, authority, dataset, adapter, lease, quorum, state, and correlation consistency across the fixtures
+- workspace, mount, authority, dataset, adapter, lease, quorum, policy, state, and correlation consistency across the fixtures
 
 It is intentionally lightweight and dependency-free so the protocol slice can be checked in a bare workspace before a fuller schema-validation stack exists.

--- a/protocol/workspace-fabric/v0/fixtures/policy-decision.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/policy-decision.example.json
@@ -1,0 +1,13 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "MountPolicyDecision",
+  "workspace_ref": "ws-research",
+  "mount_ref": "topo-main",
+  "policy_bundle_ref": "policy/default",
+  "decision_status": "approved",
+  "policy_subject": "authority_transition",
+  "reason_codes": [
+    "remote_authority_promotion_allowed_with_quorum"
+  ],
+  "correlation_id": "reg-topo-main-20260418-003"
+}

--- a/protocol/workspace-fabric/v0/fixtures/quorum-decision.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/quorum-decision.example.json
@@ -1,0 +1,12 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "MountQuorumDecision",
+  "workspace_ref": "ws-research",
+  "mount_ref": "topo-main",
+  "quorum_profile": "local-owner-plus-1",
+  "decision_status": "granted",
+  "subject": "authority_transition",
+  "required_approvers": 2,
+  "granted_approvers": 2,
+  "correlation_id": "reg-topo-main-20260418-003"
+}

--- a/protocol/workspace-fabric/v0/policy-decision.schema.json
+++ b/protocol/workspace-fabric/v0/policy-decision.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/policy-decision.schema.json",
+  "title": "MountPolicyDecision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "kind",
+    "workspace_ref",
+    "mount_ref",
+    "policy_bundle_ref",
+    "decision_status",
+    "policy_subject",
+    "reason_codes",
+    "correlation_id"
+  ],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "MountPolicyDecision"},
+    "workspace_ref": {"type": "string", "minLength": 1},
+    "mount_ref": {"type": "string", "minLength": 1},
+    "policy_bundle_ref": {"type": "string", "minLength": 1},
+    "decision_status": {"enum": ["approved", "rejected", "conditional"]},
+    "policy_subject": {
+      "enum": [
+        "mount_registration",
+        "lease_renewal",
+        "lease_revocation",
+        "authority_transition",
+        "tombstone",
+        "reconcile"
+      ]
+    },
+    "reason_codes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "correlation_id": {"type": "string", "minLength": 1}
+  }
+}

--- a/protocol/workspace-fabric/v0/quorum-decision.schema.json
+++ b/protocol/workspace-fabric/v0/quorum-decision.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/quorum-decision.schema.json",
+  "title": "MountQuorumDecision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "kind",
+    "workspace_ref",
+    "mount_ref",
+    "quorum_profile",
+    "decision_status",
+    "subject",
+    "required_approvers",
+    "granted_approvers",
+    "correlation_id"
+  ],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "MountQuorumDecision"},
+    "workspace_ref": {"type": "string", "minLength": 1},
+    "mount_ref": {"type": "string", "minLength": 1},
+    "quorum_profile": {"type": "string", "minLength": 1},
+    "decision_status": {"enum": ["granted", "rejected", "not_required"]},
+    "subject": {
+      "enum": [
+        "authority_transition",
+        "tombstone_application",
+        "remote_authority_promotion",
+        "reconcile_resolution"
+      ]
+    },
+    "required_approvers": {"type": "integer", "minimum": 0},
+    "granted_approvers": {"type": "integer", "minimum": 0},
+    "correlation_id": {"type": "string", "minLength": 1}
+  }
+}

--- a/tools/validate_workspace_fabric_fixtures.py
+++ b/tools/validate_workspace_fabric_fixtures.py
@@ -16,6 +16,8 @@ RENEWAL = FIX / "lease-renewal-request.example.json"
 REVOCATION = FIX / "lease-revocation-request.example.json"
 AUTH_REQ = FIX / "authority-transition-request.example.json"
 AUTH_DEC = FIX / "authority-transition-decision.example.json"
+POLICY_DEC = FIX / "policy-decision.example.json"
+QUORUM_DEC = FIX / "quorum-decision.example.json"
 TOMBSTONE = FIX / "tombstone-decision.example.json"
 RECONCILE = FIX / "reconcile-required.example.json"
 TRANSITION = FIX / "transition.example.json"
@@ -27,6 +29,8 @@ RENEWAL_SCHEMA = WF / "lease-renewal-request.schema.json"
 REVOCATION_SCHEMA = WF / "lease-revocation-request.schema.json"
 AUTH_REQ_SCHEMA = WF / "authority-transition-request.schema.json"
 AUTH_DEC_SCHEMA = WF / "authority-transition-decision.schema.json"
+POLICY_DEC_SCHEMA = WF / "policy-decision.schema.json"
+QUORUM_DEC_SCHEMA = WF / "quorum-decision.schema.json"
 TOMBSTONE_SCHEMA = WF / "tombstone-decision.schema.json"
 RECONCILE_SCHEMA = WF / "reconcile-required.schema.json"
 TRANSITION_SCHEMA = WF / "lifecycle-transition.schema.json"
@@ -60,6 +64,8 @@ def main() -> int:
         REVOCATION,
         AUTH_REQ,
         AUTH_DEC,
+        POLICY_DEC,
+        QUORUM_DEC,
         TOMBSTONE,
         RECONCILE,
         TRANSITION,
@@ -70,6 +76,8 @@ def main() -> int:
         REVOCATION_SCHEMA,
         AUTH_REQ_SCHEMA,
         AUTH_DEC_SCHEMA,
+        POLICY_DEC_SCHEMA,
+        QUORUM_DEC_SCHEMA,
         TOMBSTONE_SCHEMA,
         RECONCILE_SCHEMA,
         TRANSITION_SCHEMA,
@@ -87,6 +95,8 @@ def main() -> int:
     revocation = load(REVOCATION)
     auth_req = load(AUTH_REQ)
     auth_dec = load(AUTH_DEC)
+    policy_dec = load(POLICY_DEC)
+    quorum_dec = load(QUORUM_DEC)
     tombstone = load(TOMBSTONE)
     reconcile = load(RECONCILE)
     transition = load(TRANSITION)
@@ -98,6 +108,8 @@ def main() -> int:
     revocation_schema = load(REVOCATION_SCHEMA)
     auth_req_schema = load(AUTH_REQ_SCHEMA)
     auth_dec_schema = load(AUTH_DEC_SCHEMA)
+    policy_dec_schema = load(POLICY_DEC_SCHEMA)
+    quorum_dec_schema = load(QUORUM_DEC_SCHEMA)
     tombstone_schema = load(TOMBSTONE_SCHEMA)
     reconcile_schema = load(RECONCILE_SCHEMA)
     transition_schema = load(TRANSITION_SCHEMA)
@@ -111,6 +123,8 @@ def main() -> int:
     require_keys(revocation, revocation_schema["required"], "revocation fixture")
     require_keys(auth_req, auth_req_schema["required"], "authority request fixture")
     require_keys(auth_dec, auth_dec_schema["required"], "authority decision fixture")
+    require_keys(policy_dec, policy_dec_schema["required"], "policy decision fixture")
+    require_keys(quorum_dec, quorum_dec_schema["required"], "quorum decision fixture")
     require_keys(tombstone, tombstone_schema["required"], "tombstone decision fixture")
     require_keys(reconcile, reconcile_schema["required"], "reconcile-required fixture")
     require_keys(transition, transition_schema["required"], "transition fixture")
@@ -151,6 +165,8 @@ def main() -> int:
         ("revocation", revocation),
         ("authority request", auth_req),
         ("authority decision", auth_dec),
+        ("policy decision", policy_dec),
+        ("quorum decision", quorum_dec),
         ("tombstone decision", tombstone),
         ("reconcile-required", reconcile),
         ("transition", transition),
@@ -178,6 +194,20 @@ def main() -> int:
             raise SystemExit("approved authority decision must grant quorum")
         if auth_dec["resulting_authority"] != auth_req["requested_authority"]:
             raise SystemExit("approved authority decision resulting_authority does not match requested_authority")
+
+    if policy_dec["policy_subject"] != "authority_transition":
+        raise SystemExit("policy decision fixture should target authority_transition in this slice")
+    if policy_dec["correlation_id"] != auth_req["correlation_id"]:
+        raise SystemExit("policy decision correlation_id does not match authority request")
+    if policy_dec["decision_status"] == "approved" and not policy_dec["reason_codes"]:
+        raise SystemExit("approved policy decision must carry reason codes")
+
+    if quorum_dec["subject"] != "authority_transition":
+        raise SystemExit("quorum decision fixture should target authority_transition in this slice")
+    if quorum_dec["correlation_id"] != auth_req["correlation_id"]:
+        raise SystemExit("quorum decision correlation_id does not match authority request")
+    if quorum_dec["decision_status"] == "granted" and quorum_dec["granted_approvers"] < quorum_dec["required_approvers"]:
+        raise SystemExit("granted quorum decision must satisfy required approver count")
 
     if tombstone["signed_tombstone"] and not tombstone["local_dirty"]:
         if tombstone["decision_status"] == "applied" and tombstone["resulting_state"] != "tombstoned":


### PR DESCRIPTION
Adds the next machine-readable policy/quorum tranche for `protocol/workspace-fabric/v0/`.

Files:
- `policy-decision.schema.json`
- `quorum-decision.schema.json`
- matching JSON fixtures
- validator extension for policy/quorum consistency against the existing authority-transition slice
- `VALIDATION.md` and `README.md` refresh

Intent:
Move the workspace-fabric slice beyond lifecycle and reconcile envelopes into explicit policy and quorum decision artifacts with lightweight executable validation.