### PR TITLE
governance: add SourceOS substrate boundary supplement

### DIFF
--- a/docs/SOURCEOS_SUBSTRATE_ALIGNMENT.md
+++ b/docs/SOURCEOS_SUBSTRATE_ALIGNMENT.md
@@ -1,0 +1,20 @@
+# SourceOS substrate alignment note
+
+This note explains the additive SourceOS/SociOS substrate boundary supplement added under `governance/SOURCEOS_SUBSTRATE_BOUNDARIES.yaml`.
+
+## Why this file exists
+
+Recent codification work landed in multiple upstream authorities:
+- `workspace-inventory` expanded the cross-org repo graph
+- `workstation-contracts` gained the first M2 runner↔adapter IPC pack
+- `sourceos-spec` gained the shared content/build/release object family
+- `socios` gained the first FCOS + Foreman/Katello automation scaffold
+- `SourceOS` gained the first artifact-truth scaffold for flavors, installer profiles, channels, and manifests
+
+The existing `governance/CANONICAL_SOURCES.yaml` remains authoritative.
+
+This note and the companion YAML file exist only to make the new substrate boundaries explicit without rewriting the canonical map in one risky pass.
+
+## Intended follow-on
+
+After review, the accepted namespace additions should be folded into `governance/CANONICAL_SOURCES.yaml` and the supplement can be removed.

--- a/governance/SOURCEOS_SUBSTRATE_BOUNDARIES.yaml
+++ b/governance/SOURCEOS_SUBSTRATE_BOUNDARIES.yaml
@@ -1,0 +1,58 @@
+# additive SourceOS/SociOS substrate boundary supplement
+# This file does not replace governance/CANONICAL_SOURCES.yaml.
+# It records the SourceOS build/provisioning boundaries codified during the
+# FCOS + Foreman/Katello substrate tranche and can be folded into the canonical
+# source map after review.
+
+namespaces:
+  sourceos/flavors:
+    canonical_repo: SourceOS
+    note: "Artifact-truth flavor definitions for SourceOS substrate families."
+
+  sourceos/cosa:
+    canonical_repo: SourceOS
+    note: "FCOS/coreos-assembler source material and image-composition inputs."
+
+  sourceos/butane:
+    canonical_repo: SourceOS
+    note: "Butane source fragments owned by the substrate artifact-truth lane."
+
+  sourceos/installer:
+    canonical_repo: SourceOS
+    note: "Installer profile definitions for live USB, PXE, and recovery surfaces."
+
+  sourceos/channels:
+    canonical_repo: SourceOS
+    note: "Release-channel declarations for SourceOS artifact families."
+
+  sourceos/manifests:
+    canonical_repo: SourceOS
+    note: "Artifact and release manifests owned by the substrate truth lane."
+
+  sourceos/automation:
+    canonical_repo: socios
+    note: "Opt-in automation commons around SourceOS build, publish, and provisioning."
+
+  sourceos/automation/build:
+    canonical_repo: socios
+    note: "Tekton execution scaffolds for FCOS/SourceOS build and customization lanes."
+
+  sourceos/automation/provisioning:
+    canonical_repo: socios
+    note: "Foreman/Katello and Smart Proxy automation around SourceOS artifacts."
+
+  sourceos/automation/gitops:
+    canonical_repo: socios
+    note: "Argo CD placement for Kubernetes-native automation services."
+
+  contracts/shared-content-build-release:
+    canonical_repo: sourceos-spec
+    note: "Shared cross-domain object family for content/build/release/evidence/catalog semantics."
+
+  protocol/execution/local-subprocess:
+    canonical_repo: workstation-contracts
+    note: "Local runner↔adapter subprocess contract (M2 IPC NDJSON pack)."
+
+  protocol/execution/remote-canonical:
+    canonical_repo: TriTRPC
+    note: "Canonical deterministic remote/authenticated transport authority."


### PR DESCRIPTION
## Summary

This PR adds a bounded, additive SourceOS/SociOS substrate boundary supplement for the current codification wave.

It does **not** replace `governance/CANONICAL_SOURCES.yaml`.
Instead, it records the new substrate/build/provisioning boundaries that were just codified across the upstream repos and gives the workspace-controller layer a review surface before those entries are folded into the canonical source map.

## What lands

### Machine-readable supplement
- `governance/SOURCEOS_SUBSTRATE_BOUNDARIES.yaml`

### Explanatory note
- `docs/SOURCEOS_SUBSTRATE_ALIGNMENT.md`

## Why this exists

The recent upstream codification wave added real work in several authorities:
- `workspace-inventory` cross-org graph expansion
- `workstation-contracts` M2 runner↔adapter IPC pack
- `sourceos-spec` shared content/build/release object family
- `socios` FCOS + Foreman/Katello substrate automation scaffold
- `SourceOS` artifact-truth scaffold for flavors / installer / channels / manifests

The existing `governance/CANONICAL_SOURCES.yaml` remains authoritative.

This PR makes those new boundaries explicit in `sociosphere` without doing a one-shot rewrite of the canonical source map.

## What the supplement covers

- `sourceos/flavors`
- `sourceos/cosa`
- `sourceos/butane`
- `sourceos/installer`
- `sourceos/channels`
- `sourceos/manifests`
- `sourceos/automation`
- `sourceos/automation/build`
- `sourceos/automation/provisioning`
- `sourceos/automation/gitops`
- `contracts/shared-content-build-release`
- `protocol/execution/local-subprocess`
- `protocol/execution/remote-canonical`

## Important boundary note

This PR is intentionally additive and temporary in posture.

If accepted, the intended follow-on is to fold the approved namespace additions into `governance/CANONICAL_SOURCES.yaml` and remove the supplement file.
