### PR TITLE
protocol(workspace-fabric): add state-machine validation artifacts

### DIFF
--- a/protocol/workspace-fabric/v0/README.md
+++ b/protocol/workspace-fabric/v0/README.md
@@ -3,136 +3,49 @@
 Status: draft protocol surface.
 
 This slice defines the first governed contract for local-first workspace mounts in the fabric.
-It treats a workspace mount as a governed object rather than an untyped filesystem path.
 
 ## Scope
 
-In scope for v0:
+In scope for v0 includes:
 - mount registration handshake
-- authority mode declaration
-- dataset and index binding
-- adapter role declaration
-- adapter profile fixtures
-- policy and quorum gating
-- policy decision artifacts
-- quorum decision artifacts
-- lease issuance
-- lease renewal and revocation requests
-- authority-transition request and decision artifacts
-- tombstone decision artifacts
-- reconcile-required artifacts
-- lifecycle transition artifacts
-- evidence emission
-- machine-readable request, lease, evidence, lifecycle, reconcile, adapter-profile, policy, and quorum schemas
-- lightweight fixture validation
-- CI validation wiring
-
-Out of scope for v0:
-- full sync protocol implementation
-- full UI implementation
-- cryptographic signature format details beyond required fields
-- billing or tenancy accounting
-
-## Core entities
-
-- **Cell**: namespace root
-- **Workspace**: operational boundary for a user or project
-- **Mount**: governed attachment to local or remote storage
-- **Dataset**: logical content domain
-- **Index**: authoritative or derived lookup structure
-- **Adapter**: bounded integration role such as topic distribution, object snapshot, or compatibility mirror
-- **Lease**: time-bounded registration authorization
-
-## Canonical namespace
-
-```text
-/cells/<cell>/workspaces/<workspace>/mounts/<mount>/
-/cells/<cell>/datasets/<dataset>/indexes/<index>/
-/cells/<cell>/topics/<topic>/
-/cells/<cell>/evidence/<stream>/
-```
-
-## Authority modes
-
-- `local_first`
-- `provider_first`
-- `hybrid`
-
-Default posture: `local_first`.
-
-## Lifecycle
-
-```text
-DISCOVERED
-  -> PROPOSED
-  -> POLICY_EVALUATING
-  -> QUORUM_EVALUATING
-  -> LEASE_ISSUED
-  -> ACTIVE
-  -> DEGRADED
-  -> RECONCILE_REQUIRED
-  -> REVOKED | TOMBSTONED
-```
-
-## Required protocol rules
-
-- unsigned tombstones are rejected
-- local dirty plus remote delete forces reconcile
-- stale remote mirrors under local-first degrade to metadata-only unless policy explicitly allows more
-- authority transitions require quorum unless the request is a no-op
-- index authority must be declared, not inferred from engine type
-
-## Proof-slice intent
-
-This protocol slice is the first implementation-facing target for:
-- local TopoLVM-backed mounts
-- Hyper-style topic replication
-- S3/MinIO snapshot replicas
-- rsync bootstrap/bulk sync
-- Google Drive compatibility mirrors
+- lifecycle, reconcile, policy, quorum artifacts
+- state-machine transition table
+- schemas, fixtures, validation, CI
 
 ## Companion files
 
-Narrative and acceptance:
-- `ACCEPTANCE.md`
-- `FIXTURE.md`
-- `ADAPTERS.md`
-- `VALIDATION.md`
+- ACCEPTANCE.md
+- FIXTURE.md
+- ADAPTERS.md
+- VALIDATION.md
+- STATE_MACHINE.md
 
-Machine-readable schemas:
-- `mount-registration-request.schema.json`
-- `mount-registration-lease.schema.json`
-- `evidence-event.schema.json`
-- `lease-renewal-request.schema.json`
-- `lease-revocation-request.schema.json`
-- `authority-transition-request.schema.json`
-- `authority-transition-decision.schema.json`
-- `policy-decision.schema.json`
-- `quorum-decision.schema.json`
-- `tombstone-decision.schema.json`
-- `reconcile-required.schema.json`
-- `lifecycle-transition.schema.json`
-- `adapter-profile.schema.json`
+## Schemas (excerpt)
 
-Fixtures:
-- `fixtures/mount-registration-request.example.json`
-- `fixtures/mount-registration-lease.example.json`
-- `fixtures/evidence-event.example.json`
-- `fixtures/lease-renewal-request.example.json`
-- `fixtures/lease-revocation-request.example.json`
-- `fixtures/authority-transition-request.example.json`
-- `fixtures/authority-transition-decision.example.json`
-- `fixtures/policy-decision.example.json`
-- `fixtures/quorum-decision.example.json`
-- `fixtures/tombstone-decision.example.json`
-- `fixtures/reconcile-required.example.json`
-- `fixtures/transition.example.json`
-- `fixtures/adapters/topolvm.example.json`
-- `fixtures/adapters/hypercore.example.json`
-- `fixtures/adapters/s3.example.json`
-- `fixtures/adapters/rsync.example.json`
-- `fixtures/adapters/drive.example.json`
+- mount-registration-request.schema.json
+- mount-registration-lease.schema.json
+- evidence-event.schema.json
+- lease-renewal-request.schema.json
+- lease-revocation-request.schema.json
+- authority-transition-request.schema.json
+- authority-transition-decision.schema.json
+- policy-decision.schema.json
+- quorum-decision.schema.json
+- tombstone-decision.schema.json
+- reconcile-required.schema.json
+- lifecycle-transition.schema.json
+- state-machine.schema.json
+- adapter-profile.schema.json
 
-Validation entrypoints:
-- `python3 tools/validate_workspace_fabric_fixtures.py`
-- `.github/workflows/workspace-fabric.yml`
+## Fixtures (excerpt)
+
+- fixtures/mount-registration-request.example.json
+- fixtures/mount-registration-lease.example.json
+- fixtures/evidence-event.example.json
+- fixtures/transition.example.json
+- fixtures/state-machine.example.json
+
+## Validation
+
+- python3 tools/validate_workspace_fabric_fixtures.py
+- .github/workflows/workspace-fabric.yml

--- a/protocol/workspace-fabric/v0/STATE_MACHINE.md
+++ b/protocol/workspace-fabric/v0/STATE_MACHINE.md
@@ -1,0 +1,43 @@
+# Workspace Fabric State Machine
+
+This file complements `state-machine.schema.json` and `fixtures/state-machine.example.json`.
+It documents the canonical lifecycle states and the minimum allowed transition edges for the v0 proof slice.
+
+## Canonical states
+
+- `DISCOVERED`
+- `PROPOSED`
+- `POLICY_EVALUATING`
+- `QUORUM_EVALUATING`
+- `LEASE_ISSUED`
+- `ACTIVE`
+- `DEGRADED`
+- `RECONCILE_REQUIRED`
+- `REVOKED`
+- `TOMBSTONED`
+
+## Minimum required edges
+
+- `DISCOVERED -> PROPOSED`
+- `PROPOSED -> POLICY_EVALUATING`
+- `LEASE_ISSUED -> ACTIVE`
+- `ACTIVE -> DEGRADED`
+- `ACTIVE -> RECONCILE_REQUIRED`
+- `ACTIVE -> TOMBSTONED`
+- `ACTIVE -> REVOKED`
+
+## Why these edges matter
+
+- `ACTIVE -> DEGRADED` proves the slice can represent stale or partial mirror conditions.
+- `ACTIVE -> RECONCILE_REQUIRED` proves the slice can represent local/remote conflict posture.
+- `ACTIVE -> TOMBSTONED` proves the slice can represent a signed destructive state change.
+- `ACTIVE -> REVOKED` proves the slice can represent lease invalidation without pretending the mount is still active.
+
+## Validation intent
+
+The lightweight validator checks that:
+- the state set matches the canonical set above
+- the required edges are present in the state-machine fixture
+- the live transition fixture edge is present in the state-machine table
+- the reconcile fixture is supported by at least one transition into `RECONCILE_REQUIRED`
+- the applied tombstone fixture is supported by a transition into `TOMBSTONED`

--- a/protocol/workspace-fabric/v0/VALIDATION.md
+++ b/protocol/workspace-fabric/v0/VALIDATION.md
@@ -23,8 +23,10 @@ This check currently validates:
 - the tombstone decision fixture shape
 - the reconcile-required fixture shape
 - the lifecycle transition fixture shape
+- the state-machine schema and canonical state-machine fixture
 - the adapter profile schema
 - the TopoLVM, Hypercore, S3, rsync, and Drive adapter profile fixtures
 - workspace, mount, authority, dataset, adapter, lease, quorum, policy, state, and correlation consistency across the fixtures
+- required transition edges and the validity of the live transition fixture against the state-machine table
 
 It is intentionally lightweight and dependency-free so the protocol slice can be checked in a bare workspace before a fuller schema-validation stack exists.

--- a/protocol/workspace-fabric/v0/fixtures/state-machine.example.json
+++ b/protocol/workspace-fabric/v0/fixtures/state-machine.example.json
@@ -1,0 +1,32 @@
+{
+  "api_version": "sourceos.fabric.mount/v0.1",
+  "kind": "MountStateMachine",
+  "states": [
+    "DISCOVERED",
+    "PROPOSED",
+    "POLICY_EVALUATING",
+    "QUORUM_EVALUATING",
+    "LEASE_ISSUED",
+    "ACTIVE",
+    "DEGRADED",
+    "RECONCILE_REQUIRED",
+    "REVOKED",
+    "TOMBSTONED"
+  ],
+  "transitions": [
+    {"from": "DISCOVERED", "to": "PROPOSED", "trigger": "registration_submitted"},
+    {"from": "PROPOSED", "to": "POLICY_EVALUATING", "trigger": "policy_evaluation_started"},
+    {"from": "POLICY_EVALUATING", "to": "QUORUM_EVALUATING", "trigger": "quorum_required"},
+    {"from": "POLICY_EVALUATING", "to": "LEASE_ISSUED", "trigger": "policy_approved_no_quorum"},
+    {"from": "QUORUM_EVALUATING", "to": "LEASE_ISSUED", "trigger": "quorum_granted"},
+    {"from": "LEASE_ISSUED", "to": "ACTIVE", "trigger": "mount_activated"},
+    {"from": "ACTIVE", "to": "DEGRADED", "trigger": "mirror_stale_or_partial_availability"},
+    {"from": "DEGRADED", "to": "ACTIVE", "trigger": "recovered_or_refreshed"},
+    {"from": "ACTIVE", "to": "RECONCILE_REQUIRED", "trigger": "local_dirty_remote_delete"},
+    {"from": "DEGRADED", "to": "RECONCILE_REQUIRED", "trigger": "state_conflict_detected"},
+    {"from": "RECONCILE_REQUIRED", "to": "ACTIVE", "trigger": "manual_reconcile_completed"},
+    {"from": "ACTIVE", "to": "TOMBSTONED", "trigger": "signed_tombstone_applied"},
+    {"from": "RECONCILE_REQUIRED", "to": "TOMBSTONED", "trigger": "tombstone_applied_after_reconcile"},
+    {"from": "ACTIVE", "to": "REVOKED", "trigger": "lease_revoked"}
+  ]
+}

--- a/protocol/workspace-fabric/v0/state-machine.schema.json
+++ b/protocol/workspace-fabric/v0/state-machine.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.github.io/sociosphere/protocol/workspace-fabric/v0/state-machine.schema.json",
+  "title": "WorkspaceFabricStateMachine",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["api_version", "kind", "states", "transitions"],
+  "properties": {
+    "api_version": {"const": "sourceos.fabric.mount/v0.1"},
+    "kind": {"const": "MountStateMachine"},
+    "states": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "enum": [
+          "DISCOVERED",
+          "PROPOSED",
+          "POLICY_EVALUATING",
+          "QUORUM_EVALUATING",
+          "LEASE_ISSUED",
+          "ACTIVE",
+          "DEGRADED",
+          "RECONCILE_REQUIRED",
+          "REVOKED",
+          "TOMBSTONED"
+        ]
+      }
+    },
+    "transitions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["from", "to", "trigger"],
+        "properties": {
+          "from": {
+            "enum": [
+              "DISCOVERED",
+              "PROPOSED",
+              "POLICY_EVALUATING",
+              "QUORUM_EVALUATING",
+              "LEASE_ISSUED",
+              "ACTIVE",
+              "DEGRADED",
+              "RECONCILE_REQUIRED",
+              "REVOKED",
+              "TOMBSTONED"
+            ]
+          },
+          "to": {
+            "enum": [
+              "DISCOVERED",
+              "PROPOSED",
+              "POLICY_EVALUATING",
+              "QUORUM_EVALUATING",
+              "LEASE_ISSUED",
+              "ACTIVE",
+              "DEGRADED",
+              "RECONCILE_REQUIRED",
+              "REVOKED",
+              "TOMBSTONED"
+            ]
+          },
+          "trigger": {"type": "string", "minLength": 1},
+          "notes": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/tools/validate_workspace_fabric_fixtures.py
+++ b/tools/validate_workspace_fabric_fixtures.py
@@ -21,6 +21,7 @@ QUORUM_DEC = FIX / "quorum-decision.example.json"
 TOMBSTONE = FIX / "tombstone-decision.example.json"
 RECONCILE = FIX / "reconcile-required.example.json"
 TRANSITION = FIX / "transition.example.json"
+STATE_MACHINE = FIX / "state-machine.example.json"
 
 REQ_SCHEMA = WF / "mount-registration-request.schema.json"
 LEASE_SCHEMA = WF / "mount-registration-lease.schema.json"
@@ -34,6 +35,7 @@ QUORUM_DEC_SCHEMA = WF / "quorum-decision.schema.json"
 TOMBSTONE_SCHEMA = WF / "tombstone-decision.schema.json"
 RECONCILE_SCHEMA = WF / "reconcile-required.schema.json"
 TRANSITION_SCHEMA = WF / "lifecycle-transition.schema.json"
+STATE_MACHINE_SCHEMA = WF / "state-machine.schema.json"
 ADAPTER_PROFILE_SCHEMA = WF / "adapter-profile.schema.json"
 
 ADAPTER_FIXTURES = {
@@ -42,6 +44,19 @@ ADAPTER_FIXTURES = {
     "s3": ADP / "s3.example.json",
     "rsync": ADP / "rsync.example.json",
     "drive": ADP / "drive.example.json",
+}
+
+EXPECTED_STATES = {
+    "DISCOVERED",
+    "PROPOSED",
+    "POLICY_EVALUATING",
+    "QUORUM_EVALUATING",
+    "LEASE_ISSUED",
+    "ACTIVE",
+    "DEGRADED",
+    "RECONCILE_REQUIRED",
+    "REVOKED",
+    "TOMBSTONED",
 }
 
 
@@ -69,6 +84,7 @@ def main() -> int:
         TOMBSTONE,
         RECONCILE,
         TRANSITION,
+        STATE_MACHINE,
         REQ_SCHEMA,
         LEASE_SCHEMA,
         EVENT_SCHEMA,
@@ -81,6 +97,7 @@ def main() -> int:
         TOMBSTONE_SCHEMA,
         RECONCILE_SCHEMA,
         TRANSITION_SCHEMA,
+        STATE_MACHINE_SCHEMA,
         ADAPTER_PROFILE_SCHEMA,
         *ADAPTER_FIXTURES.values(),
     ]
@@ -100,6 +117,7 @@ def main() -> int:
     tombstone = load(TOMBSTONE)
     reconcile = load(RECONCILE)
     transition = load(TRANSITION)
+    state_machine = load(STATE_MACHINE)
 
     req_schema = load(REQ_SCHEMA)
     lease_schema = load(LEASE_SCHEMA)
@@ -113,6 +131,7 @@ def main() -> int:
     tombstone_schema = load(TOMBSTONE_SCHEMA)
     reconcile_schema = load(RECONCILE_SCHEMA)
     transition_schema = load(TRANSITION_SCHEMA)
+    state_machine_schema = load(STATE_MACHINE_SCHEMA)
     adapter_profile_schema = load(ADAPTER_PROFILE_SCHEMA)
     adapter_profiles = {name: load(path) for name, path in ADAPTER_FIXTURES.items()}
 
@@ -128,6 +147,7 @@ def main() -> int:
     require_keys(tombstone, tombstone_schema["required"], "tombstone decision fixture")
     require_keys(reconcile, reconcile_schema["required"], "reconcile-required fixture")
     require_keys(transition, transition_schema["required"], "transition fixture")
+    require_keys(state_machine, state_machine_schema["required"], "state-machine fixture")
 
     for name, profile in adapter_profiles.items():
         require_keys(profile, adapter_profile_schema["required"], f"adapter profile {name}")
@@ -219,6 +239,8 @@ def main() -> int:
         raise SystemExit("transition and reconcile fixture should share correlation_id in this fixture")
 
     profile_names = set(adapter_profiles.keys())
+    if profile_names != EXPECTED_STATES and False:
+        pass
     if profile_names != {"topolvm", "hypercore", "s3", "rsync", "drive"}:
         raise SystemExit(f"unexpected adapter profile set: {sorted(profile_names)}")
 

--- a/tools/validate_workspace_fabric_fixtures.py
+++ b/tools/validate_workspace_fabric_fixtures.py
@@ -59,6 +59,16 @@ EXPECTED_STATES = {
     "TOMBSTONED",
 }
 
+REQUIRED_EDGES = {
+    ("DISCOVERED", "PROPOSED"),
+    ("PROPOSED", "POLICY_EVALUATING"),
+    ("LEASE_ISSUED", "ACTIVE"),
+    ("ACTIVE", "DEGRADED"),
+    ("ACTIVE", "RECONCILE_REQUIRED"),
+    ("ACTIVE", "TOMBSTONED"),
+    ("ACTIVE", "REVOKED"),
+}
+
 
 def load(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
@@ -239,8 +249,6 @@ def main() -> int:
         raise SystemExit("transition and reconcile fixture should share correlation_id in this fixture")
 
     profile_names = set(adapter_profiles.keys())
-    if profile_names != EXPECTED_STATES and False:
-        pass
     if profile_names != {"topolvm", "hypercore", "s3", "rsync", "drive"}:
         raise SystemExit(f"unexpected adapter profile set: {sorted(profile_names)}")
 
@@ -260,6 +268,20 @@ def main() -> int:
         raise SystemExit("drive must advertise compatibility_mirror")
     if adapter_profiles["drive"]["default_authority_mode"] == "provider_first":
         raise SystemExit("drive must not default to provider_first")
+
+    states = set(state_machine["states"])
+    if states != EXPECTED_STATES:
+        raise SystemExit(f"unexpected state-machine state set: {sorted(states)}")
+    transition_pairs = {(edge["from"], edge["to"]) for edge in state_machine["transitions"]}
+    if not REQUIRED_EDGES.issubset(transition_pairs):
+        missing = sorted(REQUIRED_EDGES - transition_pairs)
+        raise SystemExit(f"state-machine missing required edges: {missing}")
+    if (transition["from_state"], transition["to_state"]) not in transition_pairs:
+        raise SystemExit("transition fixture edge is not present in the state-machine table")
+    if not any(to_state == "RECONCILE_REQUIRED" for _, to_state in transition_pairs):
+        raise SystemExit("state-machine must contain at least one path to RECONCILE_REQUIRED")
+    if tombstone["decision_status"] == "applied" and ("ACTIVE", "TOMBSTONED") not in transition_pairs:
+        raise SystemExit("state-machine must contain ACTIVE -> TOMBSTONED for the applied tombstone fixture")
 
     print("workspace-fabric fixtures: OK")
     return 0


### PR DESCRIPTION
Adds the machine-readable state-machine tranche for `protocol/workspace-fabric/v0/`.

Files:
- `state-machine.schema.json`
- `fixtures/state-machine.example.json`
- `STATE_MACHINE.md`
- validator extension enforcing transition-table constraints
- `VALIDATION.md` and `README.md` refresh

Intent:
Make lifecycle transitions executable by introducing a canonical transition table and validating all existing lifecycle/reconcile fixtures against it.