### PR TITLE
Register prophet-platform build intelligence status delta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ validate-standards:
 	@ok=1; if [ -f tools/validate_adaptation_program.py ]; then python3 tools/validate_adaptation_program.py standards/examples/adaptation/program.example.v1.json || ok=0; else echo "ERR: tools/validate_adaptation_program.py missing"; ok=0; fi; if [ -f standards/qes/tools/validate_qes_contracts.py ]; then python3 standards/qes/tools/validate_qes_contracts.py || ok=0; else echo "WARN: standards/qes/tools/validate_qes_contracts.py missing (skipping)"; fi; test $$ok -eq 1
 
 # --- registry targets ---
-.PHONY: registry-validate ontology-validate dep-cycles mirror-drift-check
+.PHONY: registry-validate ontology-validate dep-cycles mirror-drift-check build-intelligence-validate
 
 mirror-drift-check:
 	python3 engines/mirror_drift_engine.py check
@@ -45,6 +45,9 @@ registry-validate:
 	@echo "==> Validating mirror drift status..."
 	python3 engines/mirror_drift_engine.py check
 	@echo "OK: registry-validate passed"
+
+build-intelligence-validate:
+	python3 tools/validate_build_intelligence.py
 
 ontology-validate: registry-validate
 
@@ -110,5 +113,5 @@ hygiene-check:
 # --- full workspace check (run in CI) ---
 .PHONY: workspace-check
 
-workspace-check: validate registry-validate compliance-check lock-verify topology-check hygiene-check
+workspace-check: validate registry-validate build-intelligence-validate compliance-check lock-verify topology-check hygiene-check
 	@echo "OK: workspace-check passed"

--- a/status/build-intelligence/prophet-platform-2026-04-25.yaml
+++ b/status/build-intelligence/prophet-platform-2026-04-25.yaml
@@ -1,0 +1,128 @@
+# status/build-intelligence/prophet-platform-2026-04-25.yaml
+# Purpose: Sociosphere awareness record for Prophet Platform build/test/deploy work.
+# This is an additive status delta, not a replacement for status/ecosystem-status.yaml.
+
+schema_version: "sociosphere.build-intelligence/v0.1"
+recorded_at: "2026-04-25T21:50:00Z"
+controller_repo: "SocioProphet/sociosphere"
+subject_repo: "SocioProphet/prophet-platform"
+status: "active"
+
+scope:
+  program: "Prophet Platform / Alexandrian Academy / Ops Fabric Integration"
+  lane: "deployment-topology-and-operations-intelligence"
+  intent: "Register platform build, test, release, and deployment topology changes in Sociosphere so workspace/repository intelligence remains aware of current implementation state."
+
+merged_tranches:
+  - pr: 178
+    title: "Add Prophet operations intelligence evidence slice"
+    merge_commit: "0ffe9cedf66c1afc133bc87f85d5568c6c926c80"
+    gates_closed:
+      - operations evidence schemas
+      - vendor-neutral normalizer
+      - operations evidence tests
+      - operator documentation
+    artifacts:
+      - "schemas/operations/prophet-operational-signal-v0.1.schema.json"
+      - "schemas/operations/prophet-runtime-topology-evidence-v0.1.schema.json"
+      - "schemas/operations/prophet-service-health-assessment-v0.1.schema.json"
+      - "schemas/operations/prophet-optimization-recommendation-v0.1.schema.json"
+      - "tools/normalize_prophet_operations_evidence.py"
+      - "tools/tests/test_normalize_prophet_operations_evidence.py"
+      - "docs/PROPHET_OPERATIONS_INTELLIGENCE.md"
+  - pr: 179
+    title: "Link operations recommendations to Policy Fabric decisions"
+    merge_commit: "7c2b5c369d44cfb7eea1eb06e52bf0cd26f1d106"
+    gates_closed:
+      - deterministic Policy Fabric decision refs
+      - evidence links from operations bundle to policy decision target
+      - checked-in example bundle
+      - tests enforcing decision refs and evidence links
+    artifacts:
+      - "tools/normalize_prophet_operations_evidence.py"
+      - "tools/tests/test_normalize_prophet_operations_evidence.py"
+      - "examples/operations/prophet_operations_evidence_bundle_with_policy_decision_links_0001.json"
+      - "docs/PROPHET_OPERATIONS_INTELLIGENCE.md"
+  - pr: 180
+    title: "Enforce operations policy decisions before action execution"
+    merge_commit: "ef4457814f81e55c0167ff766b5bd41ffa7d1777"
+    gates_closed:
+      - local action-blocking validator
+      - manual-review and allow decision examples
+      - tool tests wired into make validate
+      - pyyaml dependency fixed for existing FogStack tool tests
+      - post-merge main verification
+    artifacts:
+      - "tools/validate_prophet_operations_policy_decisions.py"
+      - "tools/tests/test_validate_prophet_operations_policy_decisions.py"
+      - "examples/operations/prophet_operations_action_decision_manual_review_0001.json"
+      - "examples/operations/prophet_operations_action_decision_allow_0001.json"
+      - "Makefile"
+      - "docs/PROPHET_OPERATIONS_INTELLIGENCE.md"
+
+active_tranches:
+  - pr: 181
+    title: "Wire academy bridge into ApplicationSet under fogstack.knowledge"
+    branch: "deploy/appset-academy-fogstack-knowledge-v0-1"
+    state: "open"
+    subject: "ArgoCD ApplicationSet deployment topology"
+    gates_completed:
+      - verified fogstack.knowledge bundle/release/manifest/rulepack/status artifacts exist
+      - verified ApplicationSet exists
+      - identified gap: ApplicationSet deployed api/gateway/web only
+      - reused existing Search Orchestrator Academy Bridge policy overlay
+      - added ApplicationSet entry for search-orchestrator-academy-bridge
+      - added bundle metadata: fogstack.knowledge
+      - extended deployment validator to require ApplicationSet + academy bridge + fogstack.knowledge
+    files_changed:
+      - "infra/k8s/argo-cd/appsets/socioprophet-appset.yaml"
+      - "tools/validate_search_orchestrator_academy_deploy.py"
+    pending_gates:
+      - CI/workflow pass
+      - merge
+      - post-merge main verification
+      - Sociosphere follow-up registration of final merge commit
+
+test_and_workflow_surfaces:
+  make_validate:
+    status: "updated"
+    notes: "Prophet Platform make validate now runs tools/tests through test-tools."
+    tool_test_dependencies:
+      - pytest
+      - pyyaml
+  relevant_workflows:
+    - "validate"
+    - "ci"
+    - "platform-contracts-check"
+    - "platform-wave1-stubs"
+    - "premerge-audit"
+    - "fogstack-validation"
+    - "fogstack-manifest-publication"
+    - "fogstack-manifest-promotion"
+
+software_review:
+  correctness:
+    - "Operations recommendations are now locally blocked unless a matching ProphetOperationsActionDecision with decision.outcome=allow exists."
+    - "ApplicationSet PR #181 reuses an existing validated Search Orchestrator overlay instead of creating a duplicate deployment path."
+  weaknesses:
+    - "prophet-platform structurally validates Policy Fabric decisions but does not yet import or pin the policy-fabric JSON Schema; cross-repo contract drift remains possible."
+    - "PR #181 proves repo-native deployment topology, not live ArgoCD reconciliation in a cluster."
+    - "Sociosphere ecosystem-status.yaml remains stale as of 2026-04-06; this file is a current delta, not a regenerated full snapshot."
+  next_hardening:
+    - "Add cross-repo Policy Fabric schema lock or vendored contract reference."
+    - "Finalize PR #181 and register final merge commit here."
+    - "Add Sociosphere validation for build-intelligence delta records."
+    - "Evaluate whether ApplicationSet should include explicit generators for bundle metadata beyond freeform element keys."
+
+running_backlog:
+  - "Finalize prophet-platform PR #181 CI/merge/main verification."
+  - "Register PR #181 final merge commit in Sociosphere."
+  - "Add Sociosphere validator for status/build-intelligence/*.yaml."
+  - "Create cross-repo contract lock for Policy Fabric operations action decision schema."
+  - "Verify Lampstand lifecycle integration against the handoff dossier."
+  - "Verify Policy Fabric live endpoint/service completeness."
+  - "Verify Alexandrian Academy repo state against platform deployment topology."
+  - "Decide whether deployment topology belongs in AppSet only or also Sociosphere workspace manifest."
+  - "Reconcile ecosystem-status.yaml stale snapshot with current repo/PR state."
+  - "Continue SourceOS/nlboot/control-plane specs after deployment-topology closure."
+  - "Maintain actor/generator/software-review format and gate-based progress reporting."

--- a/tools/validate_build_intelligence.py
+++ b/tools/validate_build_intelligence.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+STATUS_DIR = ROOT / "status" / "build-intelligence"
+REQUIRED_TOP_LEVEL = {
+    "schema_version",
+    "recorded_at",
+    "controller_repo",
+    "subject_repo",
+    "status",
+    "scope",
+    "merged_tranches",
+    "active_tranches",
+    "test_and_workflow_surfaces",
+    "software_review",
+    "running_backlog",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERR: {message}")
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        fail(f"{path.relative_to(ROOT)} did not parse to an object")
+    return data
+
+
+def require_non_empty_list(record: dict[str, Any], key: str, rel: str) -> None:
+    value = record.get(key)
+    if not isinstance(value, list) or not value:
+        fail(f"{rel} requires non-empty list at {key}")
+
+
+def validate_record(path: Path) -> None:
+    rel = str(path.relative_to(ROOT))
+    record = load_yaml(path)
+    missing = sorted(REQUIRED_TOP_LEVEL - set(record))
+    if missing:
+        fail(f"{rel} missing required keys: {', '.join(missing)}")
+
+    if record["schema_version"] != "sociosphere.build-intelligence/v0.1":
+        fail(f"{rel} has unsupported schema_version={record['schema_version']!r}")
+    if record["controller_repo"] != "SocioProphet/sociosphere":
+        fail(f"{rel} must be controlled by SocioProphet/sociosphere")
+    if not str(record["subject_repo"]).startswith("SocioProphet/"):
+        fail(f"{rel} subject_repo must be a SocioProphet repo")
+
+    require_non_empty_list(record, "merged_tranches", rel)
+    require_non_empty_list(record, "active_tranches", rel)
+    require_non_empty_list(record, "running_backlog", rel)
+
+    for tranche in record["merged_tranches"]:
+        if not isinstance(tranche, dict):
+            fail(f"{rel} merged_tranches entries must be objects")
+        for key in ("pr", "title", "merge_commit", "artifacts"):
+            if key not in tranche:
+                fail(f"{rel} merged tranche missing {key}")
+        if not isinstance(tranche["artifacts"], list) or not tranche["artifacts"]:
+            fail(f"{rel} merged tranche PR {tranche.get('pr')} requires artifacts")
+
+    for tranche in record["active_tranches"]:
+        if not isinstance(tranche, dict):
+            fail(f"{rel} active_tranches entries must be objects")
+        for key in ("pr", "title", "branch", "state", "files_changed", "pending_gates"):
+            if key not in tranche:
+                fail(f"{rel} active tranche missing {key}")
+        if tranche["state"] not in {"open", "draft", "merged", "blocked"}:
+            fail(f"{rel} active tranche PR {tranche.get('pr')} has invalid state={tranche['state']!r}")
+
+    review = record.get("software_review", {})
+    if not isinstance(review, dict):
+        fail(f"{rel} software_review must be an object")
+    for key in ("correctness", "weaknesses", "next_hardening"):
+        if not isinstance(review.get(key), list) or not review[key]:
+            fail(f"{rel} software_review.{key} must be a non-empty list")
+
+
+def main() -> int:
+    if not STATUS_DIR.exists():
+        fail("status/build-intelligence directory missing")
+    records = sorted(STATUS_DIR.glob("*.yaml"))
+    if not records:
+        fail("status/build-intelligence contains no yaml records")
+    for record in records:
+        validate_record(record)
+    print(json.dumps({"validated_build_intelligence_records": [str(p.relative_to(ROOT)) for p in records]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Registers current `SocioProphet/prophet-platform` build/test/deploy work in Sociosphere so the workspace/repository intelligence layer is aware of the platform changes already landed and the active deployment-topology PR.

This PR adds:
- `status/build-intelligence/prophet-platform-2026-04-25.yaml`
- `tools/validate_build_intelligence.py`

This PR updates:
- `Makefile` to add `build-intelligence-validate`
- `workspace-check` to include build-intelligence validation

## Why

Sociosphere owns the repository and build-intelligence workflow for the ecosystem. Recent `prophet-platform` work closed operations intelligence, Policy Fabric decision references, local action-blocking enforcement, and opened the ApplicationSet / `fogstack.knowledge` topology tranche. That state must be registered in Sociosphere rather than living only inside `prophet-platform` PRs.

## Registered platform work

Merged tranches:
- prophet-platform PR #178 — operations evidence slice
- prophet-platform PR #179 — Policy Fabric decision refs and evidence links
- prophet-platform PR #180 — local action-blocking decision enforcement

Active tranche:
- prophet-platform PR #181 — ApplicationSet wiring for Search Orchestrator Academy Bridge under `fogstack.knowledge`

## Software review

Correctness: the status delta is additive and does not overwrite the broad `ecosystem-status.yaml` snapshot. It records concrete PRs, merge commits, artifacts, tests/workflows, weaknesses, and next hardening work.

Risk: low. This is registry/status metadata plus validation. It does not alter runtime behavior.

Weakness: the record still depends on manual update for final PR #181 merge SHA. Follow-up should update this record after #181 merges and consider regenerating the full ecosystem status snapshot.

## Validation

`make workspace-check` now includes `build-intelligence-validate`, which validates all `status/build-intelligence/*.yaml` records for required fields, merged tranche artifact lists, active tranche pending gates, and explicit software-review sections.
