### PR TITLE
Register AppSet bundle bindings as deployment topology

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ validate-standards:
 	@ok=1; if [ -f tools/validate_adaptation_program.py ]; then python3 tools/validate_adaptation_program.py standards/examples/adaptation/program.example.v1.json || ok=0; else echo "ERR: tools/validate_adaptation_program.py missing"; ok=0; fi; if [ -f standards/qes/tools/validate_qes_contracts.py ]; then python3 standards/qes/tools/validate_qes_contracts.py || ok=0; else echo "WARN: standards/qes/tools/validate_qes_contracts.py missing (skipping)"; fi; test $$ok -eq 1
 
 # --- registry targets ---
-.PHONY: registry-validate ontology-validate dep-cycles mirror-drift-check build-intelligence-validate
+.PHONY: registry-validate ontology-validate dep-cycles mirror-drift-check build-intelligence-validate deployment-topology-validate
 
 mirror-drift-check:
 	python3 engines/mirror_drift_engine.py check
@@ -48,6 +48,9 @@ registry-validate:
 
 build-intelligence-validate:
 	python3 tools/validate_build_intelligence.py
+
+deployment-topology-validate:
+	python3 tools/validate_deployment_topology.py
 
 ontology-validate: registry-validate
 
@@ -113,5 +116,5 @@ hygiene-check:
 # --- full workspace check (run in CI) ---
 .PHONY: workspace-check
 
-workspace-check: validate registry-validate build-intelligence-validate compliance-check lock-verify topology-check hygiene-check
+workspace-check: validate registry-validate build-intelligence-validate deployment-topology-validate compliance-check lock-verify topology-check hygiene-check
 	@echo "OK: workspace-check passed"

--- a/registry/deployment-topology/prophet-platform-appset-bundle-bindings-v0.1.yaml
+++ b/registry/deployment-topology/prophet-platform-appset-bundle-bindings-v0.1.yaml
@@ -1,0 +1,87 @@
+# registry/deployment-topology/prophet-platform-appset-bundle-bindings-v0.1.yaml
+# Purpose: typed Sociosphere deployment-topology record for Prophet Platform ArgoCD ApplicationSet bundle bindings.
+
+schema_version: "sociosphere.deployment-topology/v0.1"
+recorded_at: "2026-04-25T22:20:00Z"
+controller_repo: "SocioProphet/sociosphere"
+subject_repo: "SocioProphet/prophet-platform"
+status: "active"
+
+source_prs:
+  - repo: "SocioProphet/prophet-platform"
+    pr: 181
+    merge_commit: "7402547d9a3e684ac051945177763060b1f5aff4"
+  - repo: "SocioProphet/sociosphere"
+    pr: 163
+    merge_commit: "da14a5b712b353e6956ce059e7e581c518f25bec"
+  - repo: "SocioProphet/sociosphere"
+    pr: 164
+    merge_commit: "a4ddd094c5b1466414c85ac2b496d3ac93f7b67e"
+
+deployment_surfaces:
+  - id: "prophet-platform.argocd.appset.socioprophet"
+    kind: "ArgoCDApplicationSet"
+    repo: "SocioProphet/prophet-platform"
+    path: "infra/k8s/argo-cd/appsets/socioprophet-appset.yaml"
+    namespace: "argocd"
+    destination_namespace: "socioprophet"
+    target_revision: "main"
+    sync_policy:
+      automated: true
+      prune: true
+      self_heal: true
+      create_namespace: true
+    applications:
+      - name: "socioprophet-api"
+        path: "apps/api/kustomize/overlays/dev"
+        bundle: null
+        role: "platform-api"
+      - name: "socioprophet-gateway"
+        path: "apps/gateway/kustomize/overlays/dev"
+        bundle: null
+        role: "platform-gateway"
+      - name: "socioprophet-web"
+        path: "apps/socioprophet-web/kustomize/overlays/dev"
+        bundle: null
+        role: "platform-web"
+      - name: "search-orchestrator-academy-bridge"
+        path: "infra/k8s/search-orchestrator/overlays/policy"
+        bundle: "fogstack.knowledge"
+        role: "academy-search-bridge"
+        required_validation:
+          - "tools/validate_search_orchestrator_academy_deploy.py"
+        release_artifacts:
+          - "releases/manifests/search-orchestrator.academy-bridge.manifest.json"
+          - "releases/evidence/search-orchestrator.academy-bridge.validation.record.json"
+        bundle_artifacts:
+          - "bundles/fogstack.knowledge-v0.1.yaml"
+          - "releases/fogstack.knowledge-v0.1.release.json"
+          - "releases/manifests/fogstack.knowledge-v0.1.manifest.json"
+          - "conformance/rulepacks/fogstack.knowledge-v0.1.yaml"
+
+required_invariants:
+  - id: "appset-has-academy-bridge"
+    statement: "The socioprophet ApplicationSet must include search-orchestrator-academy-bridge."
+    enforced_by:
+      - "SocioProphet/prophet-platform:tools/validate_search_orchestrator_academy_deploy.py"
+      - "SocioProphet/sociosphere:tools/validate_deployment_topology.py"
+  - id: "academy-bridge-bound-to-fogstack-knowledge"
+    statement: "The search-orchestrator-academy-bridge ApplicationSet element must carry bundle=fogstack.knowledge."
+    enforced_by:
+      - "SocioProphet/prophet-platform:tools/validate_search_orchestrator_academy_deploy.py"
+      - "SocioProphet/sociosphere:tools/validate_deployment_topology.py"
+  - id: "deployment-topology-owned-by-sociosphere"
+    statement: "Sociosphere records deployment topology and build intelligence for platform AppSet bundle bindings."
+    enforced_by:
+      - "SocioProphet/sociosphere:tools/validate_deployment_topology.py"
+
+software_review:
+  correctness:
+    - "Records the exact AppSet path and application element created by prophet-platform PR #181."
+    - "Binds search-orchestrator-academy-bridge to fogstack.knowledge as typed Sociosphere topology data rather than freeform platform-local context only."
+  weaknesses:
+    - "This still does not prove live ArgoCD reconciliation in a cluster."
+    - "This record mirrors platform facts but does not fetch/parse the platform AppSet directly yet."
+  next_hardening:
+    - "Add cross-repo or vendored verification that the platform AppSet file still matches this topology record."
+    - "Add live-cluster reconciliation evidence once an ArgoCD environment is available."

--- a/tools/validate_deployment_topology.py
+++ b/tools/validate_deployment_topology.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+TOPOLOGY_DIR = ROOT / "registry" / "deployment-topology"
+REQUIRED_TOP_LEVEL = {
+    "schema_version",
+    "recorded_at",
+    "controller_repo",
+    "subject_repo",
+    "status",
+    "source_prs",
+    "deployment_surfaces",
+    "required_invariants",
+    "software_review",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERR: {message}")
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        fail(f"{path.relative_to(ROOT)} did not parse to an object")
+    return data
+
+
+def require_non_empty_list(record: dict[str, Any], key: str, rel: str) -> list[Any]:
+    value = record.get(key)
+    if not isinstance(value, list) or not value:
+        fail(f"{rel} requires non-empty list at {key}")
+    return value
+
+
+def validate_application(app: dict[str, Any], rel: str) -> None:
+    for key in ("name", "path", "role"):
+        if key not in app:
+            fail(f"{rel} application entry missing {key}")
+    if app["name"] == "search-orchestrator-academy-bridge":
+        if app.get("bundle") != "fogstack.knowledge":
+            fail(f"{rel} academy bridge must bind bundle=fogstack.knowledge")
+        if app.get("path") != "infra/k8s/search-orchestrator/overlays/policy":
+            fail(f"{rel} academy bridge must target policy overlay")
+        for key in ("required_validation", "release_artifacts", "bundle_artifacts"):
+            if not isinstance(app.get(key), list) or not app[key]:
+                fail(f"{rel} academy bridge requires non-empty {key}")
+
+
+def validate_surface(surface: dict[str, Any], rel: str) -> None:
+    for key in ("id", "kind", "repo", "path", "namespace", "destination_namespace", "target_revision", "applications"):
+        if key not in surface:
+            fail(f"{rel} deployment surface missing {key}")
+    if surface["kind"] != "ArgoCDApplicationSet":
+        fail(f"{rel} unsupported deployment surface kind={surface['kind']!r}")
+    if surface["repo"] != "SocioProphet/prophet-platform":
+        fail(f"{rel} currently supports prophet-platform surfaces only")
+    apps = surface["applications"]
+    if not isinstance(apps, list) or not apps:
+        fail(f"{rel} deployment surface requires non-empty applications list")
+    names = {app.get("name") for app in apps if isinstance(app, dict)}
+    if "search-orchestrator-academy-bridge" not in names:
+        fail(f"{rel} missing search-orchestrator-academy-bridge application")
+    for app in apps:
+        if not isinstance(app, dict):
+            fail(f"{rel} application entries must be objects")
+        validate_application(app, rel)
+
+
+def validate_record(path: Path) -> None:
+    rel = str(path.relative_to(ROOT))
+    record = load_yaml(path)
+    missing = sorted(REQUIRED_TOP_LEVEL - set(record))
+    if missing:
+        fail(f"{rel} missing required keys: {', '.join(missing)}")
+    if record["schema_version"] != "sociosphere.deployment-topology/v0.1":
+        fail(f"{rel} has unsupported schema_version={record['schema_version']!r}")
+    if record["controller_repo"] != "SocioProphet/sociosphere":
+        fail(f"{rel} must be controlled by SocioProphet/sociosphere")
+    if record["subject_repo"] != "SocioProphet/prophet-platform":
+        fail(f"{rel} subject_repo must be SocioProphet/prophet-platform")
+
+    source_prs = require_non_empty_list(record, "source_prs", rel)
+    if not any(item.get("repo") == "SocioProphet/prophet-platform" and item.get("pr") == 181 for item in source_prs if isinstance(item, dict)):
+        fail(f"{rel} must reference prophet-platform PR 181")
+
+    for surface in require_non_empty_list(record, "deployment_surfaces", rel):
+        if not isinstance(surface, dict):
+            fail(f"{rel} deployment_surfaces entries must be objects")
+        validate_surface(surface, rel)
+
+    invariants = require_non_empty_list(record, "required_invariants", rel)
+    invariant_ids = {item.get("id") for item in invariants if isinstance(item, dict)}
+    for required in {"appset-has-academy-bridge", "academy-bridge-bound-to-fogstack-knowledge", "deployment-topology-owned-by-sociosphere"}:
+        if required not in invariant_ids:
+            fail(f"{rel} missing required invariant {required}")
+
+    review = record.get("software_review", {})
+    if not isinstance(review, dict):
+        fail(f"{rel} software_review must be an object")
+    for key in ("correctness", "weaknesses", "next_hardening"):
+        if not isinstance(review.get(key), list) or not review[key]:
+            fail(f"{rel} software_review.{key} must be a non-empty list")
+
+
+def main() -> int:
+    if not TOPOLOGY_DIR.exists():
+        fail("registry/deployment-topology directory missing")
+    records = sorted(TOPOLOGY_DIR.glob("*.yaml"))
+    if not records:
+        fail("registry/deployment-topology contains no yaml records")
+    for record in records:
+        validate_record(record)
+    print(json.dumps({"validated_deployment_topology_records": [str(p.relative_to(ROOT)) for p in records]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a typed Sociosphere deployment-topology record for `prophet-platform` ArgoCD ApplicationSet bundle bindings.

This PR adds:
- `registry/deployment-topology/prophet-platform-appset-bundle-bindings-v0.1.yaml`
- `tools/validate_deployment_topology.py`

This PR updates:
- `Makefile` with `deployment-topology-validate`
- `workspace-check` to include deployment-topology validation

## Why

`prophet-platform` PR #181 added `search-orchestrator-academy-bridge` to the ArgoCD ApplicationSet and bound it to `fogstack.knowledge`. Sociosphere needs this as typed deployment topology, not only as freeform platform-local YAML.

## Software review

Correctness: the record references the exact platform PR #181 merge, the AppSet path, the `search-orchestrator-academy-bridge` element, its policy overlay path, and the `fogstack.knowledge` bundle binding.

Risk: low. This is metadata and validation only. No runtime deployment manifests are changed.

Weakness: this still mirrors platform state rather than parsing the platform AppSet directly. Cross-repo verification remains a next hardening step.

## Validation

`make workspace-check` now includes `deployment-topology-validate`, which validates deployment-topology records under `registry/deployment-topology/*.yaml`.
