### PR TITLE
Pin platform AppSet source lock in deployment topology

### DIFF
--- a/registry/deployment-topology/prophet-platform-appset-bundle-bindings-v0.1.yaml
+++ b/registry/deployment-topology/prophet-platform-appset-bundle-bindings-v0.1.yaml
@@ -2,7 +2,7 @@
 # Purpose: typed Sociosphere deployment-topology record for Prophet Platform ArgoCD ApplicationSet bundle bindings.
 
 schema_version: "sociosphere.deployment-topology/v0.1"
-recorded_at: "2026-04-25T22:20:00Z"
+recorded_at: "2026-04-25T22:28:00Z"
 controller_repo: "SocioProphet/sociosphere"
 subject_repo: "SocioProphet/prophet-platform"
 status: "active"
@@ -17,6 +17,9 @@ source_prs:
   - repo: "SocioProphet/sociosphere"
     pr: 164
     merge_commit: "a4ddd094c5b1466414c85ac2b496d3ac93f7b67e"
+  - repo: "SocioProphet/sociosphere"
+    pr: 165
+    merge_commit: "d18318fb66778c46d567f3361c89544725911e88"
 
 deployment_surfaces:
   - id: "prophet-platform.argocd.appset.socioprophet"
@@ -26,6 +29,16 @@ deployment_surfaces:
     namespace: "argocd"
     destination_namespace: "socioprophet"
     target_revision: "main"
+    source_lock:
+      ref: "main"
+      github_blob_sha: "34fa8e7629cd086b6c5a1a6b77f6354fe27d6226"
+      sha256: "caba8b802d4af00c5f6cedf24cc4c81034d43ce1bca84c0e7627415ab64f987e"
+      captured_at: "2026-04-25T22:28:00Z"
+      required_terms:
+        - "kind: ApplicationSet"
+        - "search-orchestrator-academy-bridge"
+        - "infra/k8s/search-orchestrator/overlays/policy"
+        - "bundle: fogstack.knowledge"
     sync_policy:
       automated: true
       prune: true
@@ -74,14 +87,19 @@ required_invariants:
     statement: "Sociosphere records deployment topology and build intelligence for platform AppSet bundle bindings."
     enforced_by:
       - "SocioProphet/sociosphere:tools/validate_deployment_topology.py"
+  - id: "platform-appset-source-lock"
+    statement: "Sociosphere records the observed platform ApplicationSet blob SHA and SHA-256 digest for drift detection."
+    enforced_by:
+      - "SocioProphet/sociosphere:tools/validate_deployment_topology.py"
 
 software_review:
   correctness:
     - "Records the exact AppSet path and application element created by prophet-platform PR #181."
     - "Binds search-orchestrator-academy-bridge to fogstack.knowledge as typed Sociosphere topology data rather than freeform platform-local context only."
+    - "Pins the observed platform AppSet blob SHA and SHA-256 digest for source-lock drift detection."
   weaknesses:
     - "This still does not prove live ArgoCD reconciliation in a cluster."
-    - "This record mirrors platform facts but does not fetch/parse the platform AppSet directly yet."
+    - "This record pins the observed source artifact but does not yet fetch/parse prophet-platform during Sociosphere CI."
   next_hardening:
-    - "Add cross-repo or vendored verification that the platform AppSet file still matches this topology record."
+    - "Add connector-backed or vendored artifact verification that recomputes this digest from the platform AppSet file."
     - "Add live-cluster reconciliation evidence once an ArgoCD environment is available."

--- a/tools/validate_deployment_topology.py
+++ b/tools/validate_deployment_topology.py
@@ -19,6 +19,7 @@ REQUIRED_TOP_LEVEL = {
     "required_invariants",
     "software_review",
 }
+REQUIRED_SOURCE_LOCK_KEYS = {"ref", "github_blob_sha", "sha256", "captured_at", "required_terms"}
 
 
 def fail(message: str) -> None:
@@ -37,6 +38,29 @@ def require_non_empty_list(record: dict[str, Any], key: str, rel: str) -> list[A
     if not isinstance(value, list) or not value:
         fail(f"{rel} requires non-empty list at {key}")
     return value
+
+
+def validate_source_lock(surface: dict[str, Any], rel: str) -> None:
+    source_lock = surface.get("source_lock")
+    if not isinstance(source_lock, dict):
+        fail(f"{rel} deployment surface {surface.get('id')} requires source_lock")
+    missing = sorted(REQUIRED_SOURCE_LOCK_KEYS - set(source_lock))
+    if missing:
+        fail(f"{rel} source_lock missing required keys: {', '.join(missing)}")
+    if source_lock["ref"] != "main":
+        fail(f"{rel} source_lock.ref must be main")
+    blob_sha = str(source_lock["github_blob_sha"])
+    if len(blob_sha) != 40 or not all(ch in "0123456789abcdef" for ch in blob_sha.lower()):
+        fail(f"{rel} source_lock.github_blob_sha must be a 40-character hex SHA")
+    sha256 = str(source_lock["sha256"])
+    if len(sha256) != 64 or not all(ch in "0123456789abcdef" for ch in sha256.lower()):
+        fail(f"{rel} source_lock.sha256 must be a 64-character hex SHA-256")
+    required_terms = source_lock["required_terms"]
+    if not isinstance(required_terms, list) or not required_terms:
+        fail(f"{rel} source_lock.required_terms must be a non-empty list")
+    for term in ("kind: ApplicationSet", "search-orchestrator-academy-bridge", "infra/k8s/search-orchestrator/overlays/policy", "bundle: fogstack.knowledge"):
+        if term not in required_terms:
+            fail(f"{rel} source_lock.required_terms missing {term!r}")
 
 
 def validate_application(app: dict[str, Any], rel: str) -> None:
@@ -61,6 +85,7 @@ def validate_surface(surface: dict[str, Any], rel: str) -> None:
         fail(f"{rel} unsupported deployment surface kind={surface['kind']!r}")
     if surface["repo"] != "SocioProphet/prophet-platform":
         fail(f"{rel} currently supports prophet-platform surfaces only")
+    validate_source_lock(surface, rel)
     apps = surface["applications"]
     if not isinstance(apps, list) or not apps:
         fail(f"{rel} deployment surface requires non-empty applications list")
@@ -97,7 +122,7 @@ def validate_record(path: Path) -> None:
 
     invariants = require_non_empty_list(record, "required_invariants", rel)
     invariant_ids = {item.get("id") for item in invariants if isinstance(item, dict)}
-    for required in {"appset-has-academy-bridge", "academy-bridge-bound-to-fogstack-knowledge", "deployment-topology-owned-by-sociosphere"}:
+    for required in {"appset-has-academy-bridge", "academy-bridge-bound-to-fogstack-knowledge", "deployment-topology-owned-by-sociosphere", "platform-appset-source-lock"}:
         if required not in invariant_ids:
             fail(f"{rel} missing required invariant {required}")
 


### PR DESCRIPTION
## Summary

Hardens the Sociosphere deployment-topology record for the `prophet-platform` ApplicationSet binding by adding a pinned source lock for the observed platform AppSet artifact.

This PR updates:
- `registry/deployment-topology/prophet-platform-appset-bundle-bindings-v0.1.yaml`
- `tools/validate_deployment_topology.py`

## What changes

Adds `source_lock` metadata for `SocioProphet/prophet-platform:infra/k8s/argo-cd/appsets/socioprophet-appset.yaml`:

- `ref: main`
- GitHub blob SHA `34fa8e7629cd086b6c5a1a6b77f6354fe27d6226`
- SHA-256 `caba8b802d4af00c5f6cedf24cc4c81034d43ce1bca84c0e7627415ab64f987e`
- required source terms:
  - `kind: ApplicationSet`
  - `search-orchestrator-academy-bridge`
  - `infra/k8s/search-orchestrator/overlays/policy`
  - `bundle: fogstack.knowledge`

The validator now requires source-lock fields, validates SHA shapes, and requires the AppSet/fogstack terms.

## Software review

Correctness: improves Sociosphere topology from mirrored record to pinned source observation, making platform AppSet drift visible in topology metadata.

Risk: low. Metadata and validation only. No platform runtime or deployment manifest is modified.

Weakness: still does not fetch `prophet-platform` during CI to recompute the digest. That should be a later connector-backed or vendored-artifact check.
