### PR TITLE
Vendor platform AppSet snapshot for topology lock validation

### DIFF
--- a/registry/deployment-topology/prophet-platform-appset-bundle-bindings-v0.1.yaml
+++ b/registry/deployment-topology/prophet-platform-appset-bundle-bindings-v0.1.yaml
@@ -2,7 +2,7 @@
 # Purpose: typed Sociosphere deployment-topology record for Prophet Platform ArgoCD ApplicationSet bundle bindings.
 
 schema_version: "sociosphere.deployment-topology/v0.1"
-recorded_at: "2026-04-25T22:28:00Z"
+recorded_at: "2026-04-25T22:40:00Z"
 controller_repo: "SocioProphet/sociosphere"
 subject_repo: "SocioProphet/prophet-platform"
 status: "active"
@@ -20,6 +20,9 @@ source_prs:
   - repo: "SocioProphet/sociosphere"
     pr: 165
     merge_commit: "d18318fb66778c46d567f3361c89544725911e88"
+  - repo: "SocioProphet/sociosphere"
+    pr: 166
+    merge_commit: "bd6388cddf4be9fd0fc0b827d282498937579dc4"
 
 deployment_surfaces:
   - id: "prophet-platform.argocd.appset.socioprophet"
@@ -33,7 +36,8 @@ deployment_surfaces:
       ref: "main"
       github_blob_sha: "34fa8e7629cd086b6c5a1a6b77f6354fe27d6226"
       sha256: "caba8b802d4af00c5f6cedf24cc4c81034d43ce1bca84c0e7627415ab64f987e"
-      captured_at: "2026-04-25T22:28:00Z"
+      captured_at: "2026-04-25T22:40:00Z"
+      local_snapshot: "registry/deployment-topology/source-locks/prophet-platform/socioprophet-appset.yaml"
       required_terms:
         - "kind: ApplicationSet"
         - "search-orchestrator-academy-bridge"
@@ -91,15 +95,20 @@ required_invariants:
     statement: "Sociosphere records the observed platform ApplicationSet blob SHA and SHA-256 digest for drift detection."
     enforced_by:
       - "SocioProphet/sociosphere:tools/validate_deployment_topology.py"
+  - id: "platform-appset-local-snapshot-lock"
+    statement: "Sociosphere vendors a local snapshot of the observed platform ApplicationSet and recomputes SHA-256 during validation."
+    enforced_by:
+      - "SocioProphet/sociosphere:tools/validate_deployment_topology.py"
 
 software_review:
   correctness:
     - "Records the exact AppSet path and application element created by prophet-platform PR #181."
     - "Binds search-orchestrator-academy-bridge to fogstack.knowledge as typed Sociosphere topology data rather than freeform platform-local context only."
     - "Pins the observed platform AppSet blob SHA and SHA-256 digest for source-lock drift detection."
+    - "References a vendored local snapshot so Sociosphere CI can recompute the AppSet SHA-256 without reaching across repositories."
   weaknesses:
     - "This still does not prove live ArgoCD reconciliation in a cluster."
-    - "This record pins the observed source artifact but does not yet fetch/parse prophet-platform during Sociosphere CI."
+    - "The vendored snapshot can itself drift from the upstream platform file unless refreshed by process or a connector-backed check."
   next_hardening:
-    - "Add connector-backed or vendored artifact verification that recomputes this digest from the platform AppSet file."
+    - "Add connector-backed verification that refreshes the vendored snapshot from prophet-platform."
     - "Add live-cluster reconciliation evidence once an ArgoCD environment is available."

--- a/registry/deployment-topology/source-locks/prophet-platform/socioprophet-appset.yaml
+++ b/registry/deployment-topology/source-locks/prophet-platform/socioprophet-appset.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: socioprophet
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - name: socioprophet-api
+            path: apps/api/kustomize/overlays/dev
+          - name: socioprophet-gateway
+            path: apps/gateway/kustomize/overlays/dev
+          - name: socioprophet-web
+            path: apps/socioprophet-web/kustomize/overlays/dev
+          - name: search-orchestrator-academy-bridge
+            path: infra/k8s/search-orchestrator/overlays/policy
+            bundle: fogstack.knowledge
+  template:
+    metadata:
+      name: '{{name}}'
+    spec:
+      project: default
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: socioprophet
+      source:
+        repoURL: https://github.com/SocioProphet/prophet-platform.git
+        targetRevision: main
+        path: '{{path}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true

--- a/tools/validate_deployment_topology.py
+++ b/tools/validate_deployment_topology.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
@@ -19,11 +20,15 @@ REQUIRED_TOP_LEVEL = {
     "required_invariants",
     "software_review",
 }
-REQUIRED_SOURCE_LOCK_KEYS = {"ref", "github_blob_sha", "sha256", "captured_at", "required_terms"}
+REQUIRED_SOURCE_LOCK_KEYS = {"ref", "github_blob_sha", "sha256", "captured_at", "required_terms", "local_snapshot"}
 
 
 def fail(message: str) -> None:
     raise SystemExit(f"ERR: {message}")
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def load_yaml(path: Path) -> dict[str, Any]:
@@ -52,15 +57,27 @@ def validate_source_lock(surface: dict[str, Any], rel: str) -> None:
     blob_sha = str(source_lock["github_blob_sha"])
     if len(blob_sha) != 40 or not all(ch in "0123456789abcdef" for ch in blob_sha.lower()):
         fail(f"{rel} source_lock.github_blob_sha must be a 40-character hex SHA")
-    sha256 = str(source_lock["sha256"])
-    if len(sha256) != 64 or not all(ch in "0123456789abcdef" for ch in sha256.lower()):
+    expected_sha256 = str(source_lock["sha256"])
+    if len(expected_sha256) != 64 or not all(ch in "0123456789abcdef" for ch in expected_sha256.lower()):
         fail(f"{rel} source_lock.sha256 must be a 64-character hex SHA-256")
+
+    snapshot_rel = str(source_lock["local_snapshot"])
+    snapshot_path = ROOT / snapshot_rel
+    if not snapshot_path.exists():
+        fail(f"{rel} source_lock.local_snapshot missing file: {snapshot_rel}")
+    actual_sha256 = sha256_file(snapshot_path)
+    if actual_sha256 != expected_sha256:
+        fail(f"{rel} source_lock sha256 mismatch for {snapshot_rel}: expected {expected_sha256}, got {actual_sha256}")
+    snapshot_text = snapshot_path.read_text(encoding="utf-8")
+
     required_terms = source_lock["required_terms"]
     if not isinstance(required_terms, list) or not required_terms:
         fail(f"{rel} source_lock.required_terms must be a non-empty list")
     for term in ("kind: ApplicationSet", "search-orchestrator-academy-bridge", "infra/k8s/search-orchestrator/overlays/policy", "bundle: fogstack.knowledge"):
         if term not in required_terms:
             fail(f"{rel} source_lock.required_terms missing {term!r}")
+        if term not in snapshot_text:
+            fail(f"{rel} source_lock local snapshot missing required term {term!r}")
 
 
 def validate_application(app: dict[str, Any], rel: str) -> None:
@@ -122,7 +139,7 @@ def validate_record(path: Path) -> None:
 
     invariants = require_non_empty_list(record, "required_invariants", rel)
     invariant_ids = {item.get("id") for item in invariants if isinstance(item, dict)}
-    for required in {"appset-has-academy-bridge", "academy-bridge-bound-to-fogstack-knowledge", "deployment-topology-owned-by-sociosphere", "platform-appset-source-lock"}:
+    for required in {"appset-has-academy-bridge", "academy-bridge-bound-to-fogstack-knowledge", "deployment-topology-owned-by-sociosphere", "platform-appset-source-lock", "platform-appset-local-snapshot-lock"}:
         if required not in invariant_ids:
             fail(f"{rel} missing required invariant {required}")
 


### PR DESCRIPTION
## Summary

Vendors the observed `prophet-platform` ApplicationSet snapshot into Sociosphere and makes deployment-topology validation recompute the local snapshot SHA-256.

This PR adds:
- `registry/deployment-topology/source-locks/prophet-platform/socioprophet-appset.yaml`

This PR updates:
- `registry/deployment-topology/prophet-platform-appset-bundle-bindings-v0.1.yaml`
- `tools/validate_deployment_topology.py`

## What changes

The topology record now includes:
- `source_lock.local_snapshot`
- `platform-appset-local-snapshot-lock` invariant

The validator now:
- requires `local_snapshot`
- verifies the snapshot file exists
- recomputes SHA-256 from the local snapshot
- fails if the snapshot digest differs from the recorded `source_lock.sha256`
- checks required terms inside the snapshot itself

## Software review

Correctness: this closes the previous weakness where Sociosphere only validated that a digest was recorded. Sociosphere now validates that its vendored platform AppSet snapshot matches the recorded digest and contains the expected ApplicationSet / academy bridge / `fogstack.knowledge` terms.

Risk: low. Metadata/snapshot/validation only; no runtime deployment files are modified.

Remaining weakness: the vendored snapshot can still drift from upstream `prophet-platform` unless refreshed by process or a connector-backed check. Next hardening should automate refresh or verify upstream directly.
