### PR TITLE
Add Policy Fabric schema contract lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ validate-standards:
 	@ok=1; if [ -f tools/validate_adaptation_program.py ]; then python3 tools/validate_adaptation_program.py standards/examples/adaptation/program.example.v1.json || ok=0; else echo "ERR: tools/validate_adaptation_program.py missing"; ok=0; fi; if [ -f standards/qes/tools/validate_qes_contracts.py ]; then python3 standards/qes/tools/validate_qes_contracts.py || ok=0; else echo "WARN: standards/qes/tools/validate_qes_contracts.py missing (skipping)"; fi; test $$ok -eq 1
 
 # --- registry targets ---
-.PHONY: registry-validate ontology-validate dep-cycles mirror-drift-check build-intelligence-validate deployment-topology-validate
+.PHONY: registry-validate ontology-validate dep-cycles mirror-drift-check build-intelligence-validate deployment-topology-validate contract-lock-validate
 
 mirror-drift-check:
 	python3 engines/mirror_drift_engine.py check
@@ -51,6 +51,9 @@ build-intelligence-validate:
 
 deployment-topology-validate:
 	python3 tools/validate_deployment_topology.py
+
+contract-lock-validate:
+	python3 tools/validate_contract_locks.py
 
 ontology-validate: registry-validate
 
@@ -116,5 +119,5 @@ hygiene-check:
 # --- full workspace check (run in CI) ---
 .PHONY: workspace-check
 
-workspace-check: validate registry-validate build-intelligence-validate deployment-topology-validate compliance-check lock-verify topology-check hygiene-check
+workspace-check: validate registry-validate build-intelligence-validate deployment-topology-validate contract-lock-validate compliance-check lock-verify topology-check hygiene-check
 	@echo "OK: workspace-check passed"

--- a/registry/contract-locks/policy-fabric/prophet_operations_action_decision_v1.lock.yaml
+++ b/registry/contract-locks/policy-fabric/prophet_operations_action_decision_v1.lock.yaml
@@ -1,0 +1,57 @@
+schema_version: "sociosphere.contract-lock/v0.1"
+recorded_at: "2026-04-25T23:35:00Z"
+controller_repo: "SocioProphet/sociosphere"
+upstream_repo: "SocioProphet/policy-fabric"
+consumer_repo: "SocioProphet/prophet-platform"
+status: "active"
+
+contract:
+  name: "ProphetOperationsActionDecision"
+  version: "v1"
+  upstream_path: "contracts/prophet_operations_action_decision_v1.schema.json"
+  consumer_path: "schemas/external/policy-fabric/prophet_operations_action_decision_v1.schema.json"
+  local_snapshot: "registry/contract-locks/policy-fabric/prophet_operations_action_decision_v1.schema.json"
+  github_blob_sha: "1e45630d1b05044833de9a67679ed74a4014ae44"
+  sha256: "8f6d46e018f69d3bd277bcc554745b6b6bbc46bd9f9f24f20d292c5980a73730"
+  required_terms:
+    - "ProphetOperationsActionDecision"
+    - "schema_version"
+    - "recommendation_ref"
+    - "policy_refs"
+    - "manual_review"
+    - "allow"
+    - "deny"
+
+source_prs:
+  - repo: "SocioProphet/policy-fabric"
+    pr: 25
+    purpose: "introduced ProphetOperationsActionDecision schema"
+  - repo: "SocioProphet/prophet-platform"
+    pr: 182
+    merge_commit: "d4c39f1ea43700eb748d405f665746da021dc15a"
+    purpose: "vendored and enforced Policy Fabric schema in platform validator"
+  - repo: "SocioProphet/sociosphere"
+    pr: 168
+    merge_commit: "913c54fb62911cb74f2ed8463dc7ebd347e45121"
+    purpose: "registered platform schema-lock tranche in build intelligence"
+
+validation:
+  validator: "tools/validate_contract_locks.py"
+  checks:
+    - "lock required fields"
+    - "local snapshot exists"
+    - "local snapshot SHA-256 equals lock sha256"
+    - "required terms exist inside local snapshot"
+    - "consumer path is recorded for platform schema-lock traceability"
+
+software_review:
+  correctness:
+    - "Records upstream Policy Fabric schema identity and digest in Sociosphere."
+    - "Binds the upstream policy-fabric contract to the prophet-platform vendored consumer path."
+    - "Gives Sociosphere a local snapshot for CI-runnable digest verification."
+  weaknesses:
+    - "This does not fetch policy-fabric live during CI; it validates the vendored snapshot lock."
+    - "The lock must be refreshed when policy-fabric intentionally changes the contract."
+  next_hardening:
+    - "Add connector-backed refresh check against policy-fabric main."
+    - "Add platform-side schema digest metadata to compare consumer vendored schema with Sociosphere lock."

--- a/registry/contract-locks/policy-fabric/prophet_operations_action_decision_v1.schema.json
+++ b/registry/contract-locks/policy-fabric/prophet_operations_action_decision_v1.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/prophet_operations_action_decision_v1.schema.json",
+  "title": "ProphetOperationsActionDecision",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "decision_id",
+    "decided_at",
+    "recommendation_ref",
+    "decision",
+    "basis"
+  ],
+  "properties": {
+    "kind": { "const": "ProphetOperationsActionDecision" },
+    "schema_version": { "const": "v1" },
+    "decision_id": { "type": "string", "minLength": 1 },
+    "decided_at": { "type": "string", "minLength": 1 },
+    "recommendation_ref": { "type": "string", "minLength": 1 },
+    "subject": {
+      "type": "object",
+      "properties": {
+        "id": { "type": ["string", "null"] },
+        "type": { "type": ["string", "null"] },
+        "name": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "proposed_action": {
+      "type": "object",
+      "properties": {
+        "type": { "type": ["string", "null"] },
+        "intent": { "type": ["string", "null"] },
+        "description": { "type": ["string", "null"] },
+        "parameters": { "type": "object", "additionalProperties": true }
+      },
+      "additionalProperties": true
+    },
+    "decision": {
+      "type": "object",
+      "required": ["outcome"],
+      "properties": {
+        "outcome": { "enum": ["allow", "deny", "manual_review", "defer", "unknown"] },
+        "reason": { "type": ["string", "null"] },
+        "risk_level": { "enum": ["low", "medium", "high", "critical", "unknown"] },
+        "expires_at": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "basis": {
+      "type": "object",
+      "required": ["policy_refs"],
+      "properties": {
+        "policy_refs": { "type": "array", "items": { "type": "string" } },
+        "health_assessment_ref": { "type": ["string", "null"] },
+        "topology_ref": { "type": ["string", "null"] },
+        "signal_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "evidence_refs": { "type": "array", "items": { "type": "string" }, "default": [] }
+      },
+      "additionalProperties": true
+    },
+    "controls": {
+      "type": "object",
+      "properties": {
+        "requires_human_approval": { "type": "boolean", "default": false },
+        "requires_change_window": { "type": "boolean", "default": false },
+        "max_execution_scope": { "type": ["string", "null"] },
+        "rollback_required": { "type": "boolean", "default": false }
+      },
+      "additionalProperties": true
+    },
+    "audit": {
+      "type": "object",
+      "properties": {
+        "actor": { "type": ["string", "null"] },
+        "mode": { "enum": ["automated", "human", "hybrid", "unknown"] },
+        "notes": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/tools/validate_contract_locks.py
+++ b/tools/validate_contract_locks.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCK_DIR = ROOT / "registry" / "contract-locks"
+REQUIRED_TOP_LEVEL = {
+    "schema_version",
+    "recorded_at",
+    "controller_repo",
+    "upstream_repo",
+    "consumer_repo",
+    "status",
+    "contract",
+    "source_prs",
+    "validation",
+    "software_review",
+}
+REQUIRED_CONTRACT_KEYS = {
+    "name",
+    "version",
+    "upstream_path",
+    "consumer_path",
+    "local_snapshot",
+    "github_blob_sha",
+    "sha256",
+    "required_terms",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERR: {message}")
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        fail(f"{path.relative_to(ROOT)} did not parse to an object")
+    return data
+
+
+def validate_hex(value: str, expected_len: int, label: str, rel: str) -> None:
+    if len(value) != expected_len or not all(ch in "0123456789abcdef" for ch in value.lower()):
+        fail(f"{rel} {label} must be {expected_len} hex characters")
+
+
+def validate_record(path: Path) -> None:
+    rel = str(path.relative_to(ROOT))
+    record = load_yaml(path)
+    missing = sorted(REQUIRED_TOP_LEVEL - set(record))
+    if missing:
+        fail(f"{rel} missing required keys: {', '.join(missing)}")
+    if record["schema_version"] != "sociosphere.contract-lock/v0.1":
+        fail(f"{rel} has unsupported schema_version={record['schema_version']!r}")
+    if record["controller_repo"] != "SocioProphet/sociosphere":
+        fail(f"{rel} must be controlled by SocioProphet/sociosphere")
+    if record["upstream_repo"] != "SocioProphet/policy-fabric":
+        fail(f"{rel} upstream_repo must be SocioProphet/policy-fabric")
+    if record["consumer_repo"] != "SocioProphet/prophet-platform":
+        fail(f"{rel} consumer_repo must be SocioProphet/prophet-platform")
+
+    contract = record["contract"]
+    if not isinstance(contract, dict):
+        fail(f"{rel} contract must be an object")
+    missing_contract = sorted(REQUIRED_CONTRACT_KEYS - set(contract))
+    if missing_contract:
+        fail(f"{rel} contract missing required keys: {', '.join(missing_contract)}")
+    if contract["name"] != "ProphetOperationsActionDecision":
+        fail(f"{rel} unexpected contract.name={contract['name']!r}")
+    if contract["version"] != "v1":
+        fail(f"{rel} unexpected contract.version={contract['version']!r}")
+
+    validate_hex(str(contract["github_blob_sha"]), 40, "contract.github_blob_sha", rel)
+    expected_sha256 = str(contract["sha256"])
+    validate_hex(expected_sha256, 64, "contract.sha256", rel)
+
+    snapshot_rel = str(contract["local_snapshot"])
+    snapshot_path = ROOT / snapshot_rel
+    if not snapshot_path.exists():
+        fail(f"{rel} contract.local_snapshot missing file: {snapshot_rel}")
+    actual_sha256 = sha256_file(snapshot_path)
+    if actual_sha256 != expected_sha256:
+        fail(f"{rel} local snapshot sha256 mismatch: expected {expected_sha256}, got {actual_sha256}")
+    snapshot_text = snapshot_path.read_text(encoding="utf-8")
+
+    required_terms = contract["required_terms"]
+    if not isinstance(required_terms, list) or not required_terms:
+        fail(f"{rel} contract.required_terms must be a non-empty list")
+    for term in required_terms:
+        if term not in snapshot_text:
+            fail(f"{rel} local snapshot missing required term {term!r}")
+
+    source_prs = record["source_prs"]
+    if not isinstance(source_prs, list) or not source_prs:
+        fail(f"{rel} source_prs must be a non-empty list")
+    if not any(isinstance(item, dict) and item.get("repo") == "SocioProphet/prophet-platform" and item.get("pr") == 182 for item in source_prs):
+        fail(f"{rel} must reference prophet-platform PR 182")
+
+    review = record.get("software_review", {})
+    if not isinstance(review, dict):
+        fail(f"{rel} software_review must be an object")
+    for key in ("correctness", "weaknesses", "next_hardening"):
+        if not isinstance(review.get(key), list) or not review[key]:
+            fail(f"{rel} software_review.{key} must be a non-empty list")
+
+
+def main() -> int:
+    if not LOCK_DIR.exists():
+        fail("registry/contract-locks directory missing")
+    records = sorted(LOCK_DIR.glob("**/*.lock.yaml"))
+    if not records:
+        fail("registry/contract-locks contains no lock records")
+    for record in records:
+        validate_record(record)
+    print(json.dumps({"validated_contract_locks": [str(p.relative_to(ROOT)) for p in records]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a Sociosphere contract lock for the Policy Fabric `ProphetOperationsActionDecision` schema consumed by `prophet-platform`.

This PR adds:
- `registry/contract-locks/policy-fabric/prophet_operations_action_decision_v1.schema.json`
- `registry/contract-locks/policy-fabric/prophet_operations_action_decision_v1.lock.yaml`
- `tools/validate_contract_locks.py`

This PR updates:
- `Makefile` with `contract-lock-validate`
- `workspace-check` to include contract-lock validation

## Why

`prophet-platform` PR #182 vendors and enforces the Policy Fabric operations action decision schema. Sociosphere must track that upstream/consumer contract relationship so drift risk is explicit and locally validated.

## Software review

Correctness: the lock records upstream repo/path/blob SHA, SHA-256, local snapshot, consumer path, source PRs, and required terms. The validator recomputes the local snapshot SHA-256 and fails if it differs from the lock.

Risk: low. Metadata, snapshot, and validation only. No runtime behavior changes.

Weakness: this still does not fetch `policy-fabric/main` live during CI. Next hardening is connector-backed refresh/check against upstream.
