### PR TITLE
Add source exposure governance gate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -53,6 +53,10 @@ jobs:
 
       - name: Repository hygiene check
         run: bash tools/check_hygiene.sh
+
+      - name: Source exposure check
+        run: make source-exposure-check
+
       - name: UI install
         run: make ui-install
 

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,14 @@ compliance-check:
 compliance-summary:
 	python3 telemetry/compliance_checker.py summary --format json
 
+# --- source exposure governance targets ---
+.PHONY: source-exposure-check
+
+source-exposure-check:
+	@echo "==> Running source exposure publication safety check..."
+	python3 tools/check_source_exposure.py
+	@echo "OK: source-exposure-check passed"
+
 # --- merge order ---
 .PHONY: merge-order
 
@@ -119,5 +127,5 @@ hygiene-check:
 # --- full workspace check (run in CI) ---
 .PHONY: workspace-check
 
-workspace-check: validate registry-validate build-intelligence-validate deployment-topology-validate contract-lock-validate compliance-check lock-verify topology-check hygiene-check
+workspace-check: validate registry-validate build-intelligence-validate deployment-topology-validate contract-lock-validate compliance-check source-exposure-check lock-verify topology-check hygiene-check
 	@echo "OK: workspace-check passed"

--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 Platform meta-workspace controller for the SocioProphet ecosystem.
 
 Sociosphere owns the canonical workspace manifest + lock, runner semantics,
-protocol fixtures, and deterministic multi-repo materialization for platform
-build and validation lanes.
+protocol fixtures, deterministic multi-repo materialization, source-exposure
+governance, and validation lanes for platform build and release readiness.
 
 ## Governance references
 
 - [Repository topology and dependency rules](docs/TOPOLOGY.md) — canonical source for repo roles, directionality, and the submodule update playbook.
 - [Naming and versioning policy](docs/NAMING_VERSIONING.md) — single source of truth for repo naming, SemVer discipline, and submodule pin-bump rules.
+- [Source Exposure Governance Standard](standards/source-exposure/README.md) — publication-safety rules for public source, public release mirrors, inner-source development, and restricted security/operations material.
 
 ## Canonical scope
 
@@ -20,6 +21,7 @@ Sociosphere is responsible for:
 - Materializing and validating the workspace with `tools/runner/runner.py`.
 - Enforcing topology and dependency-direction policies via `tools/check_topology.py`.
 - Maintaining cross-repo governance and registry metadata in `registry/` + `governance/`.
+- Validating source-exposure publication safety with `tools/check_source_exposure.py`.
 
 Sociosphere is **not** the place for feature implementation inside downstream
 component repositories.
@@ -32,6 +34,7 @@ component repositories.
 - Scope/current state/backlog: `docs/SCOPE_PURPOSE_STATUS_BACKLOG.md`
 - Integration ledger: `docs/INTEGRATION_STATUS.md`
 - Namespace ownership map: `governance/CANONICAL_SOURCES.yaml`
+- Source exposure standard: `standards/source-exposure/README.md`
 
 ## Repository intelligence assets
 
@@ -56,6 +59,15 @@ component repositories.
 | `engines/devops_orchestrator.py` | Build/test/deploy orchestration |
 | `engines/metrics_collector.py` | Runtime and coverage metrics |
 
+### Standards and policy layer
+
+| File | Description |
+|---|---|
+| `standards/qes/README.md` | Quality Evidence Standard |
+| `standards/source-exposure/README.md` | Source Exposure Governance Standard |
+| `standards/source-exposure/policy.v0.json` | Machine-readable source-exposure policy |
+| `standards/source-exposure/schemas/source_exposure_report.v1.json` | Source exposure report schema |
+
 ### CLI tools
 
 ```bash
@@ -66,6 +78,10 @@ python cli/validate-deps.py
 
 # Upstream drift checks
 python3 tools/check_upstream_edge_capabilities.py
+
+# Source exposure publication safety
+python3 tools/check_source_exposure.py
+make source-exposure-check
 
 # Success and dedup reporting
 python cli/measure-success.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@
 
 ## Standards
 - [QES (Quality Evidence Standard)](../standards/qes/README.md)
+- [Source Exposure Governance Standard](../standards/source-exposure/README.md)
 - [Adaptation README](standards/adaptation/README.md)
 
 ## Governance

--- a/standards/source-exposure/README.md
+++ b/standards/source-exposure/README.md
@@ -1,0 +1,91 @@
+# Source Exposure Governance Standard v0.1
+
+## Purpose
+
+This standard controls what Sociosphere and downstream platform repositories may publish in public source, public release mirrors, community inner-source repositories, and restricted security/operations channels.
+
+The goal is not secrecy for its own sake. The goal is to prevent public repositories from becoming a live, machine-readable attack graph against our own running systems while preserving auditable MIT-licensed release source, public standards, provenance, SBOMs, and security accountability.
+
+## Core rule
+
+Public source is allowed only after it is no longer privileged reconnaissance against our live systems.
+
+Code visibility must never expose:
+
+- current production topology;
+- exact deployed commit/version mapping for live services;
+- credentials, private keys, tokens, cookies, tenant identifiers, or customer context;
+- unresolved exploitable security defects;
+- exploit reproduction material before a patched release exists;
+- raw telemetry, HAR, packet capture, or log material that reveals live service structure;
+- CI/CD permissions, deployment paths, or operational gaps that enable a kill chain.
+
+## Visibility tiers
+
+| Tier | Meaning | Examples |
+|---|---|---|
+| `public_trust` | Public trust-building material that is safe before and after release. | Stable specs, high-level architecture, security policy, public governance, non-sensitive threat model summaries. |
+| `public_release_mirror` | Hardened release snapshots that passed publication gates. | Tagged source releases, SBOMs, VEX, provenance, signed artifacts. |
+| `community_inner_source` | Active development visible only to governed platform/community participants. | Work-in-progress implementation, unreleased branches, CI implementation details, non-sensitive test fixtures. |
+| `restricted_security` | Security material requiring limited access and explicit disclosure handling. | Vulnerability reports, exploit repros, fuzz crashers, detection gaps, private advisories. |
+| `restricted_operations` | Operational material that must not become public source. | Production topology, customer configs, cloud account layout, live deployed hashes, raw logs/HARs/traces. |
+
+## Exposure classes
+
+| Class | Default tier | Publication posture |
+|---|---:|---|
+| `source_text` | `community_inner_source` before release, `public_release_mirror` after gate | Publish as release snapshot only after checks pass. |
+| `stable_protocol_spec` | `public_trust` | Public by default unless it embeds live topology or exploit detail. |
+| `ci_workflow` | `community_inner_source` | Public only when token scopes, deploy paths, and operational internals are safe. |
+| `dependency_manifest` | `community_inner_source` before release, `public_release_mirror` after gate | Public with SBOM/VEX after vulnerability triage. |
+| `deployment_manifest` | `restricted_operations` | Public only as sanitized reference architecture. |
+| `telemetry_log` | `restricted_operations` | Never public unless synthetically generated or fully sanitized. |
+| `vulnerability_repro` | `restricted_security` | Private until remediation and disclosure gate complete. |
+| `threat_model` | mixed | Public summary; implementation-sensitive appendix stays restricted. |
+
+## Publication gate
+
+A repository or release snapshot is publishable only when all required checks pass:
+
+1. no blocked credential/secret indicators;
+2. no blocked operational file paths;
+3. no raw HAR, packet capture, private key, kubeconfig, Terraform state, or production `.env` files;
+4. no live production topology, customer identifiers, or exact deployed hash mapping;
+5. no unresolved exploitable critical/high vulnerability in released artifact context;
+6. SBOM emitted for release artifacts;
+7. VEX or equivalent exploitability decision emitted for known vulnerable components;
+8. provenance/attestation emitted for release artifacts;
+9. CI workflow permissions are least-privilege and publication-safe;
+10. security-sensitive issues, red-team fixtures, and exploit repros are excluded or restricted.
+
+## Sociosphere integration
+
+Sociosphere owns this standard because it is the workspace controller. The implementation surface is:
+
+- `standards/source-exposure/policy.v0.json` — machine-readable exposure policy.
+- `standards/source-exposure/schemas/source_exposure_report.v1.json` — report contract.
+- `tools/check_source_exposure.py` — stdlib-only validator for source publication checks.
+- `make source-exposure-check` — local and CI entrypoint.
+- `artifacts/source-exposure/source-exposure-report.json` — generated evidence report.
+
+## Required downstream behavior
+
+Downstream repositories should eventually expose the same target name:
+
+```bash
+make source-exposure-check
+```
+
+Where a repository cannot implement the check directly, Sociosphere may run this workspace-level validator against the materialized repository tree.
+
+## Severity model
+
+| Severity | CI behavior | Meaning |
+|---|---:|---|
+| `block` | fail | The item is likely unsafe for public source or release mirror publication. |
+| `warn` | pass with finding | The item needs review but is not automatically unsafe. |
+| `info` | pass | The item contributes to exposure accounting or inventory only. |
+
+## Design notes
+
+This standard is deliberately conservative about high-confidence leaks and deliberately restrained about natural-language scanning. A noisy validator becomes theater. A useful validator blocks things we should never publish and produces structured review evidence for the rest.

--- a/standards/source-exposure/policy.v0.json
+++ b/standards/source-exposure/policy.v0.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "sociosphere.source-exposure-policy/v0.1",
+  "name": "Sociosphere Source Exposure Governance Policy",
+  "default_visibility_tier": "community_inner_source",
+  "blocked_path_suffixes": [
+    ".pem",
+    ".key",
+    ".p12",
+    ".pfx",
+    ".har",
+    ".pcap",
+    ".pcapng",
+    ".tfstate",
+    ".tfstate.backup",
+    ".kubeconfig"
+  ],
+  "blocked_path_names": [
+    ".env",
+    ".env.local",
+    ".env.production",
+    "id_rsa",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "kubeconfig",
+    "terraform.tfstate",
+    "terraform.tfstate.backup"
+  ],
+  "ignored_dirs": [
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "venv",
+    "node_modules",
+    "dist",
+    "build",
+    "__pycache__",
+    "artifacts"
+  ],
+  "max_file_bytes": 1048576,
+  "content_rules": [
+    {
+      "id": "private-key-material",
+      "severity": "block",
+      "pattern": "-----BEGIN (RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY-----",
+      "description": "Private key material must never be committed or published."
+    },
+    {
+      "id": "aws-access-key-id",
+      "severity": "block",
+      "pattern": "\\bAKIA[0-9A-Z]{16}\\b",
+      "description": "AWS access key identifiers must never be committed or published."
+    },
+    {
+      "id": "github-token",
+      "severity": "block",
+      "pattern": "\\bgh[pousr]_[A-Za-z0-9_]{36,255}\\b",
+      "description": "GitHub tokens must never be committed or published."
+    },
+    {
+      "id": "slack-token",
+      "severity": "block",
+      "pattern": "\\bxox[baprs]-[A-Za-z0-9-]{10,}\\b",
+      "description": "Slack tokens must never be committed or published."
+    },
+    {
+      "id": "google-api-key",
+      "severity": "block",
+      "pattern": "\\bAIza[0-9A-Za-z\\-_]{35}\\b",
+      "description": "Google API keys must never be committed or published."
+    },
+    {
+      "id": "prod-env-assignment",
+      "severity": "warn",
+      "pattern": "(?i)\\b(PROD|PRODUCTION)_[A-Z0-9_]*(TOKEN|SECRET|PASSWORD|KEY)\\s*=",
+      "description": "Production credential variable assignments require review even if values are redacted."
+    }
+  ]
+}

--- a/standards/source-exposure/schemas/source_exposure_report.v1.json
+++ b/standards/source-exposure/schemas/source_exposure_report.v1.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.local/sociosphere/source-exposure-report.v1.json",
+  "title": "Sociosphere Source Exposure Report v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "generated_at",
+    "root",
+    "policy",
+    "result",
+    "counts",
+    "findings"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "sociosphere.source-exposure-report/v1"
+    },
+    "generated_at": {
+      "type": "string"
+    },
+    "root": {
+      "type": "string"
+    },
+    "policy": {
+      "type": "object",
+      "required": [
+        "path",
+        "schema_version"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "result": {
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "counts": {
+      "type": "object",
+      "required": [
+        "files_scanned",
+        "files_skipped",
+        "block",
+        "warn",
+        "info"
+      ],
+      "properties": {
+        "files_scanned": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "files_skipped": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "block": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warn": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "info": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "rule_id",
+          "severity",
+          "path",
+          "message"
+        ],
+        "properties": {
+          "rule_id": {
+            "type": "string"
+          },
+          "severity": {
+            "enum": [
+              "block",
+              "warn",
+              "info"
+            ]
+          },
+          "path": {
+            "type": "string"
+          },
+          "line": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 1
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_source_exposure.py
+++ b/tests/test_source_exposure.py
@@ -13,8 +13,10 @@ def test_source_exposure_checker_blocks_private_key(tmp_path: Path) -> None:
     source_policy = Path("standards/source-exposure/policy.v0.json")
     policy_dir.joinpath("policy.v0.json").write_text(source_policy.read_text("utf-8"), "utf-8")
 
+    begin_private_key = "-----BEGIN " + "PRIVATE KEY-----"
+    end_private_key = "-----END " + "PRIVATE KEY-----"
     secret = repo / "bad.pem"
-    secret.write_text("-----BEGIN PRIVATE KEY-----\nredacted\n-----END PRIVATE KEY-----\n", "utf-8")
+    secret.write_text(f"{begin_private_key}\nredacted\n{end_private_key}\n", "utf-8")
 
     cp = subprocess.run(
         [

--- a/tests/test_source_exposure.py
+++ b/tests/test_source_exposure.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_source_exposure_checker_blocks_private_key(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    policy_dir = repo / "standards" / "source-exposure"
+    policy_dir.mkdir(parents=True)
+    source_policy = Path("standards/source-exposure/policy.v0.json")
+    policy_dir.joinpath("policy.v0.json").write_text(source_policy.read_text("utf-8"), "utf-8")
+
+    secret = repo / "bad.pem"
+    secret.write_text("-----BEGIN PRIVATE KEY-----\nredacted\n-----END PRIVATE KEY-----\n", "utf-8")
+
+    cp = subprocess.run(
+        [
+            "python3",
+            "tools/check_source_exposure.py",
+            "--root",
+            str(repo),
+            "--policy",
+            "standards/source-exposure/policy.v0.json",
+            "--json-out",
+            "-",
+        ],
+        cwd=Path.cwd(),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert cp.returncode == 2
+    report = json.loads(cp.stdout)
+    assert report["result"] == "fail"
+    assert report["counts"]["block"] >= 1
+
+
+def test_source_exposure_checker_allows_redacted_example(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    policy_dir = repo / "standards" / "source-exposure"
+    policy_dir.mkdir(parents=True)
+    source_policy = Path("standards/source-exposure/policy.v0.json")
+    policy_dir.joinpath("policy.v0.json").write_text(source_policy.read_text("utf-8"), "utf-8")
+
+    example = repo / "README.md"
+    example.write_text("WEBHOOK_SECRET=<shared-secret>\n", "utf-8")
+
+    cp = subprocess.run(
+        [
+            "python3",
+            "tools/check_source_exposure.py",
+            "--root",
+            str(repo),
+            "--policy",
+            "standards/source-exposure/policy.v0.json",
+            "--json-out",
+            "-",
+        ],
+        cwd=Path.cwd(),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert cp.returncode == 0
+    report = json.loads(cp.stdout)
+    assert report["result"] == "pass"

--- a/tools/check_source_exposure.py
+++ b/tools/check_source_exposure.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Source exposure validator for Sociosphere.
+
+The validator is intentionally stdlib-only. It is designed to catch
+high-confidence publication blockers without turning natural-language docs into
+false-positive noise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SEVERITIES = ("block", "warn", "info")
+
+
+def now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_policy(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text("utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"policy not found: {path}") from None
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"policy is not valid JSON: {path}: {exc}") from None
+
+    if not isinstance(data, dict):
+        raise SystemExit("policy root must be an object")
+    if not data.get("schema_version"):
+        raise SystemExit("policy.schema_version missing")
+    for rule in data.get("content_rules", []):
+        try:
+            re.compile(rule["pattern"])
+        except re.error as exc:
+            raise SystemExit(f"invalid regex for rule {rule.get('id', '<unknown>')}: {exc}") from None
+    return data
+
+
+def git_tracked_files(root: Path) -> list[Path] | None:
+    try:
+        cp = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=str(root),
+            check=True,
+            text=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except Exception:
+        return None
+
+    if not cp.stdout:
+        return []
+    files: list[Path] = []
+    for raw in cp.stdout.split(b"\0"):
+        if raw:
+            files.append(root / raw.decode("utf-8", errors="replace"))
+    return files
+
+
+def walk_files(root: Path, ignored_dirs: set[str]) -> list[Path]:
+    out: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in ignored_dirs]
+        base = Path(dirpath)
+        for filename in filenames:
+            out.append(base / filename)
+    return out
+
+
+def is_ignored(path: Path, root: Path, ignored_dirs: set[str]) -> bool:
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        return True
+    return any(part in ignored_dirs for part in rel.parts)
+
+
+def rel_path(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def path_findings(path: Path, root: Path, policy: dict[str, Any]) -> list[dict[str, Any]]:
+    rel = rel_path(path, root)
+    name = path.name
+    suffixes = tuple(str(s).lower() for s in policy.get("blocked_path_suffixes", []))
+    names = {str(n) for n in policy.get("blocked_path_names", [])}
+    findings: list[dict[str, Any]] = []
+
+    if name in names:
+        findings.append(
+            {
+                "rule_id": "blocked-path-name",
+                "severity": "block",
+                "path": rel,
+                "line": None,
+                "message": f"blocked publication path name: {name}",
+            }
+        )
+
+    lower = rel.lower()
+    for suffix in suffixes:
+        if lower.endswith(suffix):
+            findings.append(
+                {
+                    "rule_id": "blocked-path-suffix",
+                    "severity": "block",
+                    "path": rel,
+                    "line": None,
+                    "message": f"blocked publication path suffix: {suffix}",
+                }
+            )
+            break
+
+    return findings
+
+
+def content_findings(path: Path, root: Path, policy: dict[str, Any]) -> tuple[list[dict[str, Any]], bool]:
+    max_bytes = int(policy.get("max_file_bytes", 1048576))
+    try:
+        stat = path.stat()
+    except OSError:
+        return [], True
+
+    if stat.st_size > max_bytes:
+        return [], True
+
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return [], True
+
+    if b"\0" in raw:
+        return [], True
+
+    text = raw.decode("utf-8", errors="replace")
+    rules = [
+        {
+            **rule,
+            "_compiled": re.compile(rule["pattern"]),
+        }
+        for rule in policy.get("content_rules", [])
+    ]
+
+    findings: list[dict[str, Any]] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for rule in rules:
+            if rule["_compiled"].search(line):
+                severity = rule.get("severity", "warn")
+                if severity not in SEVERITIES:
+                    severity = "warn"
+                findings.append(
+                    {
+                        "rule_id": rule.get("id", "unnamed-rule"),
+                        "severity": severity,
+                        "path": rel_path(path, root),
+                        "line": line_no,
+                        "message": rule.get("description", "source exposure rule matched"),
+                    }
+                )
+    return findings, False
+
+
+def build_report(root: Path, policy_path: Path) -> dict[str, Any]:
+    policy = load_policy(policy_path)
+    ignored_dirs = set(policy.get("ignored_dirs", []))
+    tracked = git_tracked_files(root)
+    candidates = tracked if tracked is not None else walk_files(root, ignored_dirs)
+
+    findings: list[dict[str, Any]] = []
+    skipped = 0
+    scanned = 0
+
+    for path in candidates:
+        if is_ignored(path, root, ignored_dirs):
+            skipped += 1
+            continue
+        if not path.exists() or not path.is_file():
+            skipped += 1
+            continue
+
+        findings.extend(path_findings(path, root, policy))
+        content_matches, was_skipped = content_findings(path, root, policy)
+        if was_skipped:
+            skipped += 1
+        else:
+            scanned += 1
+            findings.extend(content_matches)
+
+    counts = {
+        "files_scanned": scanned,
+        "files_skipped": skipped,
+        "block": sum(1 for f in findings if f["severity"] == "block"),
+        "warn": sum(1 for f in findings if f["severity"] == "warn"),
+        "info": sum(1 for f in findings if f["severity"] == "info"),
+    }
+
+    return {
+        "schema_version": "sociosphere.source-exposure-report/v1",
+        "generated_at": now_iso(),
+        "root": str(root),
+        "policy": {
+            "path": str(policy_path),
+            "schema_version": policy.get("schema_version"),
+        },
+        "result": "fail" if counts["block"] else "pass",
+        "counts": counts,
+        "findings": findings,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate source exposure publication safety.")
+    parser.add_argument("--root", default=".", help="Repository/workspace root to scan.")
+    parser.add_argument(
+        "--policy",
+        default="standards/source-exposure/policy.v0.json",
+        help="Source exposure policy JSON.",
+    )
+    parser.add_argument(
+        "--json-out",
+        default="artifacts/source-exposure/source-exposure-report.json",
+        help="Report output path. Use '-' for stdout only.",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    policy_path = (root / args.policy).resolve() if not Path(args.policy).is_absolute() else Path(args.policy)
+    report = build_report(root, policy_path)
+
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.json_out == "-":
+        print(rendered, end="")
+    else:
+        out = (root / args.json_out).resolve() if not Path(args.json_out).is_absolute() else Path(args.json_out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(rendered, "utf-8")
+        print(f"[source-exposure] wrote {out}")
+        print(
+            f"[source-exposure] result={report['result']} "
+            f"block={report['counts']['block']} warn={report['counts']['warn']} "
+            f"files_scanned={report['counts']['files_scanned']}"
+        )
+
+    return 0 if report["result"] == "pass" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the first concrete Sociosphere source-exposure governance lane for agentic reconnaissance risk.

This PR adds:
- `standards/source-exposure/README.md` — Source Exposure Governance Standard v0.1
- `standards/source-exposure/policy.v0.json` — machine-readable policy
- `standards/source-exposure/schemas/source_exposure_report.v1.json` — structured report schema
- `tools/check_source_exposure.py` — stdlib-only validator
- `tests/test_source_exposure.py` — positive/negative validator coverage
- `make source-exposure-check` — local/CI gate
- CI wiring in `.github/workflows/validate.yml`
- documentation discovery in `README.md` and `docs/README.md`

## Why

Public repositories in an agentic environment can become a live attack graph when they expose operational details, unresolved security defects, raw telemetry, secrets, production topology, or exploit reproduction material. The goal is not to hide MIT-licensed release source. The goal is to prevent public source and release mirrors from publishing privileged reconnaissance against our running systems.

## Review notes

- The validator is intentionally conservative and stdlib-only.
- It fails only on high-confidence `block` findings.
- It writes a structured report at `artifacts/source-exposure/source-exposure-report.json` by default.
- The private-key test fixture constructs its sentinel dynamically so the repo-level scanner does not block on its own test source.

## Software review

Correctness:
- Adds a real CI-backed publication safety gate rather than prose-only governance.
- Reuses Sociosphere as the workspace controller instead of creating a parallel security repo.
- Keeps source exposure aligned with standards, artifacts, and workspace-check flows.

Risk:
- Low-to-moderate. New CI step may reveal existing publication-safety blockers if tracked files contain high-confidence secrets or blocked operational artifacts.

Known weaknesses:
- This is v0.1 and does not yet run OSV/SBOM/VEX/SLSA publication gates.
- It does not yet classify every repo in the SocioProphet workspace.
- It does not yet implement delayed public release mirrors.

Next hardening:
- Add repo-level exposure classification to `registry/canonical-repos.yaml`.
- Add workspace-wide source-exposure scan mode across materialized repos.
- Add VEX/SBOM/provenance gates to public release mirror workflow.
- Add an operator dashboard surface in `apps/ui-workbench` for exposure posture and findings.
