### PR TITLE
Define Angel of the Lord hardening regime

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ Platform meta-workspace controller for the SocioProphet ecosystem.
 
 Sociosphere owns the canonical workspace manifest + lock, runner semantics,
 protocol fixtures, deterministic multi-repo materialization, source-exposure
-governance, and validation lanes for platform build and release readiness.
+governance, adversarial hardening critique, and validation lanes for platform
+build and release readiness.
 
 ## Governance references
 
 - [Repository topology and dependency rules](docs/TOPOLOGY.md) — canonical source for repo roles, directionality, and the submodule update playbook.
 - [Naming and versioning policy](docs/NAMING_VERSIONING.md) — single source of truth for repo naming, SemVer discipline, and submodule pin-bump rules.
+- [Angel of the Lord Hardening Regime](standards/angel-of-the-lord/README.md) — adversarial CI and workspace critique regime for repository, boundary, release, and evidence hardening.
 - [Source Exposure Governance Standard](standards/source-exposure/README.md) — publication-safety rules for public source, public release mirrors, inner-source development, and restricted security/operations material.
 
 ## Canonical scope
@@ -21,6 +23,7 @@ Sociosphere is responsible for:
 - Materializing and validating the workspace with `tools/runner/runner.py`.
 - Enforcing topology and dependency-direction policies via `tools/check_topology.py`.
 - Maintaining cross-repo governance and registry metadata in `registry/` + `governance/`.
+- Owning the Angel of the Lord adversarial hardening regime across workspace CI lanes.
 - Validating source-exposure publication safety with `tools/check_source_exposure.py`.
 
 Sociosphere is **not** the place for feature implementation inside downstream
@@ -34,6 +37,7 @@ component repositories.
 - Scope/current state/backlog: `docs/SCOPE_PURPOSE_STATUS_BACKLOG.md`
 - Integration ledger: `docs/INTEGRATION_STATUS.md`
 - Namespace ownership map: `governance/CANONICAL_SOURCES.yaml`
+- Angel of the Lord hardening regime: `standards/angel-of-the-lord/README.md`
 - Source exposure standard: `standards/source-exposure/README.md`
 
 ## Repository intelligence assets
@@ -64,6 +68,7 @@ component repositories.
 | File | Description |
 |---|---|
 | `standards/qes/README.md` | Quality Evidence Standard |
+| `standards/angel-of-the-lord/README.md` | Angel of the Lord adversarial hardening regime |
 | `standards/source-exposure/README.md` | Source Exposure Governance Standard |
 | `standards/source-exposure/policy.v0.json` | Machine-readable source-exposure policy |
 | `standards/source-exposure/schemas/source_exposure_report.v1.json` | Source exposure report schema |

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@
 
 ## Standards
 - [QES (Quality Evidence Standard)](../standards/qes/README.md)
+- [Angel of the Lord Hardening Regime](../standards/angel-of-the-lord/README.md)
 - [Source Exposure Governance Standard](../standards/source-exposure/README.md)
 - [Adaptation README](standards/adaptation/README.md)
 

--- a/standards/angel-of-the-lord/README.md
+++ b/standards/angel-of-the-lord/README.md
@@ -1,0 +1,100 @@
+# Angel of the Lord Hardening Regime v0.1
+
+## Purpose
+
+The Angel of the Lord is the Sociosphere adversarial hardening regime for recurring repository, CI, release, and platform-boundary critique.
+
+It is not a passive checklist and it is not a label for generic scanning. It is the critic workflow whose job is to inspect each implementation from a defensive standpoint and produce hard findings about weak boundaries, unsafe exposure, missing evidence, hidden trust assumptions, and unproven security claims.
+
+## Operating thesis
+
+Agentic development changes the economics of reconnaissance. Public code, CI metadata, dependency manifests, issue history, docs, release artifacts, and topology hints can be reviewed at machine speed. The platform therefore needs a recurring defensive reviewer that treats every repository as a possible source of sensitive implementation intelligence.
+
+The Angel of the Lord regime turns that reviewer into a governed CI and workspace workflow.
+
+## Core mandate
+
+For every repository and every release path, the regime asks:
+
+1. What sensitive implementation detail is visible here?
+2. Which trust boundary is implicit, weak, undocumented, or unenforced?
+3. Which CI permission, workflow, token, artifact, or log creates unnecessary leverage?
+4. Which dependency, parser, endpoint, or serializer is exposed without enough evidence?
+5. Which documentation or example accidentally reveals production structure?
+6. Which claim lacks a test, policy, attestation, or reproducible artifact?
+7. Which failure path is unaudited, silent, or non-deterministic?
+8. Which security finding must block release, block publication, or remain restricted?
+
+## Non-goals
+
+Public Angel of the Lord outputs must not become misuse-enabling material. Public artifacts should identify classes of weakness, impacted surfaces, severity, evidence gaps, and remediation requirements without publishing sensitive operational detail.
+
+Sensitive reproduction material, raw telemetry, incident evidence, and live topology remain restricted-security or restricted-operations material under the Source Exposure Governance Standard.
+
+## Workflow lanes
+
+| Lane | Purpose | First-class evidence |
+|---|---|---|
+| `source_exposure` | Prevent public repos and release mirrors from exposing privileged reconnaissance. | Source exposure report, blocked path/content findings, publication decision. |
+| `ci_permissions` | Inspect workflow permissions, token scopes, third-party actions, logs, and deployment paths. | CI permission report, pinned action report, token-scope findings. |
+| `repo_boundary` | Verify repo responsibility boundaries and prevent hidden feature work in controller repos. | Boundary report, topology report, canonical-source mapping. |
+| `dependency_vulnerability` | Check dependency lag, known-risk components, SBOM/VEX posture, and release impact. | SBOM, VEX/impact report, vulnerability findings. |
+| `runtime_policy` | Verify runtime enforcement expectations: identity, authorization, network policy, egress, tenant isolation. | Policy report, trust report, runtime conformance evidence. |
+| `telemetry_publication` | Prevent logs, HARs, traces, and screenshots from leaking live structure. | Telemetry sanitation report, synthetic fixture declaration. |
+| `release_mirror` | Gate public release mirrors and source snapshots after hardening checks pass. | Release gate report, provenance, SBOM, VEX, signed artifact refs. |
+| `adversarial_review` | Produce the explicit critic narrative: what is weak, what is missing, and what must be remediated. | Critic findings, severity ledger, owner/remediation backlog. |
+
+## Review posture
+
+The regime is expected to be severe, explicit, and evidence-bound. It should say when an implementation is weak. It should not soften findings to avoid discomfort. Every severe claim must identify the surface, boundary, evidence, severity, and remediation.
+
+## Severity model
+
+| Severity | Meaning | Required action |
+|---|---|---|
+| `blocker` | Unsafe to merge, release, publish, or deploy. | Must remediate or explicitly quarantine/restrict. |
+| `high` | Security boundary is weak or evidence is materially incomplete. | Must create tracked remediation before release. |
+| `medium` | Meaningful hardening gap. | Backlog with owner and target tranche. |
+| `low` | Hygiene or clarity issue. | Fix opportunistically or fold into nearby work. |
+| `info` | Observation useful for posture accounting. | No immediate remediation required. |
+
+## Required report structure
+
+Every Angel of the Lord report should include:
+
+- target repository, branch, commit, and workflow context;
+- surfaces inspected;
+- findings by severity;
+- trust boundaries found and trust boundaries missing;
+- evidence accepted;
+- evidence missing;
+- publication/deployment decision;
+- remediation backlog;
+- whether public disclosure is safe or restricted handling is required.
+
+## Sociosphere implementation status
+
+Current implemented lane:
+
+- `source_exposure`: `standards/source-exposure/README.md`, `standards/source-exposure/policy.v0.json`, `tools/check_source_exposure.py`, `make source-exposure-check`, and CI wiring in `validate`.
+
+Planned hardening lanes:
+
+- `ci_permissions`: workflow permission and third-party action audit.
+- `repo_boundary`: enforce controller/component boundary claims against canonical registry metadata.
+- `dependency_vulnerability`: workspace-level OSV/SBOM/VEX gate.
+- `release_mirror`: delayed public release mirror gate with signed artifacts.
+- `adversarial_review`: structured critic report and dashboard view.
+
+## Operating loop
+
+1. Enumerate repositories and current materialized refs from the Sociosphere manifest and registry.
+2. Run deterministic hardening lanes in CI and workspace checks.
+3. Produce structured reports and a critic narrative.
+4. Block unsafe publication, release, or deployment where severity requires it.
+5. Register remediation work in the running backlog.
+6. Re-run the regime on every pass until findings are closed or explicitly accepted with evidence.
+
+## Boundary with implementation teams
+
+The Angel of the Lord does not own downstream feature implementation. It owns critique, evidence requirements, hardening gates, release/publication decisions, and remediation pressure. Downstream repos own their fixes unless Sociosphere is the correct implementation home.

--- a/standards/source-exposure/README.md
+++ b/standards/source-exposure/README.md
@@ -6,6 +6,8 @@ This standard controls what Sociosphere and downstream platform repositories may
 
 The goal is not secrecy for its own sake. The goal is to prevent public repositories from becoming a live, machine-readable attack graph against our own running systems while preserving auditable MIT-licensed release source, public standards, provenance, SBOMs, and security accountability.
 
+This standard is the first implemented lane under the [Angel of the Lord Hardening Regime](../angel-of-the-lord/README.md).
+
 ## Core rule
 
 Public source is allowed only after it is no longer privileged reconnaissance against our live systems.

--- a/status/build-intelligence/sociosphere-source-exposure-governance-2026-04-26.yaml
+++ b/status/build-intelligence/sociosphere-source-exposure-governance-2026-04-26.yaml
@@ -1,0 +1,100 @@
+schema_version: "sociosphere.build-intelligence/v0.1"
+recorded_at: "2026-04-26T14:45:00Z"
+controller_repo: "SocioProphet/sociosphere"
+subject_repo: "SocioProphet/sociosphere"
+status: "active"
+
+scope:
+  program: "Angel of the Lord / Source Exposure Governance"
+  lane: "source-exposure-publication-safety"
+  intent: "Register the merged Sociosphere source exposure governance gate as the first implemented Angel of the Lord hardening lane."
+
+merged_tranches:
+  - pr: 185
+    title: "Add source exposure governance gate"
+    merge_commit: "69fa23d5af24d34958383a8664dd920c7c3d59c0"
+    gates_closed:
+      - added Source Exposure Governance Standard v0.1
+      - added machine-readable source exposure policy
+      - added structured source exposure report schema
+      - added stdlib-only source exposure validator
+      - added positive and negative validator tests
+      - added make source-exposure-check target
+      - wired source exposure check into validate workflow
+      - linked the standard from root and documentation indexes
+      - confirmed source exposure check passed in CI
+      - merged PR 185
+    artifacts:
+      - "standards/source-exposure/README.md"
+      - "standards/source-exposure/policy.v0.json"
+      - "standards/source-exposure/schemas/source_exposure_report.v1.json"
+      - "tools/check_source_exposure.py"
+      - "tests/test_source_exposure.py"
+      - "Makefile"
+      - ".github/workflows/validate.yml"
+      - "README.md"
+      - "docs/README.md"
+
+active_tranches:
+  - pr: 185
+    title: "Add source exposure governance gate"
+    branch: "work/source-exposure-governance-v0"
+    state: "merged"
+    subject: "Source exposure governance gate"
+    gates_completed:
+      - governance standard merged
+      - policy and report schema merged
+      - validator and tests merged
+      - CI hook merged
+      - source exposure check passed in validate workflow
+    files_changed:
+      - "standards/source-exposure/README.md"
+      - "standards/source-exposure/policy.v0.json"
+      - "standards/source-exposure/schemas/source_exposure_report.v1.json"
+      - "tools/check_source_exposure.py"
+      - "tests/test_source_exposure.py"
+      - "Makefile"
+      - ".github/workflows/validate.yml"
+      - "README.md"
+      - "docs/README.md"
+    pending_gates: []
+
+test_and_workflow_surfaces:
+  validate_workflow:
+    status: "updated"
+    notes: "The validate workflow now runs make source-exposure-check before UI and Python test stages."
+  make_targets:
+    - "source-exposure-check"
+    - "workspace-check"
+  relevant_workflows:
+    - "validate"
+    - "standards-validate"
+    - "workspace-spine"
+    - "ui-check"
+    - "compliance"
+
+software_review:
+  correctness:
+    - "Sociosphere now has a concrete CI-backed source exposure publication safety gate."
+    - "The validator blocks high-confidence source exposure findings while keeping policy and report artifacts machine-readable."
+    - "The source exposure lane is aligned to the workspace controller instead of becoming an untracked standalone process."
+  weaknesses:
+    - "The gate is repository-local and does not yet scan all materialized workspace repositories."
+    - "The gate does not yet include dependency vulnerability, VEX, SBOM, or provenance release-mirror checks."
+    - "The broader Angel of the Lord hardening regime still needs a formal umbrella standard and additional lanes."
+  next_hardening:
+    - "Formalize the Angel of the Lord hardening regime as the umbrella for recurring adversarial repository critique."
+    - "Add repo-level exposure classification to registry/canonical-repos.yaml."
+    - "Add workspace-wide source exposure scanning across materialized repositories."
+    - "Add CI permission and third-party action audit lane."
+    - "Add SBOM/VEX/provenance gates for public release mirrors."
+
+running_backlog:
+  - "Formalize the Angel of the Lord hardening regime as the umbrella workflow for adversarial CI critique."
+  - "Add repo-level exposure classification to registry/canonical-repos.yaml."
+  - "Add workspace-wide source exposure scan mode across materialized repos."
+  - "Add CI permission and third-party action audit lane."
+  - "Add dependency vulnerability and VEX/SBOM release gate."
+  - "Add delayed public release mirror gate with signed artifacts."
+  - "Add operator dashboard surface for Angel findings and source exposure posture."
+  - "Keep sensitive reproductions, raw telemetry, incident evidence, and live topology out of public artifacts."


### PR DESCRIPTION
## Summary

Defines the Angel of the Lord as the Sociosphere adversarial hardening regime and links the newly merged source-exposure gate as its first implemented lane.

This PR adds:
- `standards/angel-of-the-lord/README.md` — umbrella hardening regime standard
- root `README.md` discovery links and scope update
- `docs/README.md` standards index link
- source-exposure cross-link back to the Angel regime
- `status/build-intelligence/sociosphere-source-exposure-governance-2026-04-26.yaml` — build-intelligence record for PR #185

## Why

The source exposure gate is useful, but it should not live as a one-off scanner. We need an explicit recurring critic regime that inspects repository boundaries, CI permissions, release/publication safety, runtime policy evidence, telemetry publication, and release mirror readiness.

## Software review

Correctness:
- Establishes Angel of the Lord as the umbrella workflow for severe, evidence-bound hardening critique.
- Declares source exposure as the first implemented lane under the regime.
- Adds the missing build-intelligence record for the merged source-exposure gate.
- Keeps sensitive reproduction material, raw telemetry, incident evidence, and live topology out of public artifacts.

Risk:
- Low. Documentation/status registration only; no runtime or CI behavior changes in this PR.

Known weaknesses:
- The Angel standard is v0.1 and does not yet include machine-readable report schemas.
- Only source-exposure is implemented today; CI-permissions, dependency/VEX/SBOM, release-mirror, and runtime-policy lanes remain future work.

Next hardening:
- Add `angel_of_the_lord_report.v1.json` schema.
- Add CI permission and third-party action audit lane.
- Add repo-level exposure classification to `registry/canonical-repos.yaml`.
- Add workspace-wide source-exposure scanning across materialized repositories.
- Add operator dashboard surface for Angel findings in `apps/ui-workbench`.
