### PR TITLE
docs: add broker reasoning integration binding

### DIFF
--- a/.github/workflows/broker-reasoning-propagation.yml
+++ b/.github/workflows/broker-reasoning-propagation.yml
@@ -14,6 +14,9 @@ on:
       - "tools/check_broker_reasoning_propagation.py"
       - ".github/workflows/broker-reasoning-propagation.yml"
 
+permissions:
+  contents: read
+
 jobs:
   validate-broker-propagation:
     runs-on: ubuntu-latest

--- a/.github/workflows/broker-reasoning-propagation.yml
+++ b/.github/workflows/broker-reasoning-propagation.yml
@@ -1,0 +1,26 @@
+name: broker-reasoning-propagation
+
+on:
+  pull_request:
+    paths:
+      - "registry/broker-reasoning-propagation-rules.yaml"
+      - "tools/check_broker_reasoning_propagation.py"
+      - ".github/workflows/broker-reasoning-propagation.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "registry/broker-reasoning-propagation-rules.yaml"
+      - "tools/check_broker_reasoning_propagation.py"
+      - ".github/workflows/broker-reasoning-propagation.yml"
+
+jobs:
+  validate-broker-propagation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate broker propagation rules
+        run: python tools/check_broker_reasoning_propagation.py

--- a/docs/integration/next-gen-broker-reasoning.md
+++ b/docs/integration/next-gen-broker-reasoning.md
@@ -1,0 +1,43 @@
+# Next Gen Broker Reasoning Integration
+
+## Purpose
+
+SocioSphere is the workspace governance and propagation layer for the cross-cloud services broker model.
+
+It does not implement broker runtime features. It governs repository roles, dependency direction, source exposure, hardening critique, cross-repo drift, and validation lanes for broker-related changes.
+
+## SocioSphere responsibilities
+
+SocioSphere owns:
+
+- canonical workspace repo role declarations for broker-related repositories
+- dependency-direction checks between standards, runtime, policy, execution, intelligence, and learning repos
+- cross-repo change propagation when broker standards change
+- source-exposure and publication-safety checks for broker material
+- Angel of the Lord adversarial critique gates for broker boundaries
+- workspace validation lanes for broker readiness
+
+## Broker reasoning inputs
+
+SocioSphere should consume or reference:
+
+- broker standard changes
+- provider-binding schema changes
+- policy-pack and policy-decision contract changes
+- AgentPlane evidence/replay contract changes
+- DevSecOps intelligence broker findings
+- Academy curriculum/evaluation promotion changes
+
+## Broker reasoning outputs
+
+SocioSphere should produce:
+
+- `SocioSpherePropagationPlan`
+- topology-impact findings
+- source-exposure findings
+- Angel of the Lord hardening findings
+- cross-repo validation requirements
+
+## Design invariant
+
+SocioSphere governs the workspace and propagation loop. It must not become the implementation home for downstream broker features.

--- a/registry/broker-reasoning-propagation-rules.yaml
+++ b/registry/broker-reasoning-propagation-rules.yaml
@@ -1,0 +1,79 @@
+# Broker reasoning propagation rules
+# Companion registry for the cross-cloud services broker reasoning loop.
+
+version: "0.1.0"
+updated_at: "2026-04-26"
+
+rules:
+  - id: broker-standard-change
+    trigger:
+      repo: prophet-platform-standards
+      paths:
+        - docs/NEXT_GEN_TOM_*.md
+        - schemas/broker-reasoning/**
+    propagate_to:
+      - repo: prophet-platform
+        action: review_binding
+        reason: broker runtime bindings, schemas, examples, and validation may need updates
+      - repo: policy-fabric
+        action: review_policy_binding
+        reason: policy decision, exception, and evidence requirements may need updates
+      - repo: agentplane
+        action: review_execution_binding
+        reason: broker validation, placement, run, and replay bundles may need updates
+      - repo: global-devsecops-intelligence
+        action: review_intelligence_projection
+        reason: broker exhaust entities, findings, and graph projections may need updates
+      - repo: alexandrian-academy
+        action: review_learning_binding
+        reason: broker training, evaluation, and canon learning objects may need updates
+      - repo: sociosphere
+        action: run_angel_critique
+        reason: workspace topology, source exposure, and hardening critique must be refreshed
+
+  - id: provider-binding-contract-change
+    trigger:
+      repo: prophet-platform
+      paths:
+        - specs/brokerage/schemas/provider-binding.schema.json
+        - specs/brokerage/events/examples/provider-binding.example.json
+        - docs/reference/next-gen-tom/provider-binding.md
+    propagate_to:
+      - repo: policy-fabric
+        action: review_policy_decision_inputs
+        reason: policy evaluation must understand ProviderBinding semantics
+      - repo: agentplane
+        action: review_bundle_inputs
+        reason: execution bundles may depend on ProviderBinding fields
+      - repo: global-devsecops-intelligence
+        action: review_graph_projection
+        reason: operational intelligence should project ProviderBinding fields and findings
+      - repo: sociosphere
+        action: validate_topology
+        reason: broker contract changes must be checked against dependency-direction rules
+
+  - id: broker-reasoning-output-change
+    trigger:
+      repo: global-devsecops-intelligence
+      paths:
+        - docs/architecture/broker-operational-intelligence-binding.md
+        - profiles/**
+        - open-ai4it-spec/**
+    propagate_to:
+      - repo: alexandrian-academy
+        action: review_training_outputs
+        reason: new findings may require training or evaluation objects
+      - repo: sociosphere
+        action: review_propagation_rules
+        reason: reasoning outputs may change cross-repo validation requirements
+
+outputs:
+  propagation_plan_kind: SocioSpherePropagationPlan
+  required_fields:
+    - change_ref
+    - source_repo
+    - changed_paths
+    - affected_repos
+    - required_actions
+    - rationale
+    - validation_lanes

--- a/tools/check_broker_reasoning_propagation.py
+++ b/tools/check_broker_reasoning_propagation.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Validate broker reasoning propagation rule structure.
+
+This checker intentionally uses only the Python standard library and a small
+structure-oriented parser for the committed YAML subset. It verifies that the
+broker propagation file names the required rules and required affected repos.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+RULES = ROOT / "registry" / "broker-reasoning-propagation-rules.yaml"
+
+REQUIRED_RULE_IDS = {
+    "broker-standard-change",
+    "provider-binding-contract-change",
+    "broker-reasoning-output-change",
+}
+
+REQUIRED_AFFECTED_REPOS = {
+    "prophet-platform",
+    "policy-fabric",
+    "agentplane",
+    "global-devsecops-intelligence",
+    "alexandrian-academy",
+    "sociosphere",
+}
+
+
+def main() -> int:
+    if not RULES.exists():
+        print(f"Missing broker propagation rules: {RULES}")
+        return 1
+
+    text = RULES.read_text(encoding="utf-8")
+    rule_ids = set(re.findall(r"^\s*-\s+id:\s*([a-z0-9._-]+)\s*$", text, flags=re.MULTILINE))
+    repos = set(re.findall(r"^\s*-\s+repo:\s*([a-z0-9._-]+)\s*$", text, flags=re.MULTILINE))
+
+    missing_rules = sorted(REQUIRED_RULE_IDS - rule_ids)
+    missing_repos = sorted(REQUIRED_AFFECTED_REPOS - repos)
+
+    if missing_rules:
+        print("Missing broker propagation rule ids:")
+        for item in missing_rules:
+            print(f" - {item}")
+    if missing_repos:
+        print("Missing affected repositories:")
+        for item in missing_repos:
+            print(f" - {item}")
+
+    if missing_rules or missing_repos:
+        return 1
+
+    print("Broker propagation rules include required rule ids and affected repos.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the SocioSphere integration binding for the cross-cloud services broker reasoning loop.

It documents SocioSphere as the workspace governance and propagation layer for broker-related standards, implementation, policy, execution, intelligence, and learning changes.

## Adds

- `docs/integration/next-gen-broker-reasoning.md`

## Scope

This is documentation only. It does not implement downstream broker features in SocioSphere.
