### PR TITLE
Add SocioProphet repo governance matrix v0

### DIFF
--- a/.github/workflows/repo-governance-matrix.yml
+++ b/.github/workflows/repo-governance-matrix.yml
@@ -1,0 +1,29 @@
+name: Repo Governance Matrix
+
+on:
+  pull_request:
+    paths:
+      - "registry/repo-governance-matrix-v0.yaml"
+      - "tools/validate_repo_governance_matrix.py"
+      - ".github/workflows/repo-governance-matrix.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "registry/repo-governance-matrix-v0.yaml"
+      - "tools/validate_repo_governance_matrix.py"
+      - ".github/workflows/repo-governance-matrix.yml"
+
+jobs:
+  validate-repo-governance-matrix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate repo governance matrix
+        run: python tools/validate_repo_governance_matrix.py

--- a/docs/governance/repo-governance-matrix-v0.md
+++ b/docs/governance/repo-governance-matrix-v0.md
@@ -1,0 +1,58 @@
+# SocioProphet repository governance matrix v0
+
+Status: draft
+Date: 2026-04-26
+Owner: Sociosphere governance layer
+
+This matrix classifies current SocioProphet estate repositories by governance role. It prevents roadmap, standards, runtime, and provenance repositories from being treated as interchangeable authority sources.
+
+## Governance classes
+
+- `canonical`: authoritative repositories allowed to define current platform contracts, runtime behavior, release gates, transport semantics, execution semantics, ontology terms, public surface behavior, or governance state.
+- `promotion-candidate`: active repositories that need scope hardening, canonical consumers, validation, or ADR/Sociosphere registration before becoming authority sources.
+- `provenance-only`: historical, archival, salvage, mirror, or experimental material. Evidence, not authority.
+
+## Canonical repositories
+
+| Repository | Primary function | Authority boundary |
+|---|---|---|
+| `SocioProphet/socioprophet` | Public/application surface, surface inventory, schemas, semantic registry, UI, control-plane material | Public surface behavior and repo-local contracts. Generalized standards should graduate out. |
+| `SocioProphet/prophet-platform` | Core platform contracts, capabilities, release/publication gates, registry publication, platform services | Platform release and publication machinery. |
+| `SocioProphet/sociosphere` | Workspace governance, decision-plane registration, build intelligence, propagation awareness | Cross-repo build intelligence and governance state. |
+| `SocioProphet/agentplane` | Execution control plane: bundle, validate, place, run, evidence, replay | Agent execution and evidence semantics. |
+| `SocioProphet/TriTRPC` | Deterministic authenticated RPC and transport semantics | Transport/protocol semantics. |
+| `SocioProphet/ontogenesis` | RDF/OWL/JSON-LD ontology engineering, SHACL gates, contexts, ontology catalog | Ontology terms and SHACL validation. |
+
+## Promotion candidates
+
+| Repository | Function | Promotion condition | Risk |
+|---|---|---|---|
+| `SocioProphet/policy-fabric` | Cross-platform policy fabric | Promote when canonical repos import it as authoritative policy source or enforcement package. | Policy duplication across repos. |
+| `SocioProphet/prophet-platform-standards` | Reusable platform standards | Promote when referenced by `prophet-platform` release gates and Sociosphere registration. | Standards drift from runtime platform. |
+| `SocioProphet/prophet-workspace` | Workspace model and implementation lane | Promote when Sociosphere delegates concrete workspace behavior to this repo. | Scope overlap with `sociosphere`. |
+| `SocioProphet/socioprophet-agent-standards` | Agent standards | Promote when adopted by `agentplane` and `socioprophet` as shared contract. | Competing with `agentplane` local definitions. |
+| `SocioProphet/socioprophet-standards-storage` | Storage and incident-intelligence standards | Promote when storage contracts are imported by runtime or platform repos. | Storage semantics fragment across platform/app layers. |
+| `SocioProphet/socioprophet-standards-knowledge` | Knowledge-context, publication, masking, tokenization standards | Promote when wired into `ontogenesis`, `socioprophet`, and knowledge surfaces. | Knowledge semantics split across docs/surfaces/ontology. |
+| `SocioProphet/gaia-world-model` | Auditable world-model scaffolding | Promote when GAIA domain model is explicitly imported by platform or ontology spine. | Domain scope outpaces validation. |
+| `SocioProphet/slash-topics` | Governed topic packs and semantic BI outputs | Promote when outputs feed live surface ontology, search, or analytics. | Topic taxonomy drift from `config/surfaces.json`. |
+
+## Provenance-only by default
+
+| Repository/pattern | Use | Restriction |
+|---|---|---|
+| `mdheller/socioprophet-old` | Historical implementation reference | Must not define current contracts. |
+| `SocioProphet/socioprophet-web-medium` | Historical web material | Must not define current public surface behavior. |
+| `SocioProphet/tritrpc-notes-archive` | TriTRPC notes archive | Must not supersede `TriTRPC`. |
+| WIP salvage or mirror branches/repos | Recovery and audit continuity | Must be explicitly promoted before use as authority. |
+| One-off integration scaffolds | Experiment capture | Must not define global standards without ADR or Sociosphere registration. |
+
+## Authority boundaries
+
+1. Public surface behavior belongs in `socioprophet` unless it is reusable platform behavior.
+2. Platform release gates and publication mechanics belong in `prophet-platform`.
+3. Cross-repo awareness and build-intelligence registration belongs in `sociosphere`.
+4. Agent execution semantics belong in `agentplane`.
+5. Transport semantics belong in `TriTRPC`.
+6. Ontology terms and SHACL validation belong in `ontogenesis`.
+7. Standards repos require explicit import, ADR, or registration to be authoritative.
+8. Provenance repos are evidence, not authority.

--- a/registry/repo-governance-matrix-v0.yaml
+++ b/registry/repo-governance-matrix-v0.yaml
@@ -1,0 +1,129 @@
+version: 0.1.0
+status: draft
+date: 2026-04-26
+owner: sociosphere-governance
+purpose: Classify SocioProphet estate repositories by governance authority.
+classes:
+  canonical:
+    description: Authoritative repositories for current platform authority.
+  promotion_candidate:
+    description: Active repositories that require promotion before becoming authoritative.
+  provenance_only:
+    description: Historical or experimental evidence sources, not current authority.
+repositories:
+  - name: SocioProphet/socioprophet
+    class: canonical
+    function: public_application_surface
+    authority:
+      contracts: true
+      runtime_behavior: true
+      standards: limited_repo_local
+      evidence_state: true
+  - name: SocioProphet/prophet-platform
+    class: canonical
+    function: core_platform_contracts_capabilities_release_publication
+    authority:
+      contracts: true
+      runtime_behavior: true
+      standards: platform_local
+      evidence_state: true
+  - name: SocioProphet/sociosphere
+    class: canonical
+    function: workspace_governance_build_intelligence_registration
+    authority:
+      contracts: true
+      runtime_behavior: limited
+      standards: governance_local
+      evidence_state: true
+  - name: SocioProphet/agentplane
+    class: canonical
+    function: execution_control_plane
+    authority:
+      contracts: true
+      runtime_behavior: true
+      standards: execution_local
+      evidence_state: true
+  - name: SocioProphet/TriTRPC
+    class: canonical
+    function: deterministic_authenticated_transport
+    authority:
+      contracts: true
+      runtime_behavior: true
+      standards: protocol_local
+      evidence_state: true
+  - name: SocioProphet/ontogenesis
+    class: canonical
+    function: ontology_shacl_contexts_catalog
+    authority:
+      contracts: true
+      runtime_behavior: false
+      standards: true
+      evidence_state: true
+  - name: SocioProphet/policy-fabric
+    class: promotion_candidate
+    function: cross_platform_policy_fabric
+    promotion_condition: Canonical repos import it as authoritative policy source or enforcement package.
+    risk: policy_duplication_across_repos
+  - name: SocioProphet/prophet-platform-standards
+    class: promotion_candidate
+    function: reusable_platform_standards
+    promotion_condition: Referenced by prophet-platform release gates and Sociosphere registration.
+    risk: standards_drift_from_runtime_platform
+  - name: SocioProphet/prophet-workspace
+    class: promotion_candidate
+    function: workspace_model_implementation_lane
+    promotion_condition: Sociosphere delegates concrete workspace behavior to this repo.
+    risk: scope_overlap_with_sociosphere
+  - name: SocioProphet/socioprophet-agent-standards
+    class: promotion_candidate
+    function: agent_standards
+    promotion_condition: Adopted by agentplane and socioprophet as shared contract.
+    risk: competing_with_agentplane_repo_local_definitions
+  - name: SocioProphet/socioprophet-standards-storage
+    class: promotion_candidate
+    function: storage_and_incident_intelligence_standards
+    promotion_condition: Storage contracts are imported by runtime or platform repos.
+    risk: storage_semantics_fragment_between_platform_and_app_layers
+  - name: SocioProphet/socioprophet-standards-knowledge
+    class: promotion_candidate
+    function: knowledge_context_publication_masking_tokenization_standards
+    promotion_condition: Wired into ontogenesis, socioprophet, and knowledge surfaces.
+    risk: knowledge_semantics_split_across_docs_surfaces_ontology
+  - name: SocioProphet/gaia-world-model
+    class: promotion_candidate
+    function: auditable_world_model_scaffolding
+    promotion_condition: GAIA domain model is explicitly imported by platform or ontology spine.
+    risk: domain_scope_outpaces_validation
+  - name: SocioProphet/slash-topics
+    class: promotion_candidate
+    function: governed_topic_packs_semantic_bi_outputs
+    promotion_condition: Outputs feed live surface ontology search or analytics.
+    risk: topic_taxonomy_drift_from_config_surfaces_json
+  - name: mdheller/socioprophet-old
+    class: provenance_only
+    function: historical_implementation_reference
+    restriction: must_not_define_current_contracts
+  - name: SocioProphet/socioprophet-web-medium
+    class: provenance_only
+    function: historical_web_material
+    restriction: must_not_define_current_public_surface_behavior
+  - name: SocioProphet/tritrpc-notes-archive
+    class: provenance_only
+    function: tritrpc_notes_archive
+    restriction: must_not_supersede_TriTRPC
+authority_boundaries:
+  - public_surface_behavior_belongs_in_socioprophet_unless_reusable_platform_behavior
+  - platform_release_gates_and_publication_mechanics_belong_in_prophet_platform
+  - cross_repo_awareness_and_build_intelligence_registration_belong_in_sociosphere
+  - agent_execution_semantics_belong_in_agentplane
+  - transport_semantics_belong_in_TriTRPC
+  - ontology_terms_and_SHACL_validation_belong_in_ontogenesis
+  - standards_repos_require_explicit_import_ADR_or_registration_to_be_authoritative
+  - provenance_repos_are_evidence_not_authority
+promotion_checklist:
+  - declared_scope_boundary
+  - canonical_repo_consumer
+  - ci_or_validation_gates
+  - sociosphere_registration_or_ADR_linkage
+  - ownership_or_RACI_statement
+  - deprecation_rule_for_overlapping_definitions

--- a/status/build-intelligence/sociosphere-repo-governance-matrix-2026-04-26.yaml
+++ b/status/build-intelligence/sociosphere-repo-governance-matrix-2026-04-26.yaml
@@ -1,0 +1,49 @@
+record_type: build-intelligence
+record_version: 0.1.0
+date: 2026-04-26
+repo: SocioProphet/sociosphere
+branch: repo-governance-matrix-v0
+subject: repo-governance-matrix
+status: proposed
+summary: >-
+  Registers the SocioProphet repository governance matrix tranche. The tranche
+  classifies repositories as canonical, promotion-candidate, or provenance-only
+  and adds a zero-dependency validator plus CI gate for the machine-readable
+  matrix.
+artifacts:
+  - docs/governance/repo-governance-matrix-v0.md
+  - registry/repo-governance-matrix-v0.yaml
+  - tools/validate_repo_governance_matrix.py
+  - .github/workflows/repo-governance-matrix.yml
+governance_classes:
+  canonical:
+    - SocioProphet/socioprophet
+    - SocioProphet/prophet-platform
+    - SocioProphet/sociosphere
+    - SocioProphet/agentplane
+    - SocioProphet/TriTRPC
+    - SocioProphet/ontogenesis
+  promotion_candidate:
+    - SocioProphet/policy-fabric
+    - SocioProphet/prophet-platform-standards
+    - SocioProphet/prophet-workspace
+    - SocioProphet/socioprophet-agent-standards
+    - SocioProphet/socioprophet-standards-storage
+    - SocioProphet/socioprophet-standards-knowledge
+    - SocioProphet/gaia-world-model
+    - SocioProphet/slash-topics
+  provenance_only:
+    - mdheller/socioprophet-old
+    - SocioProphet/socioprophet-web-medium
+    - SocioProphet/tritrpc-notes-archive
+validation:
+  validator: tools/validate_repo_governance_matrix.py
+  ci_workflow: .github/workflows/repo-governance-matrix.yml
+risk: low
+limitations:
+  - Matrix is draft v0 and should be reviewed against current org inventory before canonical promotion.
+  - Validator is structural and intentionally does not yet query GitHub for repo existence or branch state.
+next_steps:
+  - Add repo-existence and archived-state checks.
+  - Add ownership/RACI fields.
+  - Add promotion decision records for policy-fabric and prophet-platform-standards.

--- a/tools/validate_repo_governance_matrix.py
+++ b/tools/validate_repo_governance_matrix.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+import sys
+
+MATRIX = Path("registry/repo-governance-matrix-v0.yaml")
+VALID_CLASSES = {"canonical", "promotion_candidate", "provenance_only"}
+REQUIRED_AUTHORITY_FIELDS = {"contracts", "runtime_behavior", "standards", "evidence_state"}
+
+
+def fail(message: str) -> int:
+    print(f"repo-governance-matrix: ERROR: {message}", file=sys.stderr)
+    return 1
+
+
+def parse_repos(text: str) -> list[dict[str, object]]:
+    repos = []
+    current = None
+    in_authority = False
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("- name: "):
+            if current is not None:
+                repos.append(current)
+            current = {"name": stripped.removeprefix("- name: ").strip(), "authority": {}}
+            in_authority = False
+            continue
+        if current is None or not stripped or stripped.startswith("#"):
+            continue
+        if stripped == "authority:":
+            in_authority = True
+            continue
+        if re.match(r"^[A-Za-z_]+:", stripped):
+            key, value = stripped.split(":", 1)
+            key = key.strip()
+            value = value.strip()
+            if in_authority and key in REQUIRED_AUTHORITY_FIELDS:
+                current["authority"][key] = value
+            elif key in {"class", "function", "promotion_condition", "risk", "restriction"}:
+                current[key] = value
+                in_authority = False
+    if current is not None:
+        repos.append(current)
+    return repos
+
+
+def main() -> int:
+    if not MATRIX.exists():
+        return fail(f"missing {MATRIX}")
+    repos = parse_repos(MATRIX.read_text(encoding="utf-8"))
+    if not repos:
+        return fail("no repository entries found")
+    seen = set()
+    classes = set()
+    for repo in repos:
+        name = str(repo.get("name", "")).strip()
+        klass = str(repo.get("class", "")).strip()
+        if not name:
+            return fail("repository entry without name")
+        if name in seen:
+            return fail(f"duplicate repository entry: {name}")
+        seen.add(name)
+        if klass not in VALID_CLASSES:
+            return fail(f"{name} has invalid class {klass!r}")
+        classes.add(klass)
+        if not str(repo.get("function", "")).strip():
+            return fail(f"{name} missing function")
+        if klass == "canonical":
+            missing = REQUIRED_AUTHORITY_FIELDS - set(repo.get("authority", {}))
+            if missing:
+                return fail(f"{name} missing authority fields: {', '.join(sorted(missing))}")
+        if klass == "promotion_candidate":
+            if not str(repo.get("promotion_condition", "")).strip():
+                return fail(f"{name} missing promotion_condition")
+            if not str(repo.get("risk", "")).strip():
+                return fail(f"{name} missing risk")
+        if klass == "provenance_only" and not str(repo.get("restriction", "")).strip():
+            return fail(f"{name} missing restriction")
+    missing_classes = VALID_CLASSES - classes
+    if missing_classes:
+        return fail(f"missing governance classes: {', '.join(sorted(missing_classes))}")
+    print(f"repo-governance-matrix: OK ({len(repos)} repositories)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Reopens the stabilized SocioProphet repo governance matrix tranche against current upstream.

Adds:
- Markdown governance matrix
- machine-readable YAML matrix
- zero-dependency validator
- narrow CI gate
- build-intelligence registration record

Scope: governance metadata and validation only. No runtime behavior changes.