### PR TITLE
Register Lattice platform asset spine

### DIFF
--- a/.github/workflows/lattice-asset-spine.yml
+++ b/.github/workflows/lattice-asset-spine.yml
@@ -1,0 +1,23 @@
+name: lattice-asset-spine
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validation dependencies
+        run: python -m pip install --upgrade pip pyyaml
+      - name: Validate Lattice platform asset spine registry
+        run: python scripts/validate_lattice_asset_spine.py

--- a/registry/lattice-platform-asset-spine.yaml
+++ b/registry/lattice-platform-asset-spine.yaml
@@ -1,0 +1,78 @@
+schema_version: 1
+name: lattice-platform-asset-spine
+canonical_identity: PlatformAssetRecord
+owner_repo: SocioProphet/prophet-platform
+purpose: >-
+  Registers the cross-repo Prophet Lattice product-surface metadata spine so
+  boot, runtime, search, topics, semantic governance, contract, policy, and
+  model-governance integrations share one asset identity.
+
+producer_surfaces:
+  - repo: SourceOS-Linux/sourceos-boot
+    handoff_object: BootReleaseSet v1
+    platform_asset_kind: boot-release-set
+    role: boot-live-installer-recovery-rollback
+  - repo: SocioProphet/lattice-forge
+    handoff_object: RuntimeAsset v1
+    platform_asset_kind: runtime-asset
+    role: runtime-package-kernel-sbom-provenance-scan
+
+canonical_platform:
+  repo: SocioProphet/prophet-platform
+  app: apps/lattice-surface-ingestor
+  canonical_record: PlatformAssetRecord
+  record_set: PlatformAssetRecordSet
+  enrichment_set: PlatformAssetRecordEnrichmentSet
+  generated_artifacts:
+    - build/lattice-surface-ingestor/lattice-surface-records.json
+    - build/lattice-surface-ingestor/lattice-surface-enrichments.json
+    - build/lattice-surface-ingestor/store/manifest.json
+
+consumers:
+  - repo: SocioProphet/sherlock-search
+    fixture: contracts/lattice/platform-asset-index-document.v1.schema.json
+    consumes: PlatformAssetRecordEnrichment.search
+    role: search-discovery-indexing
+  - repo: SocioProphet/slash-topics
+    fixture: protocols/lattice/platform-asset-topic-pack.v1.json
+    consumes: PlatformAssetRecordEnrichment.slashTopics
+    role: governed-topic-scoping
+  - repo: SocioProphet/new-hope
+    fixture: fixtures/lattice/platform-asset-carrier.v1.json
+    consumes: PlatformAssetRecordEnrichment.newHope
+    role: semantic-carrier-membrane-governance
+  - repo: SocioProphet/contractforge
+    fixture: examples/lattice/platform-asset-contract-reference.v1.json
+    consumes: PlatformAssetRecordEnrichment.contractForge
+    role: contract-referenced-asset-modeling
+  - repo: SocioProphet/policy-fabric
+    fixture: examples/lattice/platform-asset-policy-subject.v1.json
+    consumes: PlatformAssetRecordEnrichment.policyFabric
+    role: policy-subject-validation-replay
+  - repo: SocioProphet/graphbrain-contract
+    fixture: examples/lattice/platform-runtime-context.v1.json
+    consumes: PlatformAssetRecordEnrichment.languageModeling
+    role: runtime-model-governance-context
+
+invariants:
+  - PlatformAssetRecord.assetId is the canonical asset identity.
+  - Downstream repos may add enrichments, fixtures, envelopes, and mappings.
+  - Downstream repos must not replace PlatformAssetRecord.assetId with local canonical IDs for the same asset.
+  - Search, topic, semantic-governance, contract, policy, and model-governance layers must remain derivable from the same platform record.
+  - Generated enrichments must be sidecars, not destructive edits to producer records.
+
+next_required_links:
+  - repo: SocioProphet/sociosphere
+    task: add topology dependency checks against this registry
+  - repo: SocioProphet/prophet-platform
+    task: persist records and enrichments into catalog/evidence service
+  - repo: SocioProphet/sherlock-search
+    task: add ingestion converter from PlatformAssetRecordEnrichmentSet
+  - repo: SocioProphet/slash-topics
+    task: add replay fixture proving deterministic topic output
+  - repo: SocioProphet/new-hope
+    task: add membrane replay fixture
+  - repo: SocioProphet/contractforge
+    task: add explanation fixture for approval and rollback state
+  - repo: SocioProphet/policy-fabric
+    task: add validation/replay report fixture

--- a/scripts/validate_lattice_asset_spine.py
+++ b/scripts/validate_lattice_asset_spine.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Validate the Sociosphere Lattice platform asset spine registry."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+REQUIRED_CONSUMERS = {
+    "SocioProphet/sherlock-search",
+    "SocioProphet/slash-topics",
+    "SocioProphet/new-hope",
+    "SocioProphet/contractforge",
+    "SocioProphet/policy-fabric",
+    "SocioProphet/graphbrain-contract",
+}
+REQUIRED_PRODUCERS = {"SourceOS-Linux/sourceos-boot", "SocioProphet/lattice-forge"}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def minimal_yaml_load(path: Path) -> dict:
+    if yaml is not None:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        require(isinstance(data, dict), "registry must decode to object")
+        return data
+    raise RuntimeError("PyYAML is required for registry validation")
+
+
+def validate(path: Path) -> None:
+    data = minimal_yaml_load(path)
+    require(data.get("schema_version") == 1, "schema_version must be 1")
+    require(data.get("canonical_identity") == "PlatformAssetRecord", "canonical_identity must be PlatformAssetRecord")
+    require(data.get("owner_repo") == "SocioProphet/prophet-platform", "owner_repo mismatch")
+
+    producers = data.get("producer_surfaces")
+    require(isinstance(producers, list) and producers, "producer_surfaces must be non-empty")
+    producer_repos = {item.get("repo") for item in producers if isinstance(item, dict)}
+    require(REQUIRED_PRODUCERS.issubset(producer_repos), f"missing producers: {sorted(REQUIRED_PRODUCERS - producer_repos)}")
+
+    consumers = data.get("consumers")
+    require(isinstance(consumers, list) and consumers, "consumers must be non-empty")
+    consumer_repos = {item.get("repo") for item in consumers if isinstance(item, dict)}
+    require(REQUIRED_CONSUMERS.issubset(consumer_repos), f"missing consumers: {sorted(REQUIRED_CONSUMERS - consumer_repos)}")
+
+    invariants = data.get("invariants")
+    require(isinstance(invariants, list) and invariants, "invariants must be non-empty")
+    invariant_text = "\n".join(str(item) for item in invariants)
+    require("PlatformAssetRecord.assetId" in invariant_text, "assetId invariant missing")
+
+
+def main(argv: list[str] | None = None) -> int:
+    path = Path(argv[0]) if argv else Path("registry/lattice-platform-asset-spine.yaml")
+    try:
+        validate(path)
+        print(f"PASS {path}")
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL {path}: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Registers the Prophet Lattice `PlatformAssetRecord` cross-repo metadata spine in Sociosphere.

## What changed

- Adds `registry/lattice-platform-asset-spine.yaml`.
- Adds `scripts/validate_lattice_asset_spine.py`.
- Adds CI workflow `.github/workflows/lattice-asset-spine.yml`.

## Why

The Lattice asset integration now spans producer repos (`sourceos-boot`, `lattice-forge`), the platform (`prophet-platform`), and downstream consumers (`sherlock-search`, `slash-topics`, `new-hope`, `contractforge`, `policy-fabric`, `graphbrain-contract`). Sociosphere needs to register this as topology, not rely on scattered docs.

## Validation

The validator enforces the canonical identity, required producers, required consumers, and non-duplication invariant around `PlatformAssetRecord.assetId`.
