### PR TITLE
Register placement dry-run decision artifact

### DIFF
--- a/registry/lattice-placement-spine.yaml
+++ b/registry/lattice-placement-spine.yaml
@@ -6,7 +6,8 @@ purpose: >-
   Registers governed placement lanes for Lattice Studio, including BYOC storage,
   BYOC compute, BYOC I/O, CloudShell Fog shell placement, notebook placement,
   command-line notebook placement, SourceOS M2 registry mounts, TopoLVM local
-  storage, and Inception agent cluster placement.
+  storage, Inception agent cluster placement, and the PlacementDryRunReport
+  decision artifact that answers whether a promoted workload can run here.
 
 producer_surfaces:
   - repo: SocioProphet/prophet-platform
@@ -14,7 +15,8 @@ producer_surfaces:
       - BYOCPlacementPlan
       - UnifiedNotebookShellPlacementPlan
       - M2TopoLVMPlacementPlan
-    role: canonical Studio placement record producer
+      - PlacementDryRunReport
+    role: canonical Studio placement record and run-readiness decision producer
   - repo: SocioProphet/cloudshell-fog
     records:
       - CloudShellFogBinding
@@ -84,6 +86,17 @@ placement_lanes:
       - inception-agent-cluster-binding
       - proof-index-mounted
       - safety-boundary-no-host-mutation
+  placement_decision:
+    canonical_record: PlacementDryRunReport
+    purpose: can-this-run-here decision artifact for BYOC, CloudShell Fog, M2 TopoLVM, notebook launch, and notebook promotion paths
+    required_checks:
+      - byoc-compute-targets
+      - byoc-storage-targets
+      - byoc-io-bindings
+      - cloudshell-fog-terminal-path
+      - m2-topolvm-safety-boundary
+      - notebook-adapter-launch-coverage
+      - promotion-target-coverage
 
 consumers:
   - repo: SocioProphet/sherlock-search
@@ -91,13 +104,15 @@ consumers:
       - BYOCPlacementPlan
       - UnifiedNotebookShellPlacementPlan
       - M2TopoLVMPlacementPlan
-    role: indexes placement records as searchable platform assets
+      - PlacementDryRunReport
+    role: indexes placement records and run-readiness decisions as searchable platform assets
   - repo: SocioProphet/prophet-cli
     consumes:
       - BYOCPlacementPlan
       - UnifiedNotebookShellPlacementPlan
       - M2TopoLVMPlacementPlan
-    role: should expose placement dry-run and inspection commands
+      - PlacementDryRunReport
+    role: exposes placement dry-run, inspection, and can-this-run-here commands
   - repo: SocioProphet/sociosphere
     consumes:
       - lattice-placement-spine
@@ -105,6 +120,7 @@ consumers:
 
 invariants:
   - Placement records must remain side-effect-free unless an executor explicitly enters an approved execution path.
+  - PlacementDryRunReport is the canonical can-this-run-here decision artifact.
   - SourceOS M2 registry mounts are proof artifacts and must not mutate host boot state.
   - TopoLVM placement must be dry-run until a separate executor is approved.
   - CloudShell Fog and notebook placement must share policy, trust tier, data locality, audit, and telemetry semantics.
@@ -112,8 +128,8 @@ invariants:
 
 next_required_links:
   - repo: SocioProphet/prophet-platform
-    task: add dry-run executor report for BYOC and notebook placement plans
+    task: add an executor that consumes PlacementDryRunReport and emits an approved execution plan without violating safety boundaries
   - repo: SocioProphet/prophet-cli
-    task: expose BYOC, notebook-shell, and M2 TopoLVM placement commands
+    task: expose BYOC, notebook-shell, M2 TopoLVM, and PlacementDryRunReport commands
   - repo: SocioProphet/sherlock-search
-    task: add facets for placement lane, storage kind, compute kind, and I/O kind
+    task: add facets for placement lane, storage kind, compute kind, I/O kind, and decision status

--- a/scripts/validate_lattice_placement_spine.py
+++ b/scripts/validate_lattice_placement_spine.py
@@ -14,8 +14,23 @@ REQUIRED_PRODUCERS = {
     "SociOS-Linux/cloudshell-fog",
     "SourceOS-Linux/dnote",
 }
-REQUIRED_RECORDS = {"BYOCPlacementPlan", "UnifiedNotebookShellPlacementPlan", "M2TopoLVMPlacementPlan"}
+REQUIRED_RECORDS = {
+    "BYOCPlacementPlan",
+    "UnifiedNotebookShellPlacementPlan",
+    "M2TopoLVMPlacementPlan",
+    "PlacementDryRunReport",
+}
 REQUIRED_CONSUMERS = {"SocioProphet/sherlock-search", "SocioProphet/prophet-cli", "SocioProphet/sociosphere"}
+REQUIRED_LANES = {"byoc", "cloudshell_fog", "command_line_notebook", "m2_topolvm", "placement_decision"}
+REQUIRED_DECISION_CHECKS = {
+    "byoc-compute-targets",
+    "byoc-storage-targets",
+    "byoc-io-bindings",
+    "cloudshell-fog-terminal-path",
+    "m2-topolvm-safety-boundary",
+    "notebook-adapter-launch-coverage",
+    "promotion-target-coverage",
+}
 
 
 def require(condition: bool, message: str) -> None:
@@ -36,14 +51,22 @@ def validate(path: Path) -> None:
     require(REQUIRED_RECORDS.issubset(record_names), f"missing records: {sorted(REQUIRED_RECORDS - record_names)}")
     lanes = data.get("placement_lanes")
     require(isinstance(lanes, dict), "placement_lanes must be object")
-    for key in ["byoc", "cloudshell_fog", "command_line_notebook", "m2_topolvm"]:
+    for key in REQUIRED_LANES:
         require(key in lanes, f"missing placement lane {key}")
+    decision = lanes.get("placement_decision")
+    require(isinstance(decision, dict), "placement_decision must be object")
+    require(decision.get("canonical_record") == "PlacementDryRunReport", "placement decision canonical record mismatch")
+    checks = set(decision.get("required_checks", []))
+    require(REQUIRED_DECISION_CHECKS.issubset(checks), f"missing decision checks: {sorted(REQUIRED_DECISION_CHECKS - checks)}")
     consumers = data.get("consumers")
     require(isinstance(consumers, list) and consumers, "consumers must be non-empty")
     consumer_repos = {item.get("repo") for item in consumers if isinstance(item, dict)}
     require(REQUIRED_CONSUMERS.issubset(consumer_repos), f"missing consumers: {sorted(REQUIRED_CONSUMERS - consumer_repos)}")
+    consumed_records = {record for item in consumers if isinstance(item, dict) for record in item.get("consumes", [])}
+    require("PlacementDryRunReport" in consumed_records, "PlacementDryRunReport must be consumed")
     invariant_text = "\n".join(str(item) for item in data.get("invariants", []))
     require("side-effect-free" in invariant_text, "side-effect-free invariant missing")
+    require("PlacementDryRunReport" in invariant_text, "PlacementDryRunReport invariant missing")
     require("PlatformAssetRecord" in invariant_text, "PlatformAssetRecord invariant missing")
 
 


### PR DESCRIPTION
Registers PlacementDryRunReport as the canonical can-this-run-here decision artifact in the Lattice placement spine. Updates the registry and validator so BYOC, CloudShell Fog, M2 TopoLVM, notebook launch, and notebook promotion decision checks are enforced.