### PR TITLE
Register Lattice federated query spine

### DIFF
--- a/.github/workflows/lattice-federated-query-spine.yml
+++ b/.github/workflows/lattice-federated-query-spine.yml
@@ -1,0 +1,23 @@
+name: lattice-federated-query-spine
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validation dependencies
+        run: python -m pip install --upgrade pip pyyaml
+      - name: Validate Lattice federated query spine registry
+        run: python scripts/validate_lattice_federated_query_spine.py

--- a/registry/lattice-federated-query-spine.yaml
+++ b/registry/lattice-federated-query-spine.yaml
@@ -1,0 +1,198 @@
+schema_version: 1
+name: lattice-federated-query-spine
+owner_repo: SocioProphet/prophet-platform
+canonical_identity: PlatformAssetRecord
+purpose: >-
+  Registers governed federated query lanes for Lattice Studio across SQL-compatible
+  query via Apache Drill, document storage, annotation stores, SPARQL, ontology
+  query, Cypher/property graphs, GraphBrain hypergraphs, OpenCog AtomSpace/Atomese,
+  Sherlock Search, Slash Topics, New Hope, and Lampstand local search.
+
+producer_surfaces:
+  - repo: SocioProphet/prophet-platform
+    records:
+      - FederatedQueryPlane
+      - FederatedQueryEvidence
+    role: canonical Lattice Studio federated query plane producer
+  - repo: SocioProphet/sherlock-search
+    records:
+      - SherlockIndexDocument
+      - PlatformAssetRecord conversion fixture
+    role: canonical hybrid search and platform-record query index
+  - repo: SocioProphet/slash-topics
+    records:
+      - TopicPack
+      - PolicyMembrane
+      - DeterministicReceipt
+    role: governed signed scoped search and query packs
+  - repo: SocioProphet/new-hope
+    records:
+      - Message
+      - Thread
+      - Claim
+      - Citation
+      - Entity
+      - Lens
+      - ModerationEvent
+      - MembraneDecision
+    role: higher-order semantic runtime and membrane query source
+  - repo: SocioProphet/lampstand
+    records:
+      - LocalIndex
+      - FTS5Result
+      - LocalIndexHealth
+      - DataHubPromotionCandidate
+    role: local desktop and workspace file search source
+  - repo: SocioProphet/ontogenesis
+    records:
+      - OntologyContext
+      - SHACLShape
+      - SchemaAlignment
+    role: ontology and semantic-governance query source
+  - repo: SocioProphet/graphbrain-contract
+    records:
+      - HypergraphQueryContract
+    role: GraphBrain-style semantic hypergraph query contract
+
+query_lanes:
+  sql:
+    canonical_backend: apache-drill
+    backend_kind: drill-sql
+    language: sql
+    required_capabilities:
+      - lakehouse-query
+      - object-lake-query
+      - table-query
+      - jdbc-compatible-results
+  documents:
+    canonical_backend: document-store
+    backend_kind: document-store
+    language: document-query
+    required_capabilities:
+      - metadata-query
+      - full-text-query
+      - document-id-query
+      - policy-scoped-document-access
+  annotations:
+    canonical_backend: annotation-store
+    backend_kind: annotation-store
+    language: annotation-query
+    required_capabilities:
+      - label-query
+      - claim-query
+      - target-query
+      - provenance-query
+  sparql:
+    canonical_backend: rdf-store
+    backend_kind: rdf-store
+    language: sparql
+    required_capabilities:
+      - triple-pattern-query
+      - named-graph-query
+      - ontology-backed-query
+  ontology:
+    canonical_backend: ontogenesis
+    backend_kind: ontology-reasoner
+    language: ontology-query
+    required_capabilities:
+      - class-query
+      - shape-query
+      - constraint-query
+      - schema-alignment-query
+      - reasoning-result-query
+  cypher:
+    canonical_backend: property-graph
+    backend_kind: property-graph
+    language: cypher
+    required_capabilities:
+      - node-edge-query
+      - path-query
+      - graph-facet-query
+  graphbrain:
+    canonical_backend: graphbrain-contract
+    backend_kind: hypergraph-store
+    language: graphbrain-hypergraph
+    required_capabilities:
+      - hyperedge-query
+      - semantic-frame-query
+      - claim-hypergraph-query
+  atomese:
+    canonical_backend: opencog-atomspace
+    backend_kind: atomspace
+    language: atomese
+    required_capabilities:
+      - atomspace-query
+      - atomese-pattern-query
+      - cognitive-graph-query
+  sherlock:
+    canonical_backend: SocioProphet/sherlock-search
+    backend_kind: sherlock-index
+    language: sherlock-query
+    required_capabilities:
+      - hybrid-search
+      - platform-record-query
+      - evidence-query
+      - query-replay-receipts
+  slash_topics:
+    canonical_backend: SocioProphet/slash-topics
+    backend_kind: slash-topic-pack
+    language: slash-topic-query
+    required_capabilities:
+      - signed-topic-pack-query
+      - policy-membrane-query
+      - deterministic-receipt-query
+      - scoped-search-query
+  new_hope:
+    canonical_backend: SocioProphet/new-hope
+    backend_kind: newhope-runtime
+    language: newhope-membrane-query
+    required_capabilities:
+      - message-query
+      - thread-query
+      - claim-query
+      - citation-query
+      - entity-query
+      - lens-query
+      - moderation-event-query
+      - membrane-decision-query
+  lampstand:
+    canonical_backend: SocioProphet/lampstand
+    backend_kind: lampstand-local-index
+    language: lampstand-local-query
+    required_capabilities:
+      - local-file-query
+      - sqlite-fts5-query
+      - health-query
+      - stats-query
+      - datahub-promotion-candidate-query
+
+consumers:
+  - repo: SocioProphet/prophet-cli
+    consumes:
+      - FederatedQueryPlane
+    role: exposes lattice-query command surface
+  - repo: SocioProphet/sherlock-search
+    consumes:
+      - FederatedQueryPlane
+      - PlatformAssetRecord
+    role: indexes query-plane records as searchable platform assets
+  - repo: SocioProphet/sociosphere
+    consumes:
+      - lattice-federated-query-spine
+    role: topology registration and validation
+
+invariants:
+  - FederatedQueryPlane is the canonical Lattice query-plane artifact.
+  - Query backends must be policy-bound and catalog-scoped.
+  - Sherlock, Slash Topics, New Hope, and Lampstand must be first-class query integrations, not compatibility labels only.
+  - Ontology query must remain distinct from SPARQL because reasoning, SHACL shapes, and schema alignment require explicit governance.
+  - Local Lampstand query must not silently promote local files into shared catalogs without a DataHubPromotionCandidate artifact.
+  - PlatformAssetRecord remains the shared identity for query-plane registration.
+
+next_required_links:
+  - repo: SocioProphet/prophet-platform
+    task: add executable dry-run query planner that validates backend routing without issuing remote queries
+  - repo: SocioProphet/sherlock-search
+    task: add facets for query language, backend kind, catalog scope, policy ref, and integration repo
+  - repo: SocioProphet/sociosphere
+    task: register query policy and query topology in global workspace/governance views

--- a/scripts/validate_lattice_federated_query_spine.py
+++ b/scripts/validate_lattice_federated_query_spine.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Validate the Sociosphere Lattice federated query spine registry."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REQUIRED_PRODUCERS = {
+    "SocioProphet/prophet-platform",
+    "SocioProphet/sherlock-search",
+    "SocioProphet/slash-topics",
+    "SocioProphet/new-hope",
+    "SocioProphet/lampstand",
+    "SocioProphet/ontogenesis",
+    "SocioProphet/graphbrain-contract",
+}
+REQUIRED_RECORDS = {"FederatedQueryPlane", "FederatedQueryEvidence"}
+REQUIRED_LANES = {
+    "sql",
+    "documents",
+    "annotations",
+    "sparql",
+    "ontology",
+    "cypher",
+    "graphbrain",
+    "atomese",
+    "sherlock",
+    "slash_topics",
+    "new_hope",
+    "lampstand",
+}
+REQUIRED_LANGUAGES = {
+    "sql",
+    "document-query",
+    "annotation-query",
+    "sparql",
+    "ontology-query",
+    "cypher",
+    "graphbrain-hypergraph",
+    "atomese",
+    "sherlock-query",
+    "slash-topic-query",
+    "newhope-membrane-query",
+    "lampstand-local-query",
+}
+REQUIRED_CONSUMERS = {"SocioProphet/prophet-cli", "SocioProphet/sherlock-search", "SocioProphet/sociosphere"}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def validate(path: Path) -> None:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    require(isinstance(data, dict), "registry must decode to object")
+    require(data.get("schema_version") == 1, "schema_version must be 1")
+    require(data.get("canonical_identity") == "PlatformAssetRecord", "canonical identity mismatch")
+    producers = data.get("producer_surfaces")
+    require(isinstance(producers, list) and producers, "producer_surfaces must be non-empty")
+    producer_repos = {item.get("repo") for item in producers if isinstance(item, dict)}
+    require(REQUIRED_PRODUCERS.issubset(producer_repos), f"missing producers: {sorted(REQUIRED_PRODUCERS - producer_repos)}")
+    record_names = {record for item in producers if isinstance(item, dict) for record in item.get("records", [])}
+    require(REQUIRED_RECORDS.issubset(record_names), f"missing query records: {sorted(REQUIRED_RECORDS - record_names)}")
+    lanes = data.get("query_lanes")
+    require(isinstance(lanes, dict), "query_lanes must be object")
+    for lane in REQUIRED_LANES:
+        require(lane in lanes, f"missing query lane {lane}")
+    languages = {item.get("language") for item in lanes.values() if isinstance(item, dict)}
+    require(REQUIRED_LANGUAGES.issubset(languages), f"missing languages: {sorted(REQUIRED_LANGUAGES - languages)}")
+    for lane_name, lane_doc in lanes.items():
+        require(isinstance(lane_doc, dict), f"lane {lane_name} must be object")
+        require(lane_doc.get("canonical_backend"), f"lane {lane_name} missing canonical_backend")
+        require(lane_doc.get("backend_kind"), f"lane {lane_name} missing backend_kind")
+        require(lane_doc.get("language"), f"lane {lane_name} missing language")
+        caps = lane_doc.get("required_capabilities")
+        require(isinstance(caps, list) and caps, f"lane {lane_name} must declare required_capabilities")
+    consumers = data.get("consumers")
+    require(isinstance(consumers, list) and consumers, "consumers must be non-empty")
+    consumer_repos = {item.get("repo") for item in consumers if isinstance(item, dict)}
+    require(REQUIRED_CONSUMERS.issubset(consumer_repos), f"missing consumers: {sorted(REQUIRED_CONSUMERS - consumer_repos)}")
+    consumed_records = {record for item in consumers if isinstance(item, dict) for record in item.get("consumes", [])}
+    require("FederatedQueryPlane" in consumed_records, "FederatedQueryPlane must be consumed")
+    invariant_text = "\n".join(str(item) for item in data.get("invariants", []))
+    for required in ["FederatedQueryPlane", "Sherlock", "Slash Topics", "New Hope", "Lampstand", "Ontology query", "PlatformAssetRecord"]:
+        require(required in invariant_text, f"missing invariant text for {required}")
+
+
+def main() -> int:
+    path = Path("registry/lattice-federated-query-spine.yaml")
+    try:
+        validate(path)
+        print(f"PASS {path}")
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL {path}: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Registers the Lattice federated query spine for Drill SQL, document, annotation, SPARQL, ontology, Cypher, GraphBrain, Atomese, Sherlock, Slash Topics, New Hope, and Lampstand query lanes. Adds registry, validator, and CI.