### PR TITLE
Add model-fabric agent work register

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ ui-dev: ui-preflight
 # --- end ui-workbench targets ---
 
 # --- standards validation targets ---
-.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate
+.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate
 
-validate: validate-standards program-dashboard-validate
+validate: validate-standards program-dashboard-validate model-fabric-work-register-validate
 	@echo "OK: validate"
 
 validate-standards:
@@ -33,6 +33,9 @@ validate-standards:
 
 program-dashboard-validate:
 	python3 tools/validate_program_dashboard.py
+
+model-fabric-work-register-validate:
+	python3 tools/validate_model_fabric_work_register.py
 
 multidomain-geospatial-standards-compliance-validate:
 	python3 tools/check_multidomain_geospatial_standards_compliance.py

--- a/examples/model-fabric-agent-work-register.example.json
+++ b/examples/model-fabric-agent-work-register.example.json
@@ -1,0 +1,77 @@
+{
+  "apiVersion": "sociosphere.socioprophet.dev/v1",
+  "kind": "AgentWorkRegister",
+  "metadata": {
+    "name": "model-fabric-agent-work-register",
+    "version": "0.1.0",
+    "generatedAt": "2026-04-29T23:30:00Z"
+  },
+  "spec": {
+    "program": "SocioProphet Model Fabric",
+    "workItems": [
+      {
+        "repo": "SocioProphet/prophet-platform",
+        "issueRef": "https://github.com/SocioProphet/prophet-platform/issues/277",
+        "assignedLane": "Codex",
+        "workstream": "Platform Runtime Adapters",
+        "expectedArtifact": "model-fabric adapter contract fixtures and tests",
+        "status": "open",
+        "acceptanceSummary": "Adapter contracts reference functional service registry entries and stay deterministic/local-only."
+      },
+      {
+        "repo": "SocioProphet/model-router",
+        "issueRef": "https://github.com/SocioProphet/model-router/issues/4",
+        "assignedLane": "Codex",
+        "workstream": "Release Engineering",
+        "expectedArtifact": "model-router release dry-run artifacts and provenance metadata",
+        "status": "open",
+        "acceptanceSummary": "make release-dry-run emits deterministic artifact metadata without publishing a release."
+      },
+      {
+        "repo": "SocioProphet/guardrail-fabric",
+        "issueRef": "https://github.com/SocioProphet/guardrail-fabric/issues/5",
+        "assignedLane": "Copilot",
+        "workstream": "Release Engineering",
+        "expectedArtifact": "guardrail-fabric release dry-run artifacts and provenance metadata",
+        "status": "open",
+        "acceptanceSummary": "make release-dry-run remains local-only and make validate stays green."
+      },
+      {
+        "repo": "SocioProphet/model-governance-ledger",
+        "issueRef": "https://github.com/SocioProphet/model-governance-ledger/issues/5",
+        "assignedLane": "Codex",
+        "workstream": "Release Engineering",
+        "expectedArtifact": "model-governance-ledger release dry-run artifacts and provenance metadata",
+        "status": "open",
+        "acceptanceSummary": "make release-dry-run emits checksums/provenance without storing model weights, datasets, or claims."
+      },
+      {
+        "repo": "SocioProphet/agent-registry",
+        "issueRef": "https://github.com/SocioProphet/agent-registry/issues/7",
+        "assignedLane": "Copilot",
+        "workstream": "Release Engineering",
+        "expectedArtifact": "agent-registry release dry-run artifacts and provenance metadata",
+        "status": "open",
+        "acceptanceSummary": "make release-dry-run is deterministic and does not add identity-provider integration or credentials."
+      },
+      {
+        "repo": "SocioProphet/homebrew-prophet",
+        "issueRef": "https://github.com/SocioProphet/homebrew-prophet/issues/4",
+        "assignedLane": "Copilot",
+        "workstream": "Homebrew Release Formulae",
+        "expectedArtifact": "model-fabric release formula templates and documentation",
+        "status": "open",
+        "acceptanceSummary": "Templates contain placeholders only; no fake URLs or checksums; make validate remains green."
+      },
+      {
+        "repo": "SocioProphet/sociosphere",
+        "issueRef": "https://github.com/SocioProphet/sociosphere/issues/224",
+        "assignedLane": "Codex",
+        "workstream": "Agent Coordination",
+        "expectedArtifact": "agent work register and validation",
+        "status": "in-progress",
+        "acceptanceSummary": "Register references active Codex/Copilot lanes and validates as coordination metadata."
+      }
+    ]
+  }
+}

--- a/tools/tests/test_model_fabric_work_register.py
+++ b/tools/tests/test_model_fabric_work_register.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTER = ROOT / "examples" / "model-fabric-agent-work-register.example.json"
+
+
+def test_model_fabric_work_register_validator_passes() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "validate_model_fabric_work_register.py")],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "OK: validated" in result.stdout
+
+
+def test_register_tracks_codex_and_copilot_lanes() -> None:
+    data = json.loads(REGISTER.read_text(encoding="utf-8"))
+    lanes = {item["assignedLane"] for item in data["spec"]["workItems"]}
+    repos = {item["repo"] for item in data["spec"]["workItems"]}
+
+    assert lanes == {"Codex", "Copilot"}
+    assert "SocioProphet/prophet-platform" in repos
+    assert "SocioProphet/homebrew-prophet" in repos

--- a/tools/validate_model_fabric_work_register.py
+++ b/tools/validate_model_fabric_work_register.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE = ROOT / "examples" / "model-fabric-agent-work-register.example.json"
+REQUIRED_FIELDS = {
+    "repo",
+    "issueRef",
+    "assignedLane",
+    "workstream",
+    "expectedArtifact",
+    "status",
+    "acceptanceSummary",
+}
+ALLOWED_LANES = {"Codex", "Copilot"}
+ALLOWED_STATUS = {"open", "in-progress", "blocked", "closed"}
+REQUIRED_REPOS = {
+    "SocioProphet/prophet-platform",
+    "SocioProphet/model-router",
+    "SocioProphet/guardrail-fabric",
+    "SocioProphet/model-governance-ledger",
+    "SocioProphet/agent-registry",
+    "SocioProphet/homebrew-prophet",
+    "SocioProphet/sociosphere",
+}
+
+
+def fail(message: str) -> int:
+    print(f"ERROR: {message}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if not EXAMPLE.exists():
+        return fail(f"missing {EXAMPLE}")
+    data = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+    if data.get("apiVersion") != "sociosphere.socioprophet.dev/v1":
+        return fail("apiVersion must be sociosphere.socioprophet.dev/v1")
+    if data.get("kind") != "AgentWorkRegister":
+        return fail("kind must be AgentWorkRegister")
+    items = data.get("spec", {}).get("workItems", [])
+    if not items:
+        return fail("spec.workItems must not be empty")
+    repos = set()
+    issue_refs = set()
+    for idx, item in enumerate(items):
+        prefix = f"workItems[{idx}]"
+        missing = sorted(REQUIRED_FIELDS - set(item))
+        if missing:
+            return fail(f"{prefix} missing fields: {missing}")
+        if item["assignedLane"] not in ALLOWED_LANES:
+            return fail(f"{prefix}.assignedLane is invalid")
+        if item["status"] not in ALLOWED_STATUS:
+            return fail(f"{prefix}.status is invalid")
+        if not str(item["issueRef"]).startswith("https://github.com/"):
+            return fail(f"{prefix}.issueRef must be a GitHub URL")
+        if item["issueRef"] in issue_refs:
+            return fail(f"duplicate issueRef: {item['issueRef']}")
+        issue_refs.add(item["issueRef"])
+        repos.add(item["repo"])
+        if not str(item["expectedArtifact"]).strip():
+            return fail(f"{prefix}.expectedArtifact is required")
+        if not str(item["acceptanceSummary"]).strip():
+            return fail(f"{prefix}.acceptanceSummary is required")
+    missing_repos = sorted(REQUIRED_REPOS - repos)
+    if missing_repos:
+        return fail(f"missing required repos: {missing_repos}")
+    print(f"OK: validated {len(items)} model-fabric agent work items")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a SocioSphere register for active Codex/Copilot model-fabric work lanes.

## Adds

- `examples/model-fabric-agent-work-register.example.json`
- validator and pytest coverage
- Makefile validation wiring

## Purpose

This records coordination metadata for active model-fabric work across:

- prophet-platform
- model-router
- guardrail-fabric
- model-governance-ledger
- agent-registry
- homebrew-prophet
- sociosphere

This is coordination metadata, not implementation proof.

Closes #224
