### PR TITLE
Enforce Lattice query governance envelope

### DIFF
--- a/registry/lattice-federated-query-spine.yaml
+++ b/registry/lattice-federated-query-spine.yaml
@@ -8,7 +8,8 @@ purpose: >-
   query, Cypher/property graphs, GraphBrain hypergraphs, OpenCog AtomSpace/Atomese,
   Sherlock Search, Slash Topics, New Hope, and Lampstand local search, plus
   QueryRoutingDryRunPlan route-planning artifacts that prove backend routing
-  without issuing runtime queries.
+  through the Slash Topics, New Hope, Memory Mesh, and lab-profile governance
+  envelope without issuing runtime queries.
 
 producer_surfaces:
   - repo: SocioProphet/prophet-platform
@@ -40,6 +41,12 @@ producer_surfaces:
       - ModerationEvent
       - MembraneDecision
     role: higher-order semantic runtime and membrane query source
+  - repo: SocioProphet/memory-mesh
+    records:
+      - MemoryProfile
+      - MemoryEvent
+      - MemoryEvidence
+    role: scoped recall, writeback, redaction, retention, promotion, and evidence policy for Slash Topic scopes
   - repo: SocioProphet/lampstand
     records:
       - LocalIndex
@@ -58,126 +65,121 @@ producer_surfaces:
       - HypergraphQueryContract
     role: GraphBrain-style semantic hypergraph query contract
 
+lab_profile_sources:
+  confirmed_repos:
+    - repo: SocioProphet/speechlab
+      profile_ref: lab://speech-lab/default
+    - repo: SociOS-Linux/imagelab
+      profile_ref: lab://image-lab/default
+    - repo: SociOS-Linux/ocrlab
+      profile_ref: lab://ocr-lab/default
+    - repo: SociOS-Linux/speechlab
+      profile_ref: lab://speech-lab/default
+    - repo: SociOS-Linux/videolab
+      profile_ref: lab://video-lab/default
+  intended_capability_refs:
+    - lab://nlp-lab/default
+    - lab://embedding-lab/default
+    - lab://vision-lab/default
+  role: model and modality profile selection without lab runtime execution during query-routing dry-runs
+
 query_lanes:
   sql:
     canonical_backend: apache-drill
     backend_kind: drill-sql
     language: sql
-    required_capabilities:
-      - lakehouse-query
-      - object-lake-query
-      - table-query
-      - jdbc-compatible-results
+    required_capabilities: [lakehouse-query, object-lake-query, table-query, jdbc-compatible-results]
   documents:
     canonical_backend: document-store
     backend_kind: document-store
     language: document-query
-    required_capabilities:
-      - metadata-query
-      - full-text-query
-      - document-id-query
-      - policy-scoped-document-access
+    required_capabilities: [metadata-query, full-text-query, document-id-query, policy-scoped-document-access]
   annotations:
     canonical_backend: annotation-store
     backend_kind: annotation-store
     language: annotation-query
-    required_capabilities:
-      - label-query
-      - claim-query
-      - target-query
-      - provenance-query
+    required_capabilities: [label-query, claim-query, target-query, provenance-query]
   sparql:
     canonical_backend: rdf-store
     backend_kind: rdf-store
     language: sparql
-    required_capabilities:
-      - triple-pattern-query
-      - named-graph-query
-      - ontology-backed-query
+    required_capabilities: [triple-pattern-query, named-graph-query, ontology-backed-query]
   ontology:
     canonical_backend: ontogenesis
     backend_kind: ontology-reasoner
     language: ontology-query
-    required_capabilities:
-      - class-query
-      - shape-query
-      - constraint-query
-      - schema-alignment-query
-      - reasoning-result-query
+    required_capabilities: [class-query, shape-query, constraint-query, schema-alignment-query, reasoning-result-query]
   cypher:
     canonical_backend: property-graph
     backend_kind: property-graph
     language: cypher
-    required_capabilities:
-      - node-edge-query
-      - path-query
-      - graph-facet-query
+    required_capabilities: [node-edge-query, path-query, graph-facet-query]
   graphbrain:
     canonical_backend: graphbrain-contract
     backend_kind: hypergraph-store
     language: graphbrain-hypergraph
-    required_capabilities:
-      - hyperedge-query
-      - semantic-frame-query
-      - claim-hypergraph-query
+    required_capabilities: [hyperedge-query, semantic-frame-query, claim-hypergraph-query]
   atomese:
     canonical_backend: opencog-atomspace
     backend_kind: atomspace
     language: atomese
-    required_capabilities:
-      - atomspace-query
-      - atomese-pattern-query
-      - cognitive-graph-query
+    required_capabilities: [atomspace-query, atomese-pattern-query, cognitive-graph-query]
   sherlock:
     canonical_backend: SocioProphet/sherlock-search
     backend_kind: sherlock-index
     language: sherlock-query
-    required_capabilities:
-      - hybrid-search
-      - platform-record-query
-      - evidence-query
-      - query-replay-receipts
+    required_capabilities: [hybrid-search, platform-record-query, evidence-query, query-replay-receipts]
   slash_topics:
     canonical_backend: SocioProphet/slash-topics
     backend_kind: slash-topic-pack
     language: slash-topic-query
-    required_capabilities:
-      - signed-topic-pack-query
-      - policy-membrane-query
-      - deterministic-receipt-query
-      - scoped-search-query
+    required_capabilities: [signed-topic-pack-query, policy-membrane-query, deterministic-receipt-query, scoped-search-query]
   new_hope:
     canonical_backend: SocioProphet/new-hope
     backend_kind: newhope-runtime
     language: newhope-membrane-query
-    required_capabilities:
-      - message-query
-      - thread-query
-      - claim-query
-      - citation-query
-      - entity-query
-      - lens-query
-      - moderation-event-query
-      - membrane-decision-query
+    required_capabilities: [message-query, thread-query, claim-query, citation-query, entity-query, lens-query, moderation-event-query, membrane-decision-query]
   lampstand:
     canonical_backend: SocioProphet/lampstand
     backend_kind: lampstand-local-index
     language: lampstand-local-query
-    required_capabilities:
-      - local-file-query
-      - sqlite-fts5-query
-      - health-query
-      - stats-query
-      - datahub-promotion-candidate-query
+    required_capabilities: [local-file-query, sqlite-fts5-query, health-query, stats-query, datahub-promotion-candidate-query]
+
+governance_envelope:
+  canonical_sequence:
+    - slash-topic-scope
+    - newhope-membrane-admission
+    - memory-mesh-recall-policy
+    - lab-profile-selection
+    - physical-backend-route
+  required_refs:
+    topic_scope_ref_prefix: slash-topic://
+    topic_pack_ref_prefix: slash-topics://packs/
+    membrane_ref_prefix: newhope://membranes/
+    memory_profile_ref_prefix: memory-mesh://profiles/
+    memory_event_ref: memory-mesh://events/query-route-dry-run
+  required_lab_profile_refs:
+    - lab://nlp-lab/default
+    - lab://embedding-lab/default
+    - lab://image-lab/default
+    - lab://speech-lab/default
+    - lab://vision-lab/default
 
 routing_dry_run:
   canonical_record: QueryRoutingDryRunPlan
   evidence_record: QueryRoutingEvidence
-  purpose: route query requests to governed backends without executing remote or local queries
+  purpose: route query requests to governed backends only after the governance envelope is present, without executing remote or local queries
   required_boundaries:
     - dry-run-only
+    - slash-topic-scope-required
+    - newhope-membrane-required
+    - memory-mesh-context-bound
+    - lab-profile-bound
     - no-remote-query-execution
     - no-local-index-read
+    - no-memory-writeback
+    - no-embedding-job
+    - no-lab-runtime-call
     - no-sql-submission
     - no-sparql-submission
     - no-cypher-submission
@@ -202,35 +204,35 @@ routing_dry_run:
 
 consumers:
   - repo: SocioProphet/prophet-cli
-    consumes:
-      - FederatedQueryPlane
-      - QueryRoutingDryRunPlan
+    consumes: [FederatedQueryPlane, QueryRoutingDryRunPlan]
     role: exposes lattice-query and lattice-route command surfaces
   - repo: SocioProphet/sherlock-search
-    consumes:
-      - FederatedQueryPlane
-      - QueryRoutingDryRunPlan
-      - PlatformAssetRecord
+    consumes: [FederatedQueryPlane, QueryRoutingDryRunPlan, PlatformAssetRecord]
     role: indexes query-plane and query-routing records as searchable platform assets
   - repo: SocioProphet/sociosphere
-    consumes:
-      - lattice-federated-query-spine
+    consumes: [lattice-federated-query-spine]
     role: topology registration and validation
 
 invariants:
   - FederatedQueryPlane is the canonical Lattice query-plane artifact.
   - QueryRoutingDryRunPlan is the canonical route-only dry-run artifact for federated query backend selection.
+  - QueryRoutingDryRunPlan must require Slash Topics scope before backend selection.
+  - QueryRoutingDryRunPlan must require New Hope membrane admission before backend selection.
+  - QueryRoutingDryRunPlan must require Memory Mesh recall policy before backend selection.
+  - QueryRoutingDryRunPlan must require lab profile selection before backend selection.
   - Query backends must be policy-bound and catalog-scoped.
-  - QueryRoutingDryRunPlan must not issue SQL, SPARQL, Cypher, Atomese, Sherlock, Slash Topics, New Hope, Lampstand, remote, or local-index runtime calls.
-  - Sherlock, Slash Topics, New Hope, and Lampstand must be first-class query integrations, not compatibility labels only.
+  - QueryRoutingDryRunPlan must not issue SQL, SPARQL, Cypher, Atomese, Sherlock, Slash Topics, New Hope, Lampstand, Memory Mesh, lab runtime, remote, or local-index runtime calls.
+  - Sherlock, Slash Topics, New Hope, Memory Mesh, and Lampstand must be first-class query integrations, not compatibility labels only.
   - Ontology query must remain distinct from SPARQL because reasoning, SHACL shapes, and schema alignment require explicit governance.
   - Local Lampstand query must not silently promote local files into shared catalogs without a DataHubPromotionCandidate artifact.
   - PlatformAssetRecord remains the shared identity for query-plane and query-routing registration.
 
 next_required_links:
   - repo: SocioProphet/prophet-platform
-    task: add negative-path fixtures for blocked query routing decisions
+    task: add negative-path fixtures for blocked query routing decisions and lab-profile omission
+  - repo: SocioProphet/memory-mesh
+    task: define slash-topic-scoped memory profile contract
   - repo: SocioProphet/sherlock-search
-    task: add facets for query language, backend kind, catalog scope, policy ref, integration repo, and route decision status
+    task: add facets for query language, backend kind, catalog scope, policy ref, integration repo, route decision status, memory profile, and governance envelope
   - repo: SocioProphet/sociosphere
     task: register query policy and query topology in global workspace/governance views

--- a/registry/lattice-federated-query-spine.yaml
+++ b/registry/lattice-federated-query-spine.yaml
@@ -6,14 +6,18 @@ purpose: >-
   Registers governed federated query lanes for Lattice Studio across SQL-compatible
   query via Apache Drill, document storage, annotation stores, SPARQL, ontology
   query, Cypher/property graphs, GraphBrain hypergraphs, OpenCog AtomSpace/Atomese,
-  Sherlock Search, Slash Topics, New Hope, and Lampstand local search.
+  Sherlock Search, Slash Topics, New Hope, and Lampstand local search, plus
+  QueryRoutingDryRunPlan route-planning artifacts that prove backend routing
+  without issuing runtime queries.
 
 producer_surfaces:
   - repo: SocioProphet/prophet-platform
     records:
       - FederatedQueryPlane
       - FederatedQueryEvidence
-    role: canonical Lattice Studio federated query plane producer
+      - QueryRoutingDryRunPlan
+      - QueryRoutingEvidence
+    role: canonical Lattice Studio federated query plane and query-routing dry-run producer
   - repo: SocioProphet/sherlock-search
     records:
       - SherlockIndexDocument
@@ -166,16 +170,48 @@ query_lanes:
       - stats-query
       - datahub-promotion-candidate-query
 
+routing_dry_run:
+  canonical_record: QueryRoutingDryRunPlan
+  evidence_record: QueryRoutingEvidence
+  purpose: route query requests to governed backends without executing remote or local queries
+  required_boundaries:
+    - dry-run-only
+    - no-remote-query-execution
+    - no-local-index-read
+    - no-sql-submission
+    - no-sparql-submission
+    - no-cypher-submission
+    - no-atomese-submission
+    - no-sherlock-query-submission
+    - no-topic-pack-read
+    - no-newhope-runtime-call
+    - no-lampstand-rpc-call
+  required_route_families:
+    - drill-sql-route
+    - document-query-route
+    - annotation-query-route
+    - sparql-route
+    - ontology-query-route
+    - cypher-route
+    - graphbrain-route
+    - atomese-route
+    - sherlock-route
+    - slash-topics-route
+    - new-hope-route
+    - lampstand-route
+
 consumers:
   - repo: SocioProphet/prophet-cli
     consumes:
       - FederatedQueryPlane
-    role: exposes lattice-query command surface
+      - QueryRoutingDryRunPlan
+    role: exposes lattice-query and lattice-route command surfaces
   - repo: SocioProphet/sherlock-search
     consumes:
       - FederatedQueryPlane
+      - QueryRoutingDryRunPlan
       - PlatformAssetRecord
-    role: indexes query-plane records as searchable platform assets
+    role: indexes query-plane and query-routing records as searchable platform assets
   - repo: SocioProphet/sociosphere
     consumes:
       - lattice-federated-query-spine
@@ -183,16 +219,18 @@ consumers:
 
 invariants:
   - FederatedQueryPlane is the canonical Lattice query-plane artifact.
+  - QueryRoutingDryRunPlan is the canonical route-only dry-run artifact for federated query backend selection.
   - Query backends must be policy-bound and catalog-scoped.
+  - QueryRoutingDryRunPlan must not issue SQL, SPARQL, Cypher, Atomese, Sherlock, Slash Topics, New Hope, Lampstand, remote, or local-index runtime calls.
   - Sherlock, Slash Topics, New Hope, and Lampstand must be first-class query integrations, not compatibility labels only.
   - Ontology query must remain distinct from SPARQL because reasoning, SHACL shapes, and schema alignment require explicit governance.
   - Local Lampstand query must not silently promote local files into shared catalogs without a DataHubPromotionCandidate artifact.
-  - PlatformAssetRecord remains the shared identity for query-plane registration.
+  - PlatformAssetRecord remains the shared identity for query-plane and query-routing registration.
 
 next_required_links:
   - repo: SocioProphet/prophet-platform
-    task: add executable dry-run query planner that validates backend routing without issuing remote queries
+    task: add negative-path fixtures for blocked query routing decisions
   - repo: SocioProphet/sherlock-search
-    task: add facets for query language, backend kind, catalog scope, policy ref, and integration repo
+    task: add facets for query language, backend kind, catalog scope, policy ref, integration repo, and route decision status
   - repo: SocioProphet/sociosphere
     task: register query policy and query topology in global workspace/governance views

--- a/scripts/validate_lattice_federated_query_spine.py
+++ b/scripts/validate_lattice_federated_query_spine.py
@@ -13,11 +13,17 @@ REQUIRED_PRODUCERS = {
     "SocioProphet/sherlock-search",
     "SocioProphet/slash-topics",
     "SocioProphet/new-hope",
+    "SocioProphet/memory-mesh",
     "SocioProphet/lampstand",
     "SocioProphet/ontogenesis",
     "SocioProphet/graphbrain-contract",
 }
-REQUIRED_RECORDS = {"FederatedQueryPlane", "FederatedQueryEvidence"}
+REQUIRED_RECORDS = {
+    "FederatedQueryPlane",
+    "FederatedQueryEvidence",
+    "QueryRoutingDryRunPlan",
+    "QueryRoutingEvidence",
+}
 REQUIRED_LANES = {
     "sql",
     "documents",
@@ -47,6 +53,54 @@ REQUIRED_LANGUAGES = {
     "lampstand-local-query",
 }
 REQUIRED_CONSUMERS = {"SocioProphet/prophet-cli", "SocioProphet/sherlock-search", "SocioProphet/sociosphere"}
+REQUIRED_GOVERNANCE_SEQUENCE = [
+    "slash-topic-scope",
+    "newhope-membrane-admission",
+    "memory-mesh-recall-policy",
+    "lab-profile-selection",
+    "physical-backend-route",
+]
+REQUIRED_LAB_PROFILE_REFS = {
+    "lab://nlp-lab/default",
+    "lab://embedding-lab/default",
+    "lab://image-lab/default",
+    "lab://speech-lab/default",
+    "lab://vision-lab/default",
+}
+REQUIRED_BOUNDARIES = {
+    "dry-run-only",
+    "slash-topic-scope-required",
+    "newhope-membrane-required",
+    "memory-mesh-context-bound",
+    "lab-profile-bound",
+    "no-remote-query-execution",
+    "no-local-index-read",
+    "no-memory-writeback",
+    "no-embedding-job",
+    "no-lab-runtime-call",
+    "no-sql-submission",
+    "no-sparql-submission",
+    "no-cypher-submission",
+    "no-atomese-submission",
+    "no-sherlock-query-submission",
+    "no-topic-pack-read",
+    "no-newhope-runtime-call",
+    "no-lampstand-rpc-call",
+}
+REQUIRED_ROUTE_FAMILIES = {
+    "drill-sql-route",
+    "document-query-route",
+    "annotation-query-route",
+    "sparql-route",
+    "ontology-query-route",
+    "cypher-route",
+    "graphbrain-route",
+    "atomese-route",
+    "sherlock-route",
+    "slash-topics-route",
+    "new-hope-route",
+    "lampstand-route",
+}
 
 
 def require(condition: bool, message: str) -> None:
@@ -59,16 +113,23 @@ def validate(path: Path) -> None:
     require(isinstance(data, dict), "registry must decode to object")
     require(data.get("schema_version") == 1, "schema_version must be 1")
     require(data.get("canonical_identity") == "PlatformAssetRecord", "canonical identity mismatch")
+
     producers = data.get("producer_surfaces")
     require(isinstance(producers, list) and producers, "producer_surfaces must be non-empty")
     producer_repos = {item.get("repo") for item in producers if isinstance(item, dict)}
     require(REQUIRED_PRODUCERS.issubset(producer_repos), f"missing producers: {sorted(REQUIRED_PRODUCERS - producer_repos)}")
     record_names = {record for item in producers if isinstance(item, dict) for record in item.get("records", [])}
     require(REQUIRED_RECORDS.issubset(record_names), f"missing query records: {sorted(REQUIRED_RECORDS - record_names)}")
+
+    lab_sources = data.get("lab_profile_sources")
+    require(isinstance(lab_sources, dict), "lab_profile_sources must be object")
+    intended_refs = set(lab_sources.get("intended_capability_refs", []))
+    confirmed_refs = {item.get("profile_ref") for item in lab_sources.get("confirmed_repos", []) if isinstance(item, dict)}
+    require(REQUIRED_LAB_PROFILE_REFS.issubset(intended_refs | confirmed_refs), "missing required lab profile refs")
+
     lanes = data.get("query_lanes")
     require(isinstance(lanes, dict), "query_lanes must be object")
-    for lane in REQUIRED_LANES:
-        require(lane in lanes, f"missing query lane {lane}")
+    require(REQUIRED_LANES.issubset(lanes), f"missing query lanes: {sorted(REQUIRED_LANES - set(lanes))}")
     languages = {item.get("language") for item in lanes.values() if isinstance(item, dict)}
     require(REQUIRED_LANGUAGES.issubset(languages), f"missing languages: {sorted(REQUIRED_LANGUAGES - languages)}")
     for lane_name, lane_doc in lanes.items():
@@ -78,14 +139,50 @@ def validate(path: Path) -> None:
         require(lane_doc.get("language"), f"lane {lane_name} missing language")
         caps = lane_doc.get("required_capabilities")
         require(isinstance(caps, list) and caps, f"lane {lane_name} must declare required_capabilities")
+
+    envelope = data.get("governance_envelope")
+    require(isinstance(envelope, dict), "governance_envelope must be object")
+    require(envelope.get("canonical_sequence") == REQUIRED_GOVERNANCE_SEQUENCE, "governance sequence mismatch")
+    required_refs = envelope.get("required_refs")
+    require(isinstance(required_refs, dict), "governance required_refs must be object")
+    require(required_refs.get("topic_scope_ref_prefix") == "slash-topic://", "Slash Topics scope prefix mismatch")
+    require(required_refs.get("topic_pack_ref_prefix") == "slash-topics://packs/", "Slash Topics pack prefix mismatch")
+    require(required_refs.get("membrane_ref_prefix") == "newhope://membranes/", "New Hope membrane prefix mismatch")
+    require(required_refs.get("memory_profile_ref_prefix") == "memory-mesh://profiles/", "Memory Mesh profile prefix mismatch")
+    require(required_refs.get("memory_event_ref") == "memory-mesh://events/query-route-dry-run", "Memory Mesh event ref mismatch")
+    lab_refs = set(envelope.get("required_lab_profile_refs", []))
+    require(REQUIRED_LAB_PROFILE_REFS.issubset(lab_refs), f"missing envelope lab refs: {sorted(REQUIRED_LAB_PROFILE_REFS - lab_refs)}")
+
+    routing = data.get("routing_dry_run")
+    require(isinstance(routing, dict), "routing_dry_run must be object")
+    require(routing.get("canonical_record") == "QueryRoutingDryRunPlan", "routing canonical record mismatch")
+    require(routing.get("evidence_record") == "QueryRoutingEvidence", "routing evidence record mismatch")
+    boundaries = set(routing.get("required_boundaries", []))
+    require(REQUIRED_BOUNDARIES.issubset(boundaries), f"missing route boundaries: {sorted(REQUIRED_BOUNDARIES - boundaries)}")
+    families = set(routing.get("required_route_families", []))
+    require(REQUIRED_ROUTE_FAMILIES.issubset(families), f"missing route families: {sorted(REQUIRED_ROUTE_FAMILIES - families)}")
+
     consumers = data.get("consumers")
     require(isinstance(consumers, list) and consumers, "consumers must be non-empty")
     consumer_repos = {item.get("repo") for item in consumers if isinstance(item, dict)}
     require(REQUIRED_CONSUMERS.issubset(consumer_repos), f"missing consumers: {sorted(REQUIRED_CONSUMERS - consumer_repos)}")
     consumed_records = {record for item in consumers if isinstance(item, dict) for record in item.get("consumes", [])}
     require("FederatedQueryPlane" in consumed_records, "FederatedQueryPlane must be consumed")
+    require("QueryRoutingDryRunPlan" in consumed_records, "QueryRoutingDryRunPlan must be consumed")
+
     invariant_text = "\n".join(str(item) for item in data.get("invariants", []))
-    for required in ["FederatedQueryPlane", "Sherlock", "Slash Topics", "New Hope", "Lampstand", "Ontology query", "PlatformAssetRecord"]:
+    for required in [
+        "FederatedQueryPlane",
+        "QueryRoutingDryRunPlan",
+        "Slash Topics",
+        "New Hope",
+        "Memory Mesh",
+        "lab profile selection",
+        "Sherlock",
+        "Lampstand",
+        "Ontology query",
+        "PlatformAssetRecord",
+    ]:
         require(required in invariant_text, f"missing invariant text for {required}")
 
 


### PR DESCRIPTION
Registers QueryRoutingDryRunPlan as a governed route-only artifact in the Lattice federated query spine and enforces the corrected governance envelope: Slash Topics scope, New Hope membrane admission, Memory Mesh recall policy, lab profile selection, then physical backend routing. Also validates required no-execution boundaries, route families, Memory Mesh refs, and lab profile refs.