### PR TITLE
Enforce Slash Topics and New Hope query topology roles

### DIFF
--- a/registry/lattice-federated-query-spine.yaml
+++ b/registry/lattice-federated-query-spine.yaml
@@ -9,7 +9,9 @@ purpose: >-
   Sherlock Search, Slash Topics, New Hope, and Lampstand local search, plus
   QueryRoutingDryRunPlan route-planning artifacts that prove backend routing
   through the Slash Topics, New Hope, Memory Mesh, and lab-profile governance
-  envelope without issuing runtime queries.
+  envelope without issuing runtime queries. Slash Topics is the public query and
+  governance surface; New Hope is the internal membrane/runtime substrate and
+  compatibility surface until Slash Topics runtime aliases are fully conformed.
 
 producer_surfaces:
   - repo: SocioProphet/prophet-platform
@@ -29,7 +31,7 @@ producer_surfaces:
       - TopicPack
       - PolicyMembrane
       - DeterministicReceipt
-    role: governed signed scoped search and query packs
+    role: public query/governance surface for topic scope, topic packs, policy membrane references, deterministic receipts, and future Slash Topics runtime aliases
   - repo: SocioProphet/new-hope
     records:
       - Message
@@ -40,7 +42,7 @@ producer_surfaces:
       - Lens
       - ModerationEvent
       - MembraneDecision
-    role: higher-order semantic runtime and membrane query source
+    role: internal membrane/runtime substrate and New Hope compatibility surface for carrier, receptor, protocol, membrane decision, replay, provenance, and federation objects
   - repo: SocioProphet/memory-mesh
     records:
       - MemoryProfile
@@ -64,6 +66,46 @@ producer_surfaces:
     records:
       - HypergraphQueryContract
     role: GraphBrain-style semantic hypergraph query contract
+
+surface_model:
+  public_query_surface:
+    repo: SocioProphet/slash-topics
+    name: Slash Topics
+    refs:
+      - slash-topic://
+      - slash-topics://packs/
+      - slash-topics://runtime/membranes/
+    owns:
+      - topic-scope
+      - topic-pack
+      - policy-membrane-reference
+      - deterministic-receipt
+      - public-lattice-query-adapter
+  runtime_substrate:
+    repo: SocioProphet/new-hope
+    name: New Hope
+    refs:
+      - newhope://membranes/
+      - newhope://protocol-packs/
+    owns:
+      - carrier
+      - receptor
+      - protocol
+      - membrane-decision
+      - replay
+      - provenance
+      - federation
+  memory_attachment:
+    repo: SocioProphet/memory-mesh
+    attaches_to: slash-topic-scope
+    refs:
+      - memory-mesh://profiles/
+      - memory-mesh://events/query-route-dry-run
+  migration_policy:
+    recommendation: keep-slash-topics-as-public-surface-and-new-hope-as-runtime-substrate
+    future_alias: slash-topics://runtime/membranes/query-admission@0.1.0
+    compatibility_ref: newhope://membranes/query-admission@0.1.0
+    forbidden_model: ambiguous-peer-public-surfaces
 
 lab_profile_sources:
   confirmed_repos:
@@ -156,6 +198,7 @@ governance_envelope:
     topic_scope_ref_prefix: slash-topic://
     topic_pack_ref_prefix: slash-topics://packs/
     membrane_ref_prefix: newhope://membranes/
+    runtime_alias_ref_prefix: slash-topics://runtime/membranes/
     memory_profile_ref_prefix: memory-mesh://profiles/
     memory_event_ref: memory-mesh://events/query-route-dry-run
   required_lab_profile_refs:
@@ -216,6 +259,11 @@ consumers:
 invariants:
   - FederatedQueryPlane is the canonical Lattice query-plane artifact.
   - QueryRoutingDryRunPlan is the canonical route-only dry-run artifact for federated query backend selection.
+  - Slash Topics is the public query and governance surface for topic scope, topic packs, policy membrane references, deterministic receipts, and the public Lattice query adapter.
+  - New Hope is the internal membrane/runtime substrate and compatibility surface for carrier, receptor, protocol, membrane decision, replay, provenance, and federation objects.
+  - New Hope must not be treated as a competing peer public product surface to Slash Topics.
+  - Slash Topics runtime aliases must preserve New Hope compatibility references during migration.
+  - Memory Mesh memory settings attach to Slash Topic scopes rather than directly to physical query backends.
   - QueryRoutingDryRunPlan must require Slash Topics scope before backend selection.
   - QueryRoutingDryRunPlan must require New Hope membrane admission before backend selection.
   - QueryRoutingDryRunPlan must require Memory Mesh recall policy before backend selection.

--- a/scripts/validate_lattice_federated_query_spine.py
+++ b/scripts/validate_lattice_federated_query_spine.py
@@ -120,6 +120,47 @@ def validate(path: Path) -> None:
     require(REQUIRED_PRODUCERS.issubset(producer_repos), f"missing producers: {sorted(REQUIRED_PRODUCERS - producer_repos)}")
     record_names = {record for item in producers if isinstance(item, dict) for record in item.get("records", [])}
     require(REQUIRED_RECORDS.issubset(record_names), f"missing query records: {sorted(REQUIRED_RECORDS - record_names)}")
+    roles = {item.get("repo"): str(item.get("role", "")) for item in producers if isinstance(item, dict)}
+    require("public query/governance surface" in roles.get("SocioProphet/slash-topics", ""), "Slash Topics producer role must be public query/governance surface")
+    require("internal membrane/runtime substrate" in roles.get("SocioProphet/new-hope", ""), "New Hope producer role must be internal membrane/runtime substrate")
+    require("compatibility surface" in roles.get("SocioProphet/new-hope", ""), "New Hope producer role must preserve compatibility surface")
+
+    surface_model = data.get("surface_model")
+    require(isinstance(surface_model, dict), "surface_model must be object")
+    public_surface = surface_model.get("public_query_surface")
+    require(isinstance(public_surface, dict), "public_query_surface must be object")
+    require(public_surface.get("repo") == "SocioProphet/slash-topics", "public query surface must be Slash Topics")
+    require(public_surface.get("name") == "Slash Topics", "public query surface name mismatch")
+    public_refs = set(public_surface.get("refs", []))
+    require("slash-topic://" in public_refs, "Slash Topic scope ref missing")
+    require("slash-topics://packs/" in public_refs, "Slash Topics pack ref missing")
+    require("slash-topics://runtime/membranes/" in public_refs, "Slash Topics runtime alias ref missing")
+    public_owns = set(public_surface.get("owns", []))
+    for required in ["topic-scope", "topic-pack", "policy-membrane-reference", "deterministic-receipt", "public-lattice-query-adapter"]:
+        require(required in public_owns, f"Slash Topics public surface missing {required}")
+
+    runtime_substrate = surface_model.get("runtime_substrate")
+    require(isinstance(runtime_substrate, dict), "runtime_substrate must be object")
+    require(runtime_substrate.get("repo") == "SocioProphet/new-hope", "runtime substrate must be New Hope")
+    require(runtime_substrate.get("name") == "New Hope", "runtime substrate name mismatch")
+    runtime_refs = set(runtime_substrate.get("refs", []))
+    require("newhope://membranes/" in runtime_refs, "New Hope membrane ref missing")
+    require("newhope://protocol-packs/" in runtime_refs, "New Hope protocol-pack compatibility ref missing")
+    runtime_owns = set(runtime_substrate.get("owns", []))
+    for required in ["carrier", "receptor", "protocol", "membrane-decision", "replay", "provenance", "federation"]:
+        require(required in runtime_owns, f"New Hope runtime substrate missing {required}")
+
+    memory_attachment = surface_model.get("memory_attachment")
+    require(isinstance(memory_attachment, dict), "memory_attachment must be object")
+    require(memory_attachment.get("repo") == "SocioProphet/memory-mesh", "memory attachment must use Memory Mesh")
+    require(memory_attachment.get("attaches_to") == "slash-topic-scope", "Memory Mesh must attach to Slash Topic scope")
+
+    migration_policy = surface_model.get("migration_policy")
+    require(isinstance(migration_policy, dict), "migration_policy must be object")
+    require(migration_policy.get("recommendation") == "keep-slash-topics-as-public-surface-and-new-hope-as-runtime-substrate", "migration recommendation mismatch")
+    require(migration_policy.get("future_alias", "").startswith("slash-topics://runtime/membranes/"), "future Slash Topics runtime alias missing")
+    require(migration_policy.get("compatibility_ref", "").startswith("newhope://membranes/"), "New Hope compatibility ref missing")
+    require(migration_policy.get("forbidden_model") == "ambiguous-peer-public-surfaces", "forbidden ambiguous peer model must be explicit")
 
     lab_sources = data.get("lab_profile_sources")
     require(isinstance(lab_sources, dict), "lab_profile_sources must be object")
@@ -148,6 +189,7 @@ def validate(path: Path) -> None:
     require(required_refs.get("topic_scope_ref_prefix") == "slash-topic://", "Slash Topics scope prefix mismatch")
     require(required_refs.get("topic_pack_ref_prefix") == "slash-topics://packs/", "Slash Topics pack prefix mismatch")
     require(required_refs.get("membrane_ref_prefix") == "newhope://membranes/", "New Hope membrane prefix mismatch")
+    require(required_refs.get("runtime_alias_ref_prefix") == "slash-topics://runtime/membranes/", "Slash Topics runtime alias prefix mismatch")
     require(required_refs.get("memory_profile_ref_prefix") == "memory-mesh://profiles/", "Memory Mesh profile prefix mismatch")
     require(required_refs.get("memory_event_ref") == "memory-mesh://events/query-route-dry-run", "Memory Mesh event ref mismatch")
     lab_refs = set(envelope.get("required_lab_profile_refs", []))
@@ -174,9 +216,11 @@ def validate(path: Path) -> None:
     for required in [
         "FederatedQueryPlane",
         "QueryRoutingDryRunPlan",
-        "Slash Topics",
-        "New Hope",
-        "Memory Mesh",
+        "Slash Topics is the public query and governance surface",
+        "New Hope is the internal membrane/runtime substrate",
+        "New Hope must not be treated as a competing peer public product surface",
+        "Slash Topics runtime aliases must preserve New Hope compatibility references",
+        "Memory Mesh memory settings attach to Slash Topic scopes",
         "lab profile selection",
         "Sherlock",
         "Lampstand",


### PR DESCRIPTION
Closes #234.

## Summary

Makes Slash Topics/New Hope topology enforcement concrete in the Lattice federated query spine.

## Changes

- Adds `surface_model` to `registry/lattice-federated-query-spine.yaml`.
- Declares Slash Topics as the public query/governance surface.
- Declares New Hope as the internal membrane/runtime substrate and compatibility surface.
- Preserves future Slash Topics runtime alias guidance while retaining New Hope compatibility refs.
- Enforces the topology through `scripts/validate_lattice_federated_query_spine.py`.

## Non-goals

- No repo rename.
- No physical merge of `new-hope` into `slash-topics`.
- No runtime execution implementation.

## Validation

Pending GitHub workflows.