### PR TITLE
Register Lattice Data/GovernAI topology lanes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ ui-dev: ui-preflight
 # --- end ui-workbench targets ---
 
 # --- standards validation targets ---
-.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate
+.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate
 
-validate: validate-standards program-dashboard-validate model-fabric-work-register-validate
+validate: validate-standards program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate
 	@echo "OK: validate"
 
 validate-standards:
@@ -36,6 +36,10 @@ program-dashboard-validate:
 
 model-fabric-work-register-validate:
 	python3 tools/validate_model_fabric_work_register.py
+
+lattice-data-governai-topology-validate:
+	python3 -m pip install --user pyyaml >/dev/null
+	python3 tools/validate_lattice_data_governai_topology.py
 
 multidomain-geospatial-standards-compliance-validate:
 	python3 tools/check_multidomain_geospatial_standards_compliance.py

--- a/registry/lattice-data-governai-lanes.yaml
+++ b/registry/lattice-data-governai-lanes.yaml
@@ -1,0 +1,241 @@
+version: "0.1.0"
+updated_at: "2026-05-01"
+kind: LatticeDataGovernAITopologyRegistration
+
+umbrella:
+  repo: SocioProphet/prophet-platform
+  issue: 291
+  product_surface: Lattice Studio/Data/GovernAI
+  purpose: "Reproducible community AI workbench for data products, notebooks, models, prompts, agents, publications, and evidence."
+
+spine:
+  - ContentAsset
+  - CatalogAsset
+  - DataProduct
+  - AnnotationSet
+  - TrainingDataset
+  - EvaluationDataset
+  - RuntimeAsset
+  - NotebookSession
+  - QueryRun
+  - RayBeamJob
+  - ModelCandidate
+  - EvaluationBundle
+  - Factsheet
+  - PublicationArtifact
+  - ReviewWorkflow
+  - PlatformAssetRecord
+
+lanes:
+  - id: canonical-contracts
+    owner_repo: SourceOS-Linux/sourceos-spec
+    tracking_ref: SourceOS-Linux/sourceos-spec#75
+    role: canonical-schema-owner
+    owns:
+      - DataProduct
+      - DataContract
+      - QualityProfile
+      - AnnotationSet
+      - EvaluationBundle
+      - Factsheet
+      - PublicationArtifact
+    must_not:
+      - implement-product-fixtures
+      - own-runtime-execution
+
+  - id: platform-vertical-fixture
+    owner_repo: SocioProphet/prophet-platform
+    tracking_ref: SocioProphet/prophet-platform#299
+    role: product-fixture-owner
+    owns:
+      - CatalogAsset
+      - NotebookSession
+      - QueryRun
+      - PromotionCandidate
+      - PlatformAssetRecord
+    consumes:
+      - SourceOS-Linux/sourceos-spec#75
+      - SocioProphet/lattice-forge#10
+    must_not:
+      - redefine-canonical-schemas
+      - own-agent-execution
+
+  - id: runtime-production
+    owner_repo: SocioProphet/lattice-forge
+    tracking_ref: SocioProphet/lattice-forge#10
+    role: runtime-artifact-owner
+    owns:
+      - RuntimeAsset
+      - runtime-lockfiles
+      - kernel-metadata
+      - runtime-sbom-signature-scan-evidence
+    must_not:
+      - own-data-product-policy
+      - own-platform-ui
+
+  - id: governed-mlops-execution
+    owner_repo: SocioProphet/prophet-platform-fabric-mlops-ts-suite
+    tracking_ref: SocioProphet/prophet-platform-fabric-mlops-ts-suite#33
+    role: mlops-fixture-owner
+    owns:
+      - RayJobDryRunPlan
+      - BeamPipelineDryRunPlan
+      - LineageRun
+      - PromotionGate
+    consumes:
+      - DataProduct
+      - DataContract
+      - RuntimeAsset
+      - EvaluationBundle
+    must_not:
+      - own-canonical-data-schemas
+      - bypass-policy-fabric
+
+  - id: policy-subjects
+    owner_repo: SocioProphet/policy-fabric
+    tracking_ref: SocioProphet/policy-fabric#39
+    role: policy-gate-owner
+    owns:
+      - policy-subject-fixtures
+      - allow-deny-review-required-decisions
+      - promotion-gate-rules
+    consumes:
+      - DataProduct
+      - RuntimeAsset
+      - NotebookSession
+      - ModelAsset
+      - PromptAsset
+      - AgentAsset
+      - EvaluationBundle
+      - Factsheet
+      - PublicationArtifact
+    must_not:
+      - create-parallel-metadata-spine
+
+  - id: topology-registration
+    owner_repo: SocioProphet/sociosphere
+    tracking_ref: SocioProphet/sociosphere#237
+    role: topology-governor
+    owns:
+      - dependency-direction
+      - lane-registration
+      - build-intelligence-routing
+      - topology-validation
+    consumes:
+      - all-lattice-lane-records
+    must_not:
+      - implement-downstream-features
+
+  - id: search-indexing
+    owner_repo: SocioProphet/sherlock-search
+    tracking_ref: SocioProphet/sherlock-search#29
+    role: search-consumer
+    consumes:
+      - PlatformAssetRecord
+      - policyRef
+      - evidenceCorrelationId
+      - trust-fields
+    must_not:
+      - redefine-asset-identity
+
+  - id: topic-classification
+    owner_repo: SocioProphet/slash-topics
+    tracking_ref: SocioProphet/slash-topics#22
+    role: public-topic-governance-surface
+    consumes:
+      - PlatformAssetRecord
+      - DataProduct
+      - ModelAsset
+      - PromptAsset
+      - PublicationArtifact
+    must_not:
+      - own-runtime-substrate
+
+  - id: semantic-membrane
+    owner_repo: SocioProphet/new-hope
+    tracking_ref: SocioProphet/new-hope#6
+    role: internal-semantic-membrane
+    consumes:
+      - PlatformAssetRecord
+      - topic-classification
+      - policyRef
+      - evidenceCorrelationId
+    must_not:
+      - replace-slash-topics-public-surface
+
+  - id: execution-consumer
+    owner_repo: SocioProphet/agentplane
+    tracking_ref: SocioProphet/agentplane#75
+    role: governed-execution-consumer
+    consumes:
+      - RuntimeAsset
+      - DataProduct
+      - ModelAsset
+      - EvaluationBundle
+      - PublicationArtifact
+      - PolicyBundle
+    must_not:
+      - own-lattice-canonical-schemas
+
+  - id: developer-home
+    owner_repo: SocioProphet/cloudshell-fog
+    tracking_ref: SocioProphet/cloudshell-fog#29
+    role: user-workbench-shell-surface
+    consumes:
+      - PlatformAssetRecord
+      - RuntimeAsset
+      - DataProduct
+      - EvidenceBundle
+      - Factsheet
+    must_not:
+      - bypass-policy-fabric
+      - bypass-agentplane
+
+dependency_direction_rules:
+  canonical_schemas_flow_from:
+    - SourceOS-Linux/sourceos-spec
+  platform_records_flow_from:
+    - SocioProphet/prophet-platform
+    - SocioProphet/prophet-platform-fabric-mlops-ts-suite
+  runtime_artifacts_flow_from:
+    - SocioProphet/lattice-forge
+  policy_decisions_flow_from:
+    - SocioProphet/policy-fabric
+  topology_governance_flow_from:
+    - SocioProphet/sociosphere
+  consumers:
+    - SocioProphet/sherlock-search
+    - SocioProphet/slash-topics
+    - SocioProphet/new-hope
+    - SocioProphet/agentplane
+    - SocioProphet/cloudshell-fog
+
+validation_requirements:
+  required_lanes:
+    - canonical-contracts
+    - platform-vertical-fixture
+    - runtime-production
+    - governed-mlops-execution
+    - policy-subjects
+    - topology-registration
+    - search-indexing
+    - topic-classification
+    - semantic-membrane
+    - execution-consumer
+    - developer-home
+  required_tracking_refs:
+    - SourceOS-Linux/sourceos-spec#75
+    - SocioProphet/prophet-platform#299
+    - SocioProphet/lattice-forge#10
+    - SocioProphet/prophet-platform-fabric-mlops-ts-suite#33
+    - SocioProphet/policy-fabric#39
+    - SocioProphet/sociosphere#237
+    - SocioProphet/sherlock-search#29
+    - SocioProphet/slash-topics#22
+    - SocioProphet/new-hope#6
+    - SocioProphet/agentplane#75
+    - SocioProphet/cloudshell-fog#29
+  forbid_parallel_metadata_spines: true
+  require_policy_before_publication: true
+  require_runtime_before_execution: true
+  require_platform_record_before_search: true

--- a/tools/validate_lattice_data_governai_topology.py
+++ b/tools/validate_lattice_data_governai_topology.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "registry" / "lattice-data-governai-lanes.yaml"
+
+REQUIRED_LANES = {
+    "canonical-contracts",
+    "platform-vertical-fixture",
+    "runtime-production",
+    "governed-mlops-execution",
+    "policy-subjects",
+    "topology-registration",
+    "search-indexing",
+    "topic-classification",
+    "semantic-membrane",
+    "execution-consumer",
+    "developer-home",
+}
+REQUIRED_TRACKING_REFS = {
+    "SourceOS-Linux/sourceos-spec#75",
+    "SocioProphet/prophet-platform#299",
+    "SocioProphet/lattice-forge#10",
+    "SocioProphet/prophet-platform-fabric-mlops-ts-suite#33",
+    "SocioProphet/policy-fabric#39",
+    "SocioProphet/sociosphere#237",
+    "SocioProphet/sherlock-search#29",
+    "SocioProphet/slash-topics#22",
+    "SocioProphet/new-hope#6",
+    "SocioProphet/agentplane#75",
+    "SocioProphet/cloudshell-fog#29",
+}
+REQUIRED_OWNER_REPOS = {
+    "SourceOS-Linux/sourceos-spec",
+    "SocioProphet/prophet-platform",
+    "SocioProphet/lattice-forge",
+    "SocioProphet/prophet-platform-fabric-mlops-ts-suite",
+    "SocioProphet/policy-fabric",
+    "SocioProphet/sociosphere",
+    "SocioProphet/sherlock-search",
+    "SocioProphet/slash-topics",
+    "SocioProphet/new-hope",
+    "SocioProphet/agentplane",
+    "SocioProphet/cloudshell-fog",
+}
+
+
+def fail(message: str) -> int:
+    print(f"ERR: {message}", file=sys.stderr)
+    return 1
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def as_list(value: Any, field: str) -> list[Any]:
+    require(isinstance(value, list), f"{field} must be a list")
+    return value
+
+
+def main() -> int:
+    if yaml is None:
+        return fail("PyYAML is required for topology validation")
+    if not REGISTRY.exists():
+        return fail(f"missing {REGISTRY}")
+    try:
+        data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+        require(isinstance(data, dict), "registry must be a mapping")
+        require(data.get("kind") == "LatticeDataGovernAITopologyRegistration", "kind mismatch")
+        umbrella = data.get("umbrella")
+        require(isinstance(umbrella, dict), "umbrella must be mapping")
+        require(umbrella.get("repo") == "SocioProphet/prophet-platform", "umbrella.repo mismatch")
+        require(umbrella.get("issue") == 291, "umbrella.issue must be 291")
+
+        spine = as_list(data.get("spine"), "spine")
+        for required in ["DataProduct", "RuntimeAsset", "NotebookSession", "EvaluationBundle", "Factsheet", "PublicationArtifact", "PlatformAssetRecord"]:
+            require(required in spine, f"spine missing {required}")
+
+        lanes = as_list(data.get("lanes"), "lanes")
+        lane_ids = {lane.get("id") for lane in lanes if isinstance(lane, dict)}
+        missing_lanes = sorted(REQUIRED_LANES - lane_ids)
+        require(not missing_lanes, f"missing lanes: {missing_lanes}")
+        owner_repos = {lane.get("owner_repo") for lane in lanes if isinstance(lane, dict)}
+        missing_owners = sorted(REQUIRED_OWNER_REPOS - owner_repos)
+        require(not missing_owners, f"missing owner repos: {missing_owners}")
+        tracking_refs = {lane.get("tracking_ref") for lane in lanes if isinstance(lane, dict)}
+        missing_tracking = sorted(REQUIRED_TRACKING_REFS - tracking_refs)
+        require(not missing_tracking, f"missing tracking refs: {missing_tracking}")
+
+        for lane in lanes:
+            require(isinstance(lane, dict), "each lane must be mapping")
+            require(isinstance(lane.get("owns", []), list), f"lane {lane.get('id')} owns must be list")
+            require(isinstance(lane.get("must_not", []), list), f"lane {lane.get('id')} must_not must be list")
+        policy_lane = next(lane for lane in lanes if lane.get("id") == "policy-subjects")
+        require("create-parallel-metadata-spine" in policy_lane.get("must_not", []), "policy lane must forbid parallel metadata spine")
+        platform_lane = next(lane for lane in lanes if lane.get("id") == "platform-vertical-fixture")
+        require("redefine-canonical-schemas" in platform_lane.get("must_not", []), "platform lane must not redefine canonical schemas")
+        slash_lane = next(lane for lane in lanes if lane.get("id") == "topic-classification")
+        require(slash_lane.get("role") == "public-topic-governance-surface", "Slash Topics role mismatch")
+        new_hope_lane = next(lane for lane in lanes if lane.get("id") == "semantic-membrane")
+        require(new_hope_lane.get("role") == "internal-semantic-membrane", "New Hope role mismatch")
+
+        validation = data.get("validation_requirements")
+        require(isinstance(validation, dict), "validation_requirements must be mapping")
+        require(validation.get("forbid_parallel_metadata_spines") is True, "must forbid parallel metadata spines")
+        require(validation.get("require_policy_before_publication") is True, "must require policy before publication")
+        require(validation.get("require_runtime_before_execution") is True, "must require runtime before execution")
+        require(validation.get("require_platform_record_before_search") is True, "must require platform record before search")
+    except Exception as exc:  # noqa: BLE001
+        return fail(str(exc))
+    print("OK: validated Lattice Data/GovernAI topology registration")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Registers the Lattice Studio/Data/GovernAI lane as an explicit SocioSphere topology surface.

## Adds

- `registry/lattice-data-governai-lanes.yaml`
- `tools/validate_lattice_data_governai_topology.py`
- Makefile validation target

## Enforces

- canonical schemas flow from SourceOS-Linux/sourceos-spec
- platform records flow from prophet-platform and MLOps fixture repo
- runtime artifacts flow from lattice-forge
- policy decisions flow from policy-fabric
- Sherlock, Slash Topics, New Hope, AgentPlane, and CloudShell consume refs without redefining identity

## Validation

Expected:

```bash
make validate
```

## Tracking

Closes #237.
Coordinates with SocioProphet/prophet-platform#291.