### PR TITLE
Expand Lattice Data/GovernAI topology registration

### DIFF
--- a/registry/lattice-data-governai-lanes.yaml
+++ b/registry/lattice-data-governai-lanes.yaml
@@ -1,4 +1,4 @@
-version: "0.1.0"
+version: "0.2.0"
 updated_at: "2026-05-01"
 kind: LatticeDataGovernAITopologyRegistration
 
@@ -6,30 +6,42 @@ umbrella:
   repo: SocioProphet/prophet-platform
   issue: 291
   product_surface: Lattice Studio/Data/GovernAI
-  purpose: "Reproducible community AI workbench for data products, notebooks, models, prompts, agents, publications, and evidence."
+  purpose: "Reproducible community AI workbench for data products, notebooks, models, prompts, agents, publications, active metadata, trust, and evidence."
 
 spine:
   - ContentAsset
   - CatalogAsset
   - DataProduct
   - AnnotationSet
+  - LabelingProject
+  - AnnotationReliabilityScore
   - TrainingDataset
   - EvaluationDataset
+  - TrainingUsePolicy
   - RuntimeAsset
   - NotebookSession
   - QueryRun
   - RayBeamJob
   - ModelCandidate
+  - ModelZooEntry
+  - PromptAsset
+  - RAGPipeline
+  - VectorIndex
   - EvaluationBundle
   - Factsheet
   - PublicationArtifact
+  - ResearchPackage
   - ReviewWorkflow
+  - ActiveMetadataEvent
+  - TrustSignal
+  - TrustPostureSummary
   - PlatformAssetRecord
 
 lanes:
   - id: canonical-contracts
     owner_repo: SourceOS-Linux/sourceos-spec
-    tracking_ref: SourceOS-Linux/sourceos-spec#75
+    tracking_refs:
+      - SourceOS-Linux/sourceos-spec#75
     role: canonical-schema-owner
     owns:
       - DataProduct
@@ -45,7 +57,8 @@ lanes:
 
   - id: platform-vertical-fixture
     owner_repo: SocioProphet/prophet-platform
-    tracking_ref: SocioProphet/prophet-platform#299
+    tracking_refs:
+      - SocioProphet/prophet-platform#299
     role: product-fixture-owner
     owns:
       - CatalogAsset
@@ -60,9 +73,49 @@ lanes:
       - redefine-canonical-schemas
       - own-agent-execution
 
+  - id: platform-expanded-product-surfaces
+    owner_repo: SocioProphet/prophet-platform
+    tracking_refs:
+      - SocioProphet/prophet-platform#300
+      - SocioProphet/prophet-platform#301
+      - SocioProphet/prophet-platform#302
+      - SocioProphet/prophet-platform#303
+      - SocioProphet/prophet-platform#304
+      - SocioProphet/prophet-platform#305
+    role: product-surface-owner
+    owns:
+      - ModelZooEntry
+      - ModelEndpoint
+      - PromptAsset
+      - RAGPipeline
+      - VectorIndex
+      - ResearchPackage
+      - ReviewThread
+      - ReviewDecision
+      - CitationGraph
+      - ReproductionAttempt
+      - LabelingProject
+      - AnnotationReliabilityScore
+      - TrainingDataset
+      - EvaluationDataset
+      - TrainingUsePolicy
+      - ActiveMetadataEvent
+      - TrustSignal
+      - TrustPostureSummary
+    consumes:
+      - SourceOS-Linux/sourceos-spec#75
+      - SocioProphet/lattice-forge#10
+      - SocioProphet/policy-fabric#40
+    must_not:
+      - redefine-canonical-schemas
+      - own-search-index
+      - own-topic-public-surface
+      - own-semantic-membrane
+
   - id: runtime-production
     owner_repo: SocioProphet/lattice-forge
-    tracking_ref: SocioProphet/lattice-forge#10
+    tracking_refs:
+      - SocioProphet/lattice-forge#10
     role: runtime-artifact-owner
     owns:
       - RuntimeAsset
@@ -75,7 +128,8 @@ lanes:
 
   - id: governed-mlops-execution
     owner_repo: SocioProphet/prophet-platform-fabric-mlops-ts-suite
-    tracking_ref: SocioProphet/prophet-platform-fabric-mlops-ts-suite#33
+    tracking_refs:
+      - SocioProphet/prophet-platform-fabric-mlops-ts-suite#33
     role: mlops-fixture-owner
     owns:
       - RayJobDryRunPlan
@@ -93,7 +147,9 @@ lanes:
 
   - id: policy-subjects
     owner_repo: SocioProphet/policy-fabric
-    tracking_ref: SocioProphet/policy-fabric#39
+    tracking_refs:
+      - SocioProphet/policy-fabric#39
+      - SocioProphet/policy-fabric#40
     role: policy-gate-owner
     owns:
       - policy-subject-fixtures
@@ -104,17 +160,24 @@ lanes:
       - RuntimeAsset
       - NotebookSession
       - ModelAsset
+      - ModelZooEntry
       - PromptAsset
+      - RAGPipeline
       - AgentAsset
       - EvaluationBundle
       - Factsheet
       - PublicationArtifact
+      - ResearchPackage
+      - ActiveMetadataEvent
+      - TrustPostureSummary
     must_not:
       - create-parallel-metadata-spine
 
   - id: topology-registration
     owner_repo: SocioProphet/sociosphere
-    tracking_ref: SocioProphet/sociosphere#237
+    tracking_refs:
+      - SocioProphet/sociosphere#237
+      - SocioProphet/sociosphere#238
     role: topology-governor
     owns:
       - dependency-direction
@@ -128,44 +191,72 @@ lanes:
 
   - id: search-indexing
     owner_repo: SocioProphet/sherlock-search
-    tracking_ref: SocioProphet/sherlock-search#29
+    tracking_refs:
+      - SocioProphet/sherlock-search#29
+      - SocioProphet/sherlock-search#30
+      - SocioProphet/sherlock-search#31
     role: search-consumer
     consumes:
       - PlatformAssetRecord
       - policyRef
       - evidenceCorrelationId
       - trust-fields
+      - model-zoo-records
+      - prompt-rag-records
+      - publication-review-records
+      - annotation-training-records
+      - active-metadata-records
     must_not:
       - redefine-asset-identity
 
   - id: topic-classification
     owner_repo: SocioProphet/slash-topics
-    tracking_ref: SocioProphet/slash-topics#22
+    tracking_refs:
+      - SocioProphet/slash-topics#22
+      - SocioProphet/slash-topics#23
+      - SocioProphet/slash-topics#24
     role: public-topic-governance-surface
     consumes:
       - PlatformAssetRecord
       - DataProduct
       - ModelAsset
+      - ModelZooEntry
       - PromptAsset
+      - RAGPipeline
       - PublicationArtifact
+      - ResearchPackage
+      - TrainingDataset
+      - EvaluationDataset
+      - ActiveMetadataEvent
+      - TrustPostureSummary
     must_not:
       - own-runtime-substrate
 
   - id: semantic-membrane
     owner_repo: SocioProphet/new-hope
-    tracking_ref: SocioProphet/new-hope#6
+    tracking_refs:
+      - SocioProphet/new-hope#6
+      - SocioProphet/new-hope#7
+      - SocioProphet/new-hope#8
     role: internal-semantic-membrane
     consumes:
       - PlatformAssetRecord
       - topic-classification
       - policyRef
       - evidenceCorrelationId
+      - ModelZooEntry
+      - RAGPipeline
+      - TrainingDataset
+      - ResearchPackage
+      - TrustPostureSummary
     must_not:
       - replace-slash-topics-public-surface
 
   - id: execution-consumer
     owner_repo: SocioProphet/agentplane
-    tracking_ref: SocioProphet/agentplane#75
+    tracking_refs:
+      - SocioProphet/agentplane#75
+      - SocioProphet/agentplane#76
     role: governed-execution-consumer
     consumes:
       - RuntimeAsset
@@ -179,7 +270,9 @@ lanes:
 
   - id: developer-home
     owner_repo: SocioProphet/cloudshell-fog
-    tracking_ref: SocioProphet/cloudshell-fog#29
+    tracking_refs:
+      - SocioProphet/cloudshell-fog#29
+      - SocioProphet/cloudshell-fog#30
     role: user-workbench-shell-surface
     consumes:
       - PlatformAssetRecord
@@ -214,6 +307,7 @@ validation_requirements:
   required_lanes:
     - canonical-contracts
     - platform-vertical-fixture
+    - platform-expanded-product-surfaces
     - runtime-production
     - governed-mlops-execution
     - policy-subjects
@@ -226,15 +320,40 @@ validation_requirements:
   required_tracking_refs:
     - SourceOS-Linux/sourceos-spec#75
     - SocioProphet/prophet-platform#299
+    - SocioProphet/prophet-platform#300
+    - SocioProphet/prophet-platform#301
+    - SocioProphet/prophet-platform#302
+    - SocioProphet/prophet-platform#303
+    - SocioProphet/prophet-platform#304
+    - SocioProphet/prophet-platform#305
     - SocioProphet/lattice-forge#10
     - SocioProphet/prophet-platform-fabric-mlops-ts-suite#33
     - SocioProphet/policy-fabric#39
+    - SocioProphet/policy-fabric#40
     - SocioProphet/sociosphere#237
+    - SocioProphet/sociosphere#238
     - SocioProphet/sherlock-search#29
+    - SocioProphet/sherlock-search#30
+    - SocioProphet/sherlock-search#31
     - SocioProphet/slash-topics#22
+    - SocioProphet/slash-topics#23
+    - SocioProphet/slash-topics#24
     - SocioProphet/new-hope#6
+    - SocioProphet/new-hope#7
+    - SocioProphet/new-hope#8
     - SocioProphet/agentplane#75
+    - SocioProphet/agentplane#76
     - SocioProphet/cloudshell-fog#29
+    - SocioProphet/cloudshell-fog#30
+  expanded_asset_surfaces:
+    - ModelZooEntry
+    - PromptAsset
+    - RAGPipeline
+    - ResearchPackage
+    - TrainingDataset
+    - EvaluationDataset
+    - ActiveMetadataEvent
+    - TrustPostureSummary
   forbid_parallel_metadata_spines: true
   require_policy_before_publication: true
   require_runtime_before_execution: true

--- a/tools/validate_lattice_data_governai_topology.py
+++ b/tools/validate_lattice_data_governai_topology.py
@@ -16,6 +16,7 @@ REGISTRY = ROOT / "registry" / "lattice-data-governai-lanes.yaml"
 REQUIRED_LANES = {
     "canonical-contracts",
     "platform-vertical-fixture",
+    "platform-expanded-product-surfaces",
     "runtime-production",
     "governed-mlops-execution",
     "policy-subjects",
@@ -29,15 +30,31 @@ REQUIRED_LANES = {
 REQUIRED_TRACKING_REFS = {
     "SourceOS-Linux/sourceos-spec#75",
     "SocioProphet/prophet-platform#299",
+    "SocioProphet/prophet-platform#300",
+    "SocioProphet/prophet-platform#301",
+    "SocioProphet/prophet-platform#302",
+    "SocioProphet/prophet-platform#303",
+    "SocioProphet/prophet-platform#304",
+    "SocioProphet/prophet-platform#305",
     "SocioProphet/lattice-forge#10",
     "SocioProphet/prophet-platform-fabric-mlops-ts-suite#33",
     "SocioProphet/policy-fabric#39",
+    "SocioProphet/policy-fabric#40",
     "SocioProphet/sociosphere#237",
+    "SocioProphet/sociosphere#238",
     "SocioProphet/sherlock-search#29",
+    "SocioProphet/sherlock-search#30",
+    "SocioProphet/sherlock-search#31",
     "SocioProphet/slash-topics#22",
+    "SocioProphet/slash-topics#23",
+    "SocioProphet/slash-topics#24",
     "SocioProphet/new-hope#6",
+    "SocioProphet/new-hope#7",
+    "SocioProphet/new-hope#8",
     "SocioProphet/agentplane#75",
+    "SocioProphet/agentplane#76",
     "SocioProphet/cloudshell-fog#29",
+    "SocioProphet/cloudshell-fog#30",
 }
 REQUIRED_OWNER_REPOS = {
     "SourceOS-Linux/sourceos-spec",
@@ -51,6 +68,33 @@ REQUIRED_OWNER_REPOS = {
     "SocioProphet/new-hope",
     "SocioProphet/agentplane",
     "SocioProphet/cloudshell-fog",
+}
+REQUIRED_SPINE = {
+    "DataProduct",
+    "RuntimeAsset",
+    "NotebookSession",
+    "EvaluationBundle",
+    "Factsheet",
+    "PublicationArtifact",
+    "PlatformAssetRecord",
+    "ModelZooEntry",
+    "PromptAsset",
+    "RAGPipeline",
+    "ResearchPackage",
+    "TrainingDataset",
+    "EvaluationDataset",
+    "ActiveMetadataEvent",
+    "TrustPostureSummary",
+}
+REQUIRED_EXPANDED_ASSETS = {
+    "ModelZooEntry",
+    "PromptAsset",
+    "RAGPipeline",
+    "ResearchPackage",
+    "TrainingDataset",
+    "EvaluationDataset",
+    "ActiveMetadataEvent",
+    "TrustPostureSummary",
 }
 
 
@@ -69,6 +113,18 @@ def as_list(value: Any, field: str) -> list[Any]:
     return value
 
 
+def lane_refs(lane: dict[str, Any]) -> list[str]:
+    if "tracking_refs" in lane:
+        refs = lane["tracking_refs"]
+        require(isinstance(refs, list) and refs, f"lane {lane.get('id')} tracking_refs must be non-empty list")
+        return refs
+    if "tracking_ref" in lane:
+        ref = lane["tracking_ref"]
+        require(isinstance(ref, str) and ref, f"lane {lane.get('id')} tracking_ref must be non-empty string")
+        return [ref]
+    raise ValueError(f"lane {lane.get('id')} missing tracking refs")
+
+
 def main() -> int:
     if yaml is None:
         return fail("PyYAML is required for topology validation")
@@ -78,14 +134,15 @@ def main() -> int:
         data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
         require(isinstance(data, dict), "registry must be a mapping")
         require(data.get("kind") == "LatticeDataGovernAITopologyRegistration", "kind mismatch")
+        require(data.get("version") == "0.2.0", "version must be 0.2.0 for expanded registration")
         umbrella = data.get("umbrella")
         require(isinstance(umbrella, dict), "umbrella must be mapping")
         require(umbrella.get("repo") == "SocioProphet/prophet-platform", "umbrella.repo mismatch")
         require(umbrella.get("issue") == 291, "umbrella.issue must be 291")
 
-        spine = as_list(data.get("spine"), "spine")
-        for required in ["DataProduct", "RuntimeAsset", "NotebookSession", "EvaluationBundle", "Factsheet", "PublicationArtifact", "PlatformAssetRecord"]:
-            require(required in spine, f"spine missing {required}")
+        spine = set(as_list(data.get("spine"), "spine"))
+        missing_spine = sorted(REQUIRED_SPINE - spine)
+        require(not missing_spine, f"spine missing {missing_spine}")
 
         lanes = as_list(data.get("lanes"), "lanes")
         lane_ids = {lane.get("id") for lane in lanes if isinstance(lane, dict)}
@@ -94,7 +151,14 @@ def main() -> int:
         owner_repos = {lane.get("owner_repo") for lane in lanes if isinstance(lane, dict)}
         missing_owners = sorted(REQUIRED_OWNER_REPOS - owner_repos)
         require(not missing_owners, f"missing owner repos: {missing_owners}")
-        tracking_refs = {lane.get("tracking_ref") for lane in lanes if isinstance(lane, dict)}
+        tracking_refs: set[str] = set()
+        for lane in lanes:
+            require(isinstance(lane, dict), "each lane must be mapping")
+            tracking_refs.update(lane_refs(lane))
+        validation = data.get("validation_requirements")
+        require(isinstance(validation, dict), "validation_requirements must be mapping")
+        validation_tracking_refs = set(as_list(validation.get("required_tracking_refs"), "validation_requirements.required_tracking_refs"))
+        tracking_refs.update(validation_tracking_refs)
         missing_tracking = sorted(REQUIRED_TRACKING_REFS - tracking_refs)
         require(not missing_tracking, f"missing tracking refs: {missing_tracking}")
 
@@ -104,22 +168,32 @@ def main() -> int:
             require(isinstance(lane.get("must_not", []), list), f"lane {lane.get('id')} must_not must be list")
         policy_lane = next(lane for lane in lanes if lane.get("id") == "policy-subjects")
         require("create-parallel-metadata-spine" in policy_lane.get("must_not", []), "policy lane must forbid parallel metadata spine")
+        require("SocioProphet/policy-fabric#40" in lane_refs(policy_lane), "policy lane must include expanded policy PR")
         platform_lane = next(lane for lane in lanes if lane.get("id") == "platform-vertical-fixture")
         require("redefine-canonical-schemas" in platform_lane.get("must_not", []), "platform lane must not redefine canonical schemas")
+        expanded_lane = next(lane for lane in lanes if lane.get("id") == "platform-expanded-product-surfaces")
+        expanded_owns = set(as_list(expanded_lane.get("owns"), "platform-expanded-product-surfaces.owns"))
+        missing_expanded_owns = sorted(REQUIRED_EXPANDED_ASSETS - expanded_owns)
+        require(not missing_expanded_owns, f"expanded platform lane missing owns: {missing_expanded_owns}")
         slash_lane = next(lane for lane in lanes if lane.get("id") == "topic-classification")
         require(slash_lane.get("role") == "public-topic-governance-surface", "Slash Topics role mismatch")
+        require("SocioProphet/slash-topics#24" in lane_refs(slash_lane), "Slash Topics lane must include expanded topic PR")
         new_hope_lane = next(lane for lane in lanes if lane.get("id") == "semantic-membrane")
         require(new_hope_lane.get("role") == "internal-semantic-membrane", "New Hope role mismatch")
+        require("SocioProphet/new-hope#8" in lane_refs(new_hope_lane), "New Hope lane must include expanded membrane PR")
+        sherlock_lane = next(lane for lane in lanes if lane.get("id") == "search-indexing")
+        require("SocioProphet/sherlock-search#31" in lane_refs(sherlock_lane), "Sherlock lane must include expanded index PR")
 
-        validation = data.get("validation_requirements")
-        require(isinstance(validation, dict), "validation_requirements must be mapping")
+        validation_expanded_assets = set(as_list(validation.get("expanded_asset_surfaces"), "validation_requirements.expanded_asset_surfaces"))
+        missing_validation_assets = sorted(REQUIRED_EXPANDED_ASSETS - validation_expanded_assets)
+        require(not missing_validation_assets, f"expanded_asset_surfaces missing {missing_validation_assets}")
         require(validation.get("forbid_parallel_metadata_spines") is True, "must forbid parallel metadata spines")
         require(validation.get("require_policy_before_publication") is True, "must require policy before publication")
         require(validation.get("require_runtime_before_execution") is True, "must require runtime before execution")
         require(validation.get("require_platform_record_before_search") is True, "must require platform record before search")
     except Exception as exc:  # noqa: BLE001
         return fail(str(exc))
-    print("OK: validated Lattice Data/GovernAI topology registration")
+    print("OK: validated expanded Lattice Data/GovernAI topology registration")
     return 0
 
 


### PR DESCRIPTION
## Summary

Updates the SocioSphere Lattice Data/GovernAI topology registration to match the expanded work now merged across Prophet Platform, Sherlock, Slash Topics, New Hope, and Policy Fabric.

## Adds

- Expanded platform product-surface lane for Model Zoo, Prompt/RAG, publication review, annotation training, active metadata, and trust posture assets.
- Expanded tracking refs for Prophet Platform PRs #300-#305.
- Expanded Sherlock, Slash Topics, New Hope, and Policy Fabric refs.
- Expanded validator coverage for multi-PR `tracking_refs`, expanded asset surfaces, and topology ownership rules.

## Scope discipline

SocioSphere remains topology governor only. It does not implement product features, policy decisions, search, topics, membranes, runtime, or execution.

## Validation

Expected:

```bash
make validate
```

## Tracking

Advances SocioProphet/prophet-platform#291 and follows the expanded Lattice Data/GovernAI downstream tranches.