### PR TITLE
Register Lattice runtime profile topology tranche

### DIFF
--- a/registry/lattice-data-governai-lanes.yaml
+++ b/registry/lattice-data-governai-lanes.yaml
@@ -1,4 +1,4 @@
-version: "0.2.0"
+version: "0.3.0"
 updated_at: "2026-05-01"
 kind: LatticeDataGovernAITopologyRegistration
 
@@ -6,7 +6,7 @@ umbrella:
   repo: SocioProphet/prophet-platform
   issue: 291
   product_surface: Lattice Studio/Data/GovernAI
-  purpose: "Reproducible community AI workbench for data products, notebooks, models, prompts, agents, publications, active metadata, trust, and evidence."
+  purpose: "Reproducible community AI workbench for data products, notebooks, models, prompts, agents, publications, active metadata, trust, runtime profiles, and evidence."
 
 spine:
   - ContentAsset
@@ -19,6 +19,7 @@ spine:
   - EvaluationDataset
   - TrainingUsePolicy
   - RuntimeAsset
+  - RuntimeProfileBinding
   - NotebookSession
   - QueryRun
   - RayBeamJob
@@ -36,6 +37,25 @@ spine:
   - TrustSignal
   - TrustPostureSummary
   - PlatformAssetRecord
+
+runtime_profiles:
+  notebook_runtime_ref: runtime-asset:prophet-python-ml:0.1.0
+  ray_runtime_ref: runtime-asset:prophet-ray-ml:0.1.0
+  beam_runtime_ref: runtime-asset:prophet-beam-dataops:0.1.0
+  role_bindings:
+    NotebookSession: runtime-asset:prophet-python-ml:0.1.0
+    QueryRun: runtime-asset:prophet-python-ml:0.1.0
+    PublicationArtifact: runtime-asset:prophet-python-ml:0.1.0
+    ModelZooEntry: runtime-asset:prophet-ray-ml:0.1.0
+    ModelRuntimeProfile: runtime-asset:prophet-ray-ml:0.1.0
+    ModelEndpoint: runtime-asset:prophet-ray-ml:0.1.0
+    RayJobDryRunPlan: runtime-asset:prophet-ray-ml:0.1.0
+    RAGPipeline: runtime-asset:prophet-ray-ml:0.1.0
+    EvaluationBundle: runtime-asset:prophet-ray-ml:0.1.0
+    BeamPipelineDryRunPlan: runtime-asset:prophet-beam-dataops:0.1.0
+    TrainingDatasetRecipe: runtime-asset:prophet-beam-dataops:0.1.0
+    QualityProfile: runtime-asset:prophet-beam-dataops:0.1.0
+    VectorIndex: runtime-asset:prophet-beam-dataops:0.1.0
 
 lanes:
   - id: canonical-contracts
@@ -69,6 +89,7 @@ lanes:
     consumes:
       - SourceOS-Linux/sourceos-spec#75
       - SocioProphet/lattice-forge#10
+      - SocioProphet/lattice-forge#11
     must_not:
       - redefine-canonical-schemas
       - own-agent-execution
@@ -105,6 +126,7 @@ lanes:
     consumes:
       - SourceOS-Linux/sourceos-spec#75
       - SocioProphet/lattice-forge#10
+      - SocioProphet/lattice-forge#11
       - SocioProphet/policy-fabric#40
     must_not:
       - redefine-canonical-schemas
@@ -116,15 +138,37 @@ lanes:
     owner_repo: SocioProphet/lattice-forge
     tracking_refs:
       - SocioProphet/lattice-forge#10
+      - SocioProphet/lattice-forge#11
     role: runtime-artifact-owner
     owns:
       - RuntimeAsset
+      - prophet-python-ml
+      - prophet-ray-ml
+      - prophet-beam-dataops
       - runtime-lockfiles
       - kernel-metadata
       - runtime-sbom-signature-scan-evidence
     must_not:
       - own-data-product-policy
       - own-platform-ui
+      - own-agent-execution
+
+  - id: runtime-profile-bindings
+    owner_repo: SocioProphet/prophet-platform
+    tracking_refs:
+      - SocioProphet/prophet-platform#306
+    role: runtime-role-binding-owner
+    owns:
+      - RuntimeProfileBinding
+      - notebook-runtime-role
+      - ray-runtime-role
+      - beam-runtime-role
+    consumes:
+      - SocioProphet/lattice-forge#11
+    must_not:
+      - own-runtime-build-artifacts
+      - own-agent-execution
+      - redefine-runtime-asset-schema
 
   - id: governed-mlops-execution
     owner_repo: SocioProphet/prophet-platform-fabric-mlops-ts-suite
@@ -141,6 +185,7 @@ lanes:
       - DataContract
       - RuntimeAsset
       - EvaluationBundle
+      - SocioProphet/lattice-forge#11
     must_not:
       - own-canonical-data-schemas
       - bypass-policy-fabric
@@ -170,6 +215,7 @@ lanes:
       - ResearchPackage
       - ActiveMetadataEvent
       - TrustPostureSummary
+      - RuntimeProfileBinding
     must_not:
       - create-parallel-metadata-spine
 
@@ -178,6 +224,7 @@ lanes:
     tracking_refs:
       - SocioProphet/sociosphere#237
       - SocioProphet/sociosphere#238
+      - SocioProphet/sociosphere#239
     role: topology-governor
     owns:
       - dependency-direction
@@ -201,6 +248,7 @@ lanes:
       - policyRef
       - evidenceCorrelationId
       - trust-fields
+      - runtime-profile-bindings
       - model-zoo-records
       - prompt-rag-records
       - publication-review-records
@@ -219,6 +267,8 @@ lanes:
     consumes:
       - PlatformAssetRecord
       - DataProduct
+      - RuntimeAsset
+      - RuntimeProfileBinding
       - ModelAsset
       - ModelZooEntry
       - PromptAsset
@@ -244,6 +294,7 @@ lanes:
       - topic-classification
       - policyRef
       - evidenceCorrelationId
+      - RuntimeProfileBinding
       - ModelZooEntry
       - RAGPipeline
       - TrainingDataset
@@ -257,9 +308,11 @@ lanes:
     tracking_refs:
       - SocioProphet/agentplane#75
       - SocioProphet/agentplane#76
+      - SocioProphet/agentplane#77
     role: governed-execution-consumer
     consumes:
       - RuntimeAsset
+      - RuntimeProfileBinding
       - DataProduct
       - ModelAsset
       - EvaluationBundle
@@ -267,6 +320,7 @@ lanes:
       - PolicyBundle
     must_not:
       - own-lattice-canonical-schemas
+      - own-runtime-build-artifacts
 
   - id: developer-home
     owner_repo: SocioProphet/cloudshell-fog
@@ -277,6 +331,7 @@ lanes:
     consumes:
       - PlatformAssetRecord
       - RuntimeAsset
+      - RuntimeProfileBinding
       - DataProduct
       - EvidenceBundle
       - Factsheet
@@ -287,11 +342,13 @@ lanes:
 dependency_direction_rules:
   canonical_schemas_flow_from:
     - SourceOS-Linux/sourceos-spec
+  runtime_artifacts_flow_from:
+    - SocioProphet/lattice-forge
+  runtime_profile_bindings_flow_from:
+    - SocioProphet/prophet-platform
   platform_records_flow_from:
     - SocioProphet/prophet-platform
     - SocioProphet/prophet-platform-fabric-mlops-ts-suite
-  runtime_artifacts_flow_from:
-    - SocioProphet/lattice-forge
   policy_decisions_flow_from:
     - SocioProphet/policy-fabric
   topology_governance_flow_from:
@@ -309,6 +366,7 @@ validation_requirements:
     - platform-vertical-fixture
     - platform-expanded-product-surfaces
     - runtime-production
+    - runtime-profile-bindings
     - governed-mlops-execution
     - policy-subjects
     - topology-registration
@@ -326,12 +384,15 @@ validation_requirements:
     - SocioProphet/prophet-platform#303
     - SocioProphet/prophet-platform#304
     - SocioProphet/prophet-platform#305
+    - SocioProphet/prophet-platform#306
     - SocioProphet/lattice-forge#10
+    - SocioProphet/lattice-forge#11
     - SocioProphet/prophet-platform-fabric-mlops-ts-suite#33
     - SocioProphet/policy-fabric#39
     - SocioProphet/policy-fabric#40
     - SocioProphet/sociosphere#237
     - SocioProphet/sociosphere#238
+    - SocioProphet/sociosphere#239
     - SocioProphet/sherlock-search#29
     - SocioProphet/sherlock-search#30
     - SocioProphet/sherlock-search#31
@@ -343,6 +404,7 @@ validation_requirements:
     - SocioProphet/new-hope#8
     - SocioProphet/agentplane#75
     - SocioProphet/agentplane#76
+    - SocioProphet/agentplane#77
     - SocioProphet/cloudshell-fog#29
     - SocioProphet/cloudshell-fog#30
   expanded_asset_surfaces:
@@ -354,7 +416,13 @@ validation_requirements:
     - EvaluationDataset
     - ActiveMetadataEvent
     - TrustPostureSummary
+    - RuntimeProfileBinding
+  runtime_profile_refs:
+    - runtime-asset:prophet-python-ml:0.1.0
+    - runtime-asset:prophet-ray-ml:0.1.0
+    - runtime-asset:prophet-beam-dataops:0.1.0
   forbid_parallel_metadata_spines: true
   require_policy_before_publication: true
   require_runtime_before_execution: true
   require_platform_record_before_search: true
+  require_runtime_profile_binding_before_agent_execution: true

--- a/tools/validate_lattice_data_governai_topology.py
+++ b/tools/validate_lattice_data_governai_topology.py
@@ -13,11 +13,16 @@ except ImportError:  # pragma: no cover
 ROOT = Path(__file__).resolve().parents[1]
 REGISTRY = ROOT / "registry" / "lattice-data-governai-lanes.yaml"
 
+NOTEBOOK_RUNTIME_REF = "runtime-asset:prophet-python-ml:0.1.0"
+RAY_RUNTIME_REF = "runtime-asset:prophet-ray-ml:0.1.0"
+BEAM_RUNTIME_REF = "runtime-asset:prophet-beam-dataops:0.1.0"
+
 REQUIRED_LANES = {
     "canonical-contracts",
     "platform-vertical-fixture",
     "platform-expanded-product-surfaces",
     "runtime-production",
+    "runtime-profile-bindings",
     "governed-mlops-execution",
     "policy-subjects",
     "topology-registration",
@@ -36,12 +41,15 @@ REQUIRED_TRACKING_REFS = {
     "SocioProphet/prophet-platform#303",
     "SocioProphet/prophet-platform#304",
     "SocioProphet/prophet-platform#305",
+    "SocioProphet/prophet-platform#306",
     "SocioProphet/lattice-forge#10",
+    "SocioProphet/lattice-forge#11",
     "SocioProphet/prophet-platform-fabric-mlops-ts-suite#33",
     "SocioProphet/policy-fabric#39",
     "SocioProphet/policy-fabric#40",
     "SocioProphet/sociosphere#237",
     "SocioProphet/sociosphere#238",
+    "SocioProphet/sociosphere#239",
     "SocioProphet/sherlock-search#29",
     "SocioProphet/sherlock-search#30",
     "SocioProphet/sherlock-search#31",
@@ -53,6 +61,7 @@ REQUIRED_TRACKING_REFS = {
     "SocioProphet/new-hope#8",
     "SocioProphet/agentplane#75",
     "SocioProphet/agentplane#76",
+    "SocioProphet/agentplane#77",
     "SocioProphet/cloudshell-fog#29",
     "SocioProphet/cloudshell-fog#30",
 }
@@ -72,6 +81,7 @@ REQUIRED_OWNER_REPOS = {
 REQUIRED_SPINE = {
     "DataProduct",
     "RuntimeAsset",
+    "RuntimeProfileBinding",
     "NotebookSession",
     "EvaluationBundle",
     "Factsheet",
@@ -95,6 +105,23 @@ REQUIRED_EXPANDED_ASSETS = {
     "EvaluationDataset",
     "ActiveMetadataEvent",
     "TrustPostureSummary",
+    "RuntimeProfileBinding",
+}
+REQUIRED_RUNTIME_REFS = {NOTEBOOK_RUNTIME_REF, RAY_RUNTIME_REF, BEAM_RUNTIME_REF}
+REQUIRED_ROLE_BINDINGS = {
+    "NotebookSession": NOTEBOOK_RUNTIME_REF,
+    "QueryRun": NOTEBOOK_RUNTIME_REF,
+    "PublicationArtifact": NOTEBOOK_RUNTIME_REF,
+    "ModelZooEntry": RAY_RUNTIME_REF,
+    "ModelRuntimeProfile": RAY_RUNTIME_REF,
+    "ModelEndpoint": RAY_RUNTIME_REF,
+    "RayJobDryRunPlan": RAY_RUNTIME_REF,
+    "RAGPipeline": RAY_RUNTIME_REF,
+    "EvaluationBundle": RAY_RUNTIME_REF,
+    "BeamPipelineDryRunPlan": BEAM_RUNTIME_REF,
+    "TrainingDatasetRecipe": BEAM_RUNTIME_REF,
+    "QualityProfile": BEAM_RUNTIME_REF,
+    "VectorIndex": BEAM_RUNTIME_REF,
 }
 
 
@@ -134,7 +161,7 @@ def main() -> int:
         data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
         require(isinstance(data, dict), "registry must be a mapping")
         require(data.get("kind") == "LatticeDataGovernAITopologyRegistration", "kind mismatch")
-        require(data.get("version") == "0.2.0", "version must be 0.2.0 for expanded registration")
+        require(data.get("version") == "0.3.0", "version must be 0.3.0 for runtime profile registration")
         umbrella = data.get("umbrella")
         require(isinstance(umbrella, dict), "umbrella must be mapping")
         require(umbrella.get("repo") == "SocioProphet/prophet-platform", "umbrella.repo mismatch")
@@ -143,6 +170,16 @@ def main() -> int:
         spine = set(as_list(data.get("spine"), "spine"))
         missing_spine = sorted(REQUIRED_SPINE - spine)
         require(not missing_spine, f"spine missing {missing_spine}")
+
+        runtime_profiles = data.get("runtime_profiles")
+        require(isinstance(runtime_profiles, dict), "runtime_profiles must be mapping")
+        require(runtime_profiles.get("notebook_runtime_ref") == NOTEBOOK_RUNTIME_REF, "notebook runtime ref mismatch")
+        require(runtime_profiles.get("ray_runtime_ref") == RAY_RUNTIME_REF, "ray runtime ref mismatch")
+        require(runtime_profiles.get("beam_runtime_ref") == BEAM_RUNTIME_REF, "beam runtime ref mismatch")
+        role_bindings = runtime_profiles.get("role_bindings")
+        require(isinstance(role_bindings, dict), "runtime_profiles.role_bindings must be mapping")
+        for role, runtime_ref in REQUIRED_ROLE_BINDINGS.items():
+            require(role_bindings.get(role) == runtime_ref, f"runtime role binding mismatch for {role}")
 
         lanes = as_list(data.get("lanes"), "lanes")
         lane_ids = {lane.get("id") for lane in lanes if isinstance(lane, dict)}
@@ -166,6 +203,21 @@ def main() -> int:
             require(isinstance(lane, dict), "each lane must be mapping")
             require(isinstance(lane.get("owns", []), list), f"lane {lane.get('id')} owns must be list")
             require(isinstance(lane.get("must_not", []), list), f"lane {lane.get('id')} must_not must be list")
+
+        runtime_lane = next(lane for lane in lanes if lane.get("id") == "runtime-production")
+        require("SocioProphet/lattice-forge#11" in lane_refs(runtime_lane), "runtime lane must include #11")
+        runtime_owns = set(as_list(runtime_lane.get("owns"), "runtime-production.owns"))
+        for owned in ["prophet-python-ml", "prophet-ray-ml", "prophet-beam-dataops"]:
+            require(owned in runtime_owns, f"runtime lane missing {owned}")
+
+        runtime_binding_lane = next(lane for lane in lanes if lane.get("id") == "runtime-profile-bindings")
+        require("SocioProphet/prophet-platform#306" in lane_refs(runtime_binding_lane), "runtime-profile-bindings lane must include #306")
+        require("redefine-runtime-asset-schema" in runtime_binding_lane.get("must_not", []), "runtime-profile-bindings must not redefine RuntimeAsset schema")
+
+        execution_lane = next(lane for lane in lanes if lane.get("id") == "execution-consumer")
+        require("SocioProphet/agentplane#77" in lane_refs(execution_lane), "AgentPlane execution lane must include #77")
+        require("own-runtime-build-artifacts" in execution_lane.get("must_not", []), "AgentPlane must not own runtime build artifacts")
+
         policy_lane = next(lane for lane in lanes if lane.get("id") == "policy-subjects")
         require("create-parallel-metadata-spine" in policy_lane.get("must_not", []), "policy lane must forbid parallel metadata spine")
         require("SocioProphet/policy-fabric#40" in lane_refs(policy_lane), "policy lane must include expanded policy PR")
@@ -173,7 +225,7 @@ def main() -> int:
         require("redefine-canonical-schemas" in platform_lane.get("must_not", []), "platform lane must not redefine canonical schemas")
         expanded_lane = next(lane for lane in lanes if lane.get("id") == "platform-expanded-product-surfaces")
         expanded_owns = set(as_list(expanded_lane.get("owns"), "platform-expanded-product-surfaces.owns"))
-        missing_expanded_owns = sorted(REQUIRED_EXPANDED_ASSETS - expanded_owns)
+        missing_expanded_owns = sorted((REQUIRED_EXPANDED_ASSETS - {"RuntimeProfileBinding"}) - expanded_owns)
         require(not missing_expanded_owns, f"expanded platform lane missing owns: {missing_expanded_owns}")
         slash_lane = next(lane for lane in lanes if lane.get("id") == "topic-classification")
         require(slash_lane.get("role") == "public-topic-governance-surface", "Slash Topics role mismatch")
@@ -187,13 +239,17 @@ def main() -> int:
         validation_expanded_assets = set(as_list(validation.get("expanded_asset_surfaces"), "validation_requirements.expanded_asset_surfaces"))
         missing_validation_assets = sorted(REQUIRED_EXPANDED_ASSETS - validation_expanded_assets)
         require(not missing_validation_assets, f"expanded_asset_surfaces missing {missing_validation_assets}")
+        runtime_refs = set(as_list(validation.get("runtime_profile_refs"), "validation_requirements.runtime_profile_refs"))
+        missing_runtime_refs = sorted(REQUIRED_RUNTIME_REFS - runtime_refs)
+        require(not missing_runtime_refs, f"runtime_profile_refs missing {missing_runtime_refs}")
         require(validation.get("forbid_parallel_metadata_spines") is True, "must forbid parallel metadata spines")
         require(validation.get("require_policy_before_publication") is True, "must require policy before publication")
         require(validation.get("require_runtime_before_execution") is True, "must require runtime before execution")
         require(validation.get("require_platform_record_before_search") is True, "must require platform record before search")
+        require(validation.get("require_runtime_profile_binding_before_agent_execution") is True, "must require runtime profile binding before agent execution")
     except Exception as exc:  # noqa: BLE001
         return fail(str(exc))
-    print("OK: validated expanded Lattice Data/GovernAI topology registration")
+    print("OK: validated runtime-profile Lattice Data/GovernAI topology registration")
     return 0
 
 


### PR DESCRIPTION
## Summary

Updates the Lattice Data/GovernAI topology registration to v0.3.0 for the runtime-profile tranche.

## Adds

- explicit runtime profile refs for notebook, Ray, and Beam RuntimeAssets
- `runtime-profile-bindings` lane for `SocioProphet/prophet-platform#306`
- `SocioProphet/lattice-forge#11` in runtime production
- `SocioProphet/agentplane#77` in execution consumer topology
- validator coverage for runtime role bindings and required runtime profile refs

## Runtime role split

- `runtime-asset:prophet-python-ml:0.1.0` for notebook/query/publication reproduction
- `runtime-asset:prophet-ray-ml:0.1.0` for model/Ray/RAG evaluation roles
- `runtime-asset:prophet-beam-dataops:0.1.0` for Beam/dataset/quality/vector-index roles

## Scope discipline

SocioSphere remains topology governor only. It does not build runtime artifacts, own platform product fixtures, or own AgentPlane execution.

## Validation

Expected:

```bash
make validate
```

## Tracking

Advances SocioProphet/prophet-platform#291 and follows SocioProphet/lattice-forge#11, SocioProphet/prophet-platform#306, and SocioProphet/agentplane#77.