### PR TITLE
Register Lattice runtime profile consumer parity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ ui-dev: ui-preflight
 # --- end ui-workbench targets ---
 
 # --- standards validation targets ---
-.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate
+.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate
 
-validate: validate-standards program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate
+validate: validate-standards program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate
 	@echo "OK: validate"
 
 validate-standards:
@@ -40,6 +40,10 @@ model-fabric-work-register-validate:
 lattice-data-governai-topology-validate:
 	python3 -m pip install --user pyyaml >/dev/null
 	python3 tools/validate_lattice_data_governai_topology.py
+
+lattice-runtime-profile-consumer-parity-validate:
+	python3 -m pip install --user pyyaml >/dev/null
+	python3 tools/validate_lattice_runtime_profile_consumer_parity.py
 
 multidomain-geospatial-standards-compliance-validate:
 	python3 tools/check_multidomain_geospatial_standards_compliance.py

--- a/registry/lattice-runtime-profile-consumer-parity.yaml
+++ b/registry/lattice-runtime-profile-consumer-parity.yaml
@@ -1,0 +1,201 @@
+version: "0.1.0"
+updated_at: "2026-05-01"
+kind: LatticeRuntimeProfileConsumerParityRegistration
+
+umbrella:
+  repo: SocioProphet/prophet-platform
+  issue: 291
+  parent_registry: registry/lattice-data-governai-lanes.yaml
+  parent_registry_version: "0.3.0"
+  purpose: "Registers the final runtime-profile consumer parity wave for notebook, Ray, and Beam RuntimeAsset recognition across runtime, platform, execution, search, topic, membrane, policy, shell, and topology consumers."
+
+runtime_profile_refs:
+  notebook_runtime_ref: runtime-asset:prophet-python-ml:0.1.0
+  ray_runtime_ref: runtime-asset:prophet-ray-ml:0.1.0
+  beam_runtime_ref: runtime-asset:prophet-beam-dataops:0.1.0
+  runtime_profile_binding_ref: runtime-profile-binding:lattice-data-governai:0.1.0
+
+runtime_role_bindings:
+  NotebookSession: runtime-asset:prophet-python-ml:0.1.0
+  QueryRun: runtime-asset:prophet-python-ml:0.1.0
+  PublicationArtifact: runtime-asset:prophet-python-ml:0.1.0
+  ModelZooEntry: runtime-asset:prophet-ray-ml:0.1.0
+  ModelRuntimeProfile: runtime-asset:prophet-ray-ml:0.1.0
+  ModelEndpoint: runtime-asset:prophet-ray-ml:0.1.0
+  RayJobDryRunPlan: runtime-asset:prophet-ray-ml:0.1.0
+  RAGPipeline: runtime-asset:prophet-ray-ml:0.1.0
+  EvaluationBundle: runtime-asset:prophet-ray-ml:0.1.0
+  BeamPipelineDryRunPlan: runtime-asset:prophet-beam-dataops:0.1.0
+  TrainingDatasetRecipe: runtime-asset:prophet-beam-dataops:0.1.0
+  QualityProfile: runtime-asset:prophet-beam-dataops:0.1.0
+  VectorIndex: runtime-asset:prophet-beam-dataops:0.1.0
+
+consumer_parity_wave:
+  - id: runtime-artifacts
+    owner_repo: SocioProphet/lattice-forge
+    tracking_refs:
+      - SocioProphet/lattice-forge#11
+    role: runtime-artifact-owner
+    recognizes:
+      - runtime-asset:prophet-python-ml:0.1.0
+      - runtime-asset:prophet-ray-ml:0.1.0
+      - runtime-asset:prophet-beam-dataops:0.1.0
+    must_not:
+      - own-platform-runtime-bindings
+      - own-agent-execution
+
+  - id: platform-runtime-bindings
+    owner_repo: SocioProphet/prophet-platform
+    tracking_refs:
+      - SocioProphet/prophet-platform#306
+    role: runtime-role-binding-owner
+    recognizes:
+      - runtime-profile-binding:lattice-data-governai:0.1.0
+      - runtime-asset:prophet-python-ml:0.1.0
+      - runtime-asset:prophet-ray-ml:0.1.0
+      - runtime-asset:prophet-beam-dataops:0.1.0
+    must_not:
+      - own-runtime-build-artifacts
+      - own-agent-execution
+
+  - id: mlops-runtime-execution
+    owner_repo: SocioProphet/prophet-platform-fabric-mlops-ts-suite
+    tracking_refs:
+      - SocioProphet/prophet-platform-fabric-mlops-ts-suite#34
+    role: role-specific-runtime-execution-fixture-owner
+    recognizes:
+      - RayJobDryRunPlan -> runtime-asset:prophet-ray-ml:0.1.0
+      - BeamPipelineDryRunPlan -> runtime-asset:prophet-beam-dataops:0.1.0
+      - EvaluationBundle -> runtime-asset:prophet-ray-ml:0.1.0
+    must_not:
+      - collapse-ray-and-beam-onto-notebook-runtime
+      - bypass-policy-fabric
+
+  - id: agentplane-runtime-consumer
+    owner_repo: SocioProphet/agentplane
+    tracking_refs:
+      - SocioProphet/agentplane#77
+    role: execution-consumer
+    recognizes:
+      - runtime-profile-binding:lattice-data-governai:0.1.0
+      - runtime-asset:prophet-python-ml:0.1.0
+      - runtime-asset:prophet-ray-ml:0.1.0
+      - runtime-asset:prophet-beam-dataops:0.1.0
+    must_not:
+      - own-runtime-build-artifacts
+      - redefine-runtime-asset-schema
+
+  - id: sherlock-runtime-index
+    owner_repo: SocioProphet/sherlock-search
+    tracking_refs:
+      - SocioProphet/sherlock-search#32
+    role: search-consumer
+    recognizes:
+      - runtime-profile-binding:lattice-data-governai:0.1.0
+      - runtime-asset:prophet-python-ml:0.1.0
+      - runtime-asset:prophet-ray-ml:0.1.0
+      - runtime-asset:prophet-beam-dataops:0.1.0
+    must_not:
+      - redefine-asset-identity
+
+  - id: slash-runtime-topics
+    owner_repo: SocioProphet/slash-topics
+    tracking_refs:
+      - SocioProphet/slash-topics#25
+    role: public-topic-governance-surface
+    recognizes:
+      - slash-topic://lattice/data-governai/runtime-profiles
+      - runtime-profile-binding:lattice-data-governai:0.1.0
+      - runtime-asset:prophet-python-ml:0.1.0
+      - runtime-asset:prophet-ray-ml:0.1.0
+      - runtime-asset:prophet-beam-dataops:0.1.0
+    must_not:
+      - own-runtime-substrate
+
+  - id: newhope-runtime-membrane
+    owner_repo: SocioProphet/new-hope
+    tracking_refs:
+      - SocioProphet/new-hope#9
+    role: internal-semantic-membrane
+    recognizes:
+      - slash-topic://lattice/data-governai/runtime-profiles
+      - newhope://membranes/lattice-data-governai-admission@0.1.0
+      - runtime-profile-binding:lattice-data-governai:0.1.0
+      - runtime-asset:prophet-python-ml:0.1.0
+      - runtime-asset:prophet-ray-ml:0.1.0
+      - runtime-asset:prophet-beam-dataops:0.1.0
+    must_not:
+      - replace-slash-topics-public-surface
+      - redefine-runtime-asset-schema
+
+  - id: policy-runtime-gates
+    owner_repo: SocioProphet/policy-fabric
+    tracking_refs:
+      - SocioProphet/policy-fabric#41
+    role: policy-gate-owner
+    recognizes:
+      - RuntimeAsset
+      - RuntimeProfileBinding
+      - NotebookRuntimeProfile
+      - RayRuntimeProfile
+      - BeamRuntimeProfile
+    must_not:
+      - create-parallel-metadata-spine
+      - bypass-policy-fabric
+
+  - id: cloudshell-runtime-routes
+    owner_repo: SocioProphet/cloudshell-fog
+    tracking_refs:
+      - SocioProphet/cloudshell-fog#31
+    role: user-workbench-shell-surface
+    recognizes:
+      - /lattice runtime pick prophet-python-ml
+      - /lattice runtime pick prophet-ray-ml
+      - /lattice runtime pick prophet-beam-dataops
+      - /lattice runtime bindings inspect
+      - /lattice mlops ray run community_truth_demo --runtime prophet-ray-ml --dry-run
+      - /lattice dataops beam run community_truth_demo --runtime prophet-beam-dataops --dry-run
+    must_not:
+      - bypass-policy-fabric
+      - bypass-agentplane
+      - bypass-slash-topics-or-new-hope
+
+  - id: topology-consumer-parity
+    owner_repo: SocioProphet/sociosphere
+    tracking_refs:
+      - SocioProphet/sociosphere#240
+    role: topology-governor
+    recognizes:
+      - all-runtime-profile-consumer-parity-records
+    must_not:
+      - implement-downstream-features
+
+validation_requirements:
+  required_tracking_refs:
+    - SocioProphet/lattice-forge#11
+    - SocioProphet/prophet-platform#306
+    - SocioProphet/prophet-platform-fabric-mlops-ts-suite#34
+    - SocioProphet/agentplane#77
+    - SocioProphet/sherlock-search#32
+    - SocioProphet/slash-topics#25
+    - SocioProphet/new-hope#9
+    - SocioProphet/policy-fabric#41
+    - SocioProphet/cloudshell-fog#31
+    - SocioProphet/sociosphere#240
+  required_owner_repos:
+    - SocioProphet/lattice-forge
+    - SocioProphet/prophet-platform
+    - SocioProphet/prophet-platform-fabric-mlops-ts-suite
+    - SocioProphet/agentplane
+    - SocioProphet/sherlock-search
+    - SocioProphet/slash-topics
+    - SocioProphet/new-hope
+    - SocioProphet/policy-fabric
+    - SocioProphet/cloudshell-fog
+    - SocioProphet/sociosphere
+  require_runtime_profile_binding_before_agent_execution: true
+  require_policy_before_runtime_launch: true
+  require_runtime_profile_topics_before_newhope_membrane: true
+  require_runtime_profile_index_before_shell_discovery: true
+  forbid_runtime_schema_redefinition_outside_lattice_forge: true
+  forbid_policy_bypass: true

--- a/tools/validate_lattice_runtime_profile_consumer_parity.py
+++ b/tools/validate_lattice_runtime_profile_consumer_parity.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "registry" / "lattice-runtime-profile-consumer-parity.yaml"
+
+NOTEBOOK = "runtime-asset:prophet-python-ml:0.1.0"
+RAY = "runtime-asset:prophet-ray-ml:0.1.0"
+BEAM = "runtime-asset:prophet-beam-dataops:0.1.0"
+BINDING = "runtime-profile-binding:lattice-data-governai:0.1.0"
+
+REQUIRED_OWNER_REPOS = {
+    "SocioProphet/lattice-forge",
+    "SocioProphet/prophet-platform",
+    "SocioProphet/prophet-platform-fabric-mlops-ts-suite",
+    "SocioProphet/agentplane",
+    "SocioProphet/sherlock-search",
+    "SocioProphet/slash-topics",
+    "SocioProphet/new-hope",
+    "SocioProphet/policy-fabric",
+    "SocioProphet/cloudshell-fog",
+    "SocioProphet/sociosphere",
+}
+REQUIRED_TRACKING_REFS = {
+    "SocioProphet/lattice-forge#11",
+    "SocioProphet/prophet-platform#306",
+    "SocioProphet/prophet-platform-fabric-mlops-ts-suite#34",
+    "SocioProphet/agentplane#77",
+    "SocioProphet/sherlock-search#32",
+    "SocioProphet/slash-topics#25",
+    "SocioProphet/new-hope#9",
+    "SocioProphet/policy-fabric#41",
+    "SocioProphet/cloudshell-fog#31",
+    "SocioProphet/sociosphere#240",
+}
+REQUIRED_LANES = {
+    "runtime-artifacts",
+    "platform-runtime-bindings",
+    "mlops-runtime-execution",
+    "agentplane-runtime-consumer",
+    "sherlock-runtime-index",
+    "slash-runtime-topics",
+    "newhope-runtime-membrane",
+    "policy-runtime-gates",
+    "cloudshell-runtime-routes",
+    "topology-consumer-parity",
+}
+REQUIRED_ROLE_BINDINGS = {
+    "NotebookSession": NOTEBOOK,
+    "QueryRun": NOTEBOOK,
+    "PublicationArtifact": NOTEBOOK,
+    "ModelZooEntry": RAY,
+    "ModelRuntimeProfile": RAY,
+    "ModelEndpoint": RAY,
+    "RayJobDryRunPlan": RAY,
+    "RAGPipeline": RAY,
+    "EvaluationBundle": RAY,
+    "BeamPipelineDryRunPlan": BEAM,
+    "TrainingDatasetRecipe": BEAM,
+    "QualityProfile": BEAM,
+    "VectorIndex": BEAM,
+}
+
+
+def fail(message: str) -> int:
+    print(f"ERR: {message}", file=sys.stderr)
+    return 1
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def as_list(value: Any, field: str) -> list[Any]:
+    require(isinstance(value, list), f"{field} must be a list")
+    require(bool(value), f"{field} must not be empty")
+    return value
+
+
+def main() -> int:
+    if yaml is None:
+        return fail("PyYAML is required for runtime profile consumer parity validation")
+    if not REGISTRY.exists():
+        return fail(f"missing {REGISTRY}")
+    try:
+        data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+        require(isinstance(data, dict), "registry must be mapping")
+        require(data.get("kind") == "LatticeRuntimeProfileConsumerParityRegistration", "kind mismatch")
+        require(data.get("version") == "0.1.0", "version mismatch")
+
+        umbrella = data.get("umbrella")
+        require(isinstance(umbrella, dict), "umbrella must be mapping")
+        require(umbrella.get("repo") == "SocioProphet/prophet-platform", "umbrella.repo mismatch")
+        require(umbrella.get("issue") == 291, "umbrella.issue mismatch")
+        require(umbrella.get("parent_registry") == "registry/lattice-data-governai-lanes.yaml", "parent registry mismatch")
+
+        refs = data.get("runtime_profile_refs")
+        require(isinstance(refs, dict), "runtime_profile_refs must be mapping")
+        require(refs.get("notebook_runtime_ref") == NOTEBOOK, "notebook runtime ref mismatch")
+        require(refs.get("ray_runtime_ref") == RAY, "ray runtime ref mismatch")
+        require(refs.get("beam_runtime_ref") == BEAM, "beam runtime ref mismatch")
+        require(refs.get("runtime_profile_binding_ref") == BINDING, "runtime profile binding ref mismatch")
+
+        role_bindings = data.get("runtime_role_bindings")
+        require(isinstance(role_bindings, dict), "runtime_role_bindings must be mapping")
+        for role, runtime_ref in REQUIRED_ROLE_BINDINGS.items():
+            require(role_bindings.get(role) == runtime_ref, f"role binding mismatch for {role}")
+
+        lanes = as_list(data.get("consumer_parity_wave"), "consumer_parity_wave")
+        lane_ids = {lane.get("id") for lane in lanes if isinstance(lane, dict)}
+        missing_lanes = sorted(REQUIRED_LANES - lane_ids)
+        require(not missing_lanes, f"missing lanes: {missing_lanes}")
+
+        owner_repos = {lane.get("owner_repo") for lane in lanes if isinstance(lane, dict)}
+        missing_owners = sorted(REQUIRED_OWNER_REPOS - owner_repos)
+        require(not missing_owners, f"missing owner repos: {missing_owners}")
+
+        tracking_refs: set[str] = set()
+        for lane in lanes:
+            require(isinstance(lane, dict), "lane must be mapping")
+            require(isinstance(lane.get("tracking_refs"), list) and lane["tracking_refs"], f"lane {lane.get('id')} tracking_refs required")
+            tracking_refs.update(lane["tracking_refs"])
+            require(isinstance(lane.get("recognizes"), list) and lane["recognizes"], f"lane {lane.get('id')} recognizes required")
+            require(isinstance(lane.get("must_not"), list) and lane["must_not"], f"lane {lane.get('id')} must_not required")
+        missing_tracking = sorted(REQUIRED_TRACKING_REFS - tracking_refs)
+        require(not missing_tracking, f"missing tracking refs: {missing_tracking}")
+
+        mlops_lane = next(lane for lane in lanes if lane.get("id") == "mlops-runtime-execution")
+        recognizes = "\n".join(str(item) for item in mlops_lane["recognizes"])
+        require("RayJobDryRunPlan -> runtime-asset:prophet-ray-ml:0.1.0" in recognizes, "MLOps lane must bind Ray to Ray runtime")
+        require("BeamPipelineDryRunPlan -> runtime-asset:prophet-beam-dataops:0.1.0" in recognizes, "MLOps lane must bind Beam to Beam runtime")
+        require("collapse-ray-and-beam-onto-notebook-runtime" in mlops_lane["must_not"], "MLOps lane must forbid runtime collapse")
+
+        shell_lane = next(lane for lane in lanes if lane.get("id") == "cloudshell-runtime-routes")
+        shell_recognizes = "\n".join(str(item) for item in shell_lane["recognizes"])
+        require("/lattice runtime pick prophet-ray-ml" in shell_recognizes, "CloudShell lane missing Ray runtime route")
+        require("/lattice runtime pick prophet-beam-dataops" in shell_recognizes, "CloudShell lane missing Beam runtime route")
+        require("bypass-policy-fabric" in shell_lane["must_not"], "CloudShell lane must forbid Policy Fabric bypass")
+        require("bypass-agentplane" in shell_lane["must_not"], "CloudShell lane must forbid AgentPlane bypass")
+
+        policy_lane = next(lane for lane in lanes if lane.get("id") == "policy-runtime-gates")
+        require("RuntimeProfileBinding" in policy_lane["recognizes"], "Policy lane must recognize RuntimeProfileBinding")
+        require("create-parallel-metadata-spine" in policy_lane["must_not"], "Policy lane must forbid parallel metadata spine")
+
+        validation = data.get("validation_requirements")
+        require(isinstance(validation, dict), "validation_requirements must be mapping")
+        validation_refs = set(as_list(validation.get("required_tracking_refs"), "validation_requirements.required_tracking_refs"))
+        missing_validation_refs = sorted(REQUIRED_TRACKING_REFS - validation_refs)
+        require(not missing_validation_refs, f"validation refs missing: {missing_validation_refs}")
+        validation_owners = set(as_list(validation.get("required_owner_repos"), "validation_requirements.required_owner_repos"))
+        missing_validation_owners = sorted(REQUIRED_OWNER_REPOS - validation_owners)
+        require(not missing_validation_owners, f"validation owners missing: {missing_validation_owners}")
+        for key in [
+            "require_runtime_profile_binding_before_agent_execution",
+            "require_policy_before_runtime_launch",
+            "require_runtime_profile_topics_before_newhope_membrane",
+            "require_runtime_profile_index_before_shell_discovery",
+            "forbid_runtime_schema_redefinition_outside_lattice_forge",
+            "forbid_policy_bypass",
+        ]:
+            require(validation.get(key) is True, f"{key} must be true")
+    except Exception as exc:  # noqa: BLE001
+        return fail(str(exc))
+    print("OK: validated Lattice runtime profile consumer parity registration")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Registers the final Lattice runtime-profile consumer parity wave in SocioSphere.

## Adds

- `registry/lattice-runtime-profile-consumer-parity.yaml`
- `tools/validate_lattice_runtime_profile_consumer_parity.py`
- Makefile validation hook

## Coverage

Registers runtime-profile recognition across:

- Lattice Forge runtime artifacts
- Prophet Platform runtime bindings
- MLOps Ray/Beam execution
- AgentPlane execution consumer
- Sherlock Search indexing
- Slash Topics classification
- New Hope membrane decisions
- Policy Fabric runtime gates
- CloudShell/Fog Shell Developer Home routes
- SocioSphere topology governance

## Validation

Expected:

```bash
make validate
```

## Tracking

Advances SocioProphet/prophet-platform#291 and follows the final runtime-profile consumer parity wave.