### PR TITLE
Register Lattice runtime promotion policy closure

### DIFF
--- a/registry/lattice-runtime-profile-consumer-parity.yaml
+++ b/registry/lattice-runtime-profile-consumer-parity.yaml
@@ -1,4 +1,4 @@
-version: "0.2.0"
+version: "0.3.0"
 updated_at: "2026-05-01"
 kind: LatticeRuntimeProfileConsumerParityRegistration
 
@@ -7,7 +7,7 @@ umbrella:
   issue: 291
   parent_registry: registry/lattice-data-governai-lanes.yaml
   parent_registry_version: "0.3.0"
-  purpose: "Registers runtime-profile consumer parity and promotion-evidence gates for notebook, Ray, and Beam RuntimeAsset recognition across runtime, platform, execution, search, topic, membrane, policy, shell, and topology consumers."
+  purpose: "Registers runtime-profile consumer parity, promotion-evidence gates, and RuntimePromotionManifest policy decisions for notebook, Ray, and Beam RuntimeAsset recognition across runtime, platform, execution, search, topic, membrane, policy, shell, and topology consumers."
 
 runtime_profile_refs:
   notebook_runtime_ref: runtime-asset:prophet-python-ml:0.1.0
@@ -152,6 +152,7 @@ consumer_parity_wave:
     owner_repo: SocioProphet/policy-fabric
     tracking_refs:
       - SocioProphet/policy-fabric#41
+      - SocioProphet/policy-fabric#42
     role: policy-gate-owner
     recognizes:
       - RuntimeAsset
@@ -160,9 +161,12 @@ consumer_parity_wave:
       - RayRuntimeProfile
       - BeamRuntimeProfile
       - RuntimePromotionManifest
+      - dev-runtime-promotion-allow-decisions
+      - stable-runtime-promotion-deny-review-decisions
     must_not:
       - create-parallel-metadata-spine
       - bypass-policy-fabric
+      - allow-stable-promotion-with-generated-evidence-only
 
   - id: cloudshell-runtime-routes
     owner_repo: SocioProphet/cloudshell-fog
@@ -185,10 +189,12 @@ consumer_parity_wave:
     owner_repo: SocioProphet/sociosphere
     tracking_refs:
       - SocioProphet/sociosphere#240
+      - SocioProphet/sociosphere#242
     role: topology-governor
     recognizes:
       - all-runtime-profile-consumer-parity-records
       - RuntimePromotionManifest topology closure
+      - RuntimePromotionManifest policy closure
     must_not:
       - implement-downstream-features
 
@@ -203,8 +209,10 @@ validation_requirements:
     - SocioProphet/slash-topics#25
     - SocioProphet/new-hope#9
     - SocioProphet/policy-fabric#41
+    - SocioProphet/policy-fabric#42
     - SocioProphet/cloudshell-fog#31
     - SocioProphet/sociosphere#240
+    - SocioProphet/sociosphere#242
   required_owner_repos:
     - SocioProphet/lattice-forge
     - SocioProphet/prophet-platform
@@ -221,6 +229,7 @@ validation_requirements:
   require_runtime_profile_topics_before_newhope_membrane: true
   require_runtime_profile_index_before_shell_discovery: true
   require_promotion_manifest_before_runtime_promotion_decision: true
+  require_runtime_promotion_policy_after_manifest: true
   require_external_evidence_before_stable_promotion: true
   forbid_runtime_schema_redefinition_outside_lattice_forge: true
   forbid_policy_bypass: true

--- a/tools/validate_lattice_runtime_profile_consumer_parity.py
+++ b/tools/validate_lattice_runtime_profile_consumer_parity.py
@@ -41,8 +41,10 @@ REQUIRED_TRACKING_REFS = {
     "SocioProphet/slash-topics#25",
     "SocioProphet/new-hope#9",
     "SocioProphet/policy-fabric#41",
+    "SocioProphet/policy-fabric#42",
     "SocioProphet/cloudshell-fog#31",
     "SocioProphet/sociosphere#240",
+    "SocioProphet/sociosphere#242",
 }
 REQUIRED_LANES = {
     "runtime-artifacts",
@@ -111,7 +113,7 @@ def main() -> int:
         data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
         require(isinstance(data, dict), "registry must be mapping")
         require(data.get("kind") == "LatticeRuntimeProfileConsumerParityRegistration", "kind mismatch")
-        require(data.get("version") == "0.2.0", "version must be 0.2.0 after promotion gate registration")
+        require(data.get("version") == "0.3.0", "version must be 0.3.0 after policy promotion registration")
 
         umbrella = data.get("umbrella")
         require(isinstance(umbrella, dict), "umbrella must be mapping")
@@ -181,9 +183,17 @@ def main() -> int:
         require("bypass-agentplane" in shell_lane["must_not"], "CloudShell lane must forbid AgentPlane bypass")
 
         policy_lane = next(lane for lane in lanes if lane.get("id") == "policy-runtime-gates")
-        require("RuntimeProfileBinding" in policy_lane["recognizes"], "Policy lane must recognize RuntimeProfileBinding")
-        require("RuntimePromotionManifest" in policy_lane["recognizes"], "Policy lane must recognize RuntimePromotionManifest")
+        require("SocioProphet/policy-fabric#42" in policy_lane["tracking_refs"], "Policy lane must include policy-fabric#42")
+        policy_recognizes = "\n".join(str(item) for item in policy_lane["recognizes"])
+        require("RuntimeProfileBinding" in policy_recognizes, "Policy lane must recognize RuntimeProfileBinding")
+        require("RuntimePromotionManifest" in policy_recognizes, "Policy lane must recognize RuntimePromotionManifest")
+        require("dev-runtime-promotion-allow-decisions" in policy_recognizes, "Policy lane must recognize dev runtime promotion decisions")
+        require("stable-runtime-promotion-deny-review-decisions" in policy_recognizes, "Policy lane must recognize stable deny/review decisions")
         require("create-parallel-metadata-spine" in policy_lane["must_not"], "Policy lane must forbid parallel metadata spine")
+        require("allow-stable-promotion-with-generated-evidence-only" in policy_lane["must_not"], "Policy lane must forbid stable promotion with generated evidence only")
+
+        topology_lane = next(lane for lane in lanes if lane.get("id") == "topology-consumer-parity")
+        require("SocioProphet/sociosphere#242" in topology_lane["tracking_refs"], "Topology lane must include sociosphere#242")
 
         validation = data.get("validation_requirements")
         require(isinstance(validation, dict), "validation_requirements must be mapping")
@@ -199,6 +209,7 @@ def main() -> int:
             "require_runtime_profile_topics_before_newhope_membrane",
             "require_runtime_profile_index_before_shell_discovery",
             "require_promotion_manifest_before_runtime_promotion_decision",
+            "require_runtime_promotion_policy_after_manifest",
             "require_external_evidence_before_stable_promotion",
             "forbid_runtime_schema_redefinition_outside_lattice_forge",
             "forbid_policy_bypass",


### PR DESCRIPTION
## Summary

Registers `SocioProphet/policy-fabric#42` as the RuntimePromotionManifest-consuming policy closure in SocioSphere.

## Updates

- `registry/lattice-runtime-profile-consumer-parity.yaml`
- `tools/validate_lattice_runtime_profile_consumer_parity.py`

## Enforces

- Policy Fabric recognizes RuntimePromotionManifest as a promotion decision input.
- Dev runtime promotion allow decisions are tracked.
- Stable runtime promotion deny/review decisions are tracked.
- Stable runtime promotion with generated evidence only remains forbidden.

## Validation

Expected:

```bash
make validate
```

## Tracking

Advances SocioProphet/prophet-platform#291 and follows SocioProphet/policy-fabric#42.