### PR TITLE
Register Lattice replayable MLOps evidence contracts

### DIFF
--- a/registry/lattice-demo-readiness.yaml
+++ b/registry/lattice-demo-readiness.yaml
@@ -1,4 +1,4 @@
-version: "0.2.0"
+version: "0.3.0"
 updated_at: "2026-05-02"
 kind: LatticeDemoReadinessRegistration
 
@@ -7,10 +7,11 @@ umbrella:
   issue: 291
   readiness_pr: SocioProphet/prophet-platform#307
   command_bundle_pr: SocioProphet/cloudshell-fog#32
+  mlops_replay_evidence_pr: SocioProphet/prophet-platform-fabric-mlops-ts-suite#35
   parent_registries:
     - registry/lattice-data-governai-lanes.yaml
     - registry/lattice-runtime-profile-consumer-parity.yaml
-  purpose: "Registers the end-to-end Lattice Studio/Data/GovernAI demo readiness report and executable Fog Shell command bundle across product, runtime, execution, search, topic, membrane, policy, shell, and topology surfaces."
+  purpose: "Registers the end-to-end Lattice Studio/Data/GovernAI demo readiness report, executable Fog Shell command bundle, and replayable Ray/Beam evidence contracts across product, runtime, execution, search, topic, membrane, policy, shell, and topology surfaces."
 
 readiness_report:
   kind: LatticeDemoReadinessReport
@@ -36,12 +37,42 @@ command_bundle:
     secrets: none
     host_mutation: false
 
+mlops_replay_evidence:
+  kind: ReplayEvidenceBundle
+  producer_repo: SocioProphet/prophet-platform-fabric-mlops-ts-suite
+  tracking_ref: SocioProphet/prophet-platform-fabric-mlops-ts-suite#35
+  bundle_ref: urn:srcos:evidence-bundle:lattice-governed-execution-0001
+  required_artifacts:
+    - urn:srcos:artifact:community_truth_demo_ray_metrics
+    - urn:srcos:artifact:community_truth_demo_beam_quality
+    - urn:srcos:model:community_truth_demo_candidate
+  required_lineage_receipts:
+    - urn:srcos:lineage-receipt:ray-community-truth-demo-0001
+    - urn:srcos:lineage-receipt:beam-community-truth-demo-0001
+  required_metrics:
+    ray:
+      - factuality_f1
+      - grounding_precision
+      - training_records
+    beam:
+      - quality_completeness
+      - annotation_coverage
+      - duplicate_rate
+  replay_commands:
+    - /lattice mlops ray run community_truth_demo --runtime prophet-ray-ml --dry-run
+    - /lattice dataops beam run community_truth_demo --runtime prophet-beam-dataops --dry-run
+  safety:
+    network: none
+    secrets: none
+    host_mutation: false
+
 required_estate_refs:
   schema: SourceOS-Linux/sourceos-spec#75
   runtime_profiles: SocioProphet/lattice-forge#11
   runtime_promotion_manifest: SocioProphet/lattice-forge#12
   runtime_profile_catalog: SocioProphet/prophet-platform#306
   mlops_runtime_execution: SocioProphet/prophet-platform-fabric-mlops-ts-suite#34
+  mlops_replay_evidence: SocioProphet/prophet-platform-fabric-mlops-ts-suite#35
   agentplane_runtime_refs: SocioProphet/agentplane#77
   sherlock_runtime_index: SocioProphet/sherlock-search#32
   slash_runtime_topics: SocioProphet/slash-topics#25
@@ -51,6 +82,7 @@ required_estate_refs:
   cloudshell_demo_command_bundle: SocioProphet/cloudshell-fog#32
   topology_runtime_promotion: SocioProphet/sociosphere#243
   topology_demo_readiness: SocioProphet/sociosphere#244
+  topology_demo_command_bundle: SocioProphet/sociosphere#245
 
 runtime_refs:
   notebook_runtime_ref: runtime-asset:prophet-python-ml:0.1.0
@@ -84,6 +116,7 @@ required_checks:
   - trust-reputation
   - policy-governance
   - developer-home
+  - replay-evidence-bundle
 
 shell_commands:
   - /lattice data search community_truth_demo
@@ -107,6 +140,7 @@ validation_requirements:
     - SocioProphet/lattice-forge#12
     - SocioProphet/prophet-platform#306
     - SocioProphet/prophet-platform-fabric-mlops-ts-suite#34
+    - SocioProphet/prophet-platform-fabric-mlops-ts-suite#35
     - SocioProphet/agentplane#77
     - SocioProphet/sherlock-search#32
     - SocioProphet/slash-topics#25
@@ -116,11 +150,15 @@ validation_requirements:
     - SocioProphet/cloudshell-fog#32
     - SocioProphet/sociosphere#243
     - SocioProphet/sociosphere#244
+    - SocioProphet/sociosphere#245
   require_all_demo_path_steps: true
   require_all_readiness_checks: true
   require_shell_command_surface: true
   require_executable_command_bundle: true
   require_ordered_demo_commands: true
+  require_replay_evidence_bundle: true
+  require_lineage_receipts: true
+  require_ray_and_beam_metric_expectations: true
   require_dev_runtime_promotion_allowed: true
   require_stable_runtime_promotion_blocked: true
   require_no_network_secrets_or_host_mutation: true

--- a/tools/validate_lattice_demo_readiness.py
+++ b/tools/validate_lattice_demo_readiness.py
@@ -20,6 +20,7 @@ REQUIRED_REFS = {
     "SocioProphet/lattice-forge#12",
     "SocioProphet/prophet-platform#306",
     "SocioProphet/prophet-platform-fabric-mlops-ts-suite#34",
+    "SocioProphet/prophet-platform-fabric-mlops-ts-suite#35",
     "SocioProphet/agentplane#77",
     "SocioProphet/sherlock-search#32",
     "SocioProphet/slash-topics#25",
@@ -29,6 +30,7 @@ REQUIRED_REFS = {
     "SocioProphet/cloudshell-fog#32",
     "SocioProphet/sociosphere#243",
     "SocioProphet/sociosphere#244",
+    "SocioProphet/sociosphere#245",
 }
 REQUIRED_DEMO_PATH = [
     "catalog-search",
@@ -55,6 +57,7 @@ REQUIRED_CHECKS = {
     "trust-reputation",
     "policy-governance",
     "developer-home",
+    "replay-evidence-bundle",
 }
 REQUIRED_RUNTIME_REFS = {
     "notebook_runtime_ref": "runtime-asset:prophet-python-ml:0.1.0",
@@ -77,6 +80,17 @@ REQUIRED_COMMANDS = [
     "/lattice publication inspect urn:srcos:publication-artifact:community_truth_demo_report",
     "/lattice publication export urn:srcos:publication-artifact:community_truth_demo_report",
 ]
+REQUIRED_ARTIFACTS = {
+    "urn:srcos:artifact:community_truth_demo_ray_metrics",
+    "urn:srcos:artifact:community_truth_demo_beam_quality",
+    "urn:srcos:model:community_truth_demo_candidate",
+}
+REQUIRED_RECEIPTS = {
+    "urn:srcos:lineage-receipt:ray-community-truth-demo-0001",
+    "urn:srcos:lineage-receipt:beam-community-truth-demo-0001",
+}
+REQUIRED_RAY_METRICS = {"factuality_f1", "grounding_precision", "training_records"}
+REQUIRED_BEAM_METRICS = {"quality_completeness", "annotation_coverage", "duplicate_rate"}
 
 
 def fail(message: str) -> int:
@@ -104,13 +118,14 @@ def main() -> int:
         data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
         require(isinstance(data, dict), "registry must be mapping")
         require(data.get("kind") == "LatticeDemoReadinessRegistration", "kind mismatch")
-        require(data.get("version") == "0.2.0", "version mismatch")
+        require(data.get("version") == "0.3.0", "version mismatch")
         umbrella = data.get("umbrella")
         require(isinstance(umbrella, dict), "umbrella must be mapping")
         require(umbrella.get("repo") == "SocioProphet/prophet-platform", "umbrella.repo mismatch")
         require(umbrella.get("issue") == 291, "umbrella.issue mismatch")
         require(umbrella.get("readiness_pr") == "SocioProphet/prophet-platform#307", "readiness PR mismatch")
         require(umbrella.get("command_bundle_pr") == "SocioProphet/cloudshell-fog#32", "command bundle PR mismatch")
+        require(umbrella.get("mlops_replay_evidence_pr") == "SocioProphet/prophet-platform-fabric-mlops-ts-suite#35", "MLOps replay evidence PR mismatch")
 
         report = data.get("readiness_report")
         require(isinstance(report, dict), "readiness_report must be mapping")
@@ -127,16 +142,32 @@ def main() -> int:
 
         bundle = data.get("command_bundle")
         require(isinstance(bundle, dict), "command_bundle must be mapping")
-        require(bundle.get("kind") == "LatticeDemoCommandBundleFixture", "command bundle kind mismatch")
-        require(bundle.get("producer_repo") == "SocioProphet/cloudshell-fog", "command bundle producer mismatch")
         require(bundle.get("tracking_ref") == "SocioProphet/cloudshell-fog#32", "command bundle tracking ref mismatch")
         require(bundle.get("expected_step_count") == 12, "command bundle expected_step_count must be 12")
-        require(bundle.get("execution_mode") == "dry-run", "command bundle execution_mode must be dry-run")
-        bundle_safety = bundle.get("safety")
-        require(isinstance(bundle_safety, dict), "command bundle safety must be mapping")
-        require(bundle_safety.get("network") == "none", "bundle network must be none")
-        require(bundle_safety.get("secrets") == "none", "bundle secrets must be none")
-        require(bundle_safety.get("host_mutation") is False, "bundle host_mutation must be false")
+
+        replay = data.get("mlops_replay_evidence")
+        require(isinstance(replay, dict), "mlops_replay_evidence must be mapping")
+        require(replay.get("kind") == "ReplayEvidenceBundle", "replay evidence kind mismatch")
+        require(replay.get("tracking_ref") == "SocioProphet/prophet-platform-fabric-mlops-ts-suite#35", "replay evidence tracking ref mismatch")
+        require(replay.get("bundle_ref") == "urn:srcos:evidence-bundle:lattice-governed-execution-0001", "replay bundle ref mismatch")
+        missing_artifacts = sorted(REQUIRED_ARTIFACTS - set(as_list(replay.get("required_artifacts"), "mlops_replay_evidence.required_artifacts")))
+        require(not missing_artifacts, f"missing replay artifacts: {missing_artifacts}")
+        missing_receipts = sorted(REQUIRED_RECEIPTS - set(as_list(replay.get("required_lineage_receipts"), "mlops_replay_evidence.required_lineage_receipts")))
+        require(not missing_receipts, f"missing lineage receipts: {missing_receipts}")
+        metrics = replay.get("required_metrics")
+        require(isinstance(metrics, dict), "required_metrics must be mapping")
+        missing_ray = sorted(REQUIRED_RAY_METRICS - set(as_list(metrics.get("ray"), "required_metrics.ray")))
+        missing_beam = sorted(REQUIRED_BEAM_METRICS - set(as_list(metrics.get("beam"), "required_metrics.beam")))
+        require(not missing_ray, f"missing Ray metrics: {missing_ray}")
+        require(not missing_beam, f"missing Beam metrics: {missing_beam}")
+        replay_commands = set(as_list(replay.get("replay_commands"), "mlops_replay_evidence.replay_commands"))
+        require("/lattice mlops ray run community_truth_demo --runtime prophet-ray-ml --dry-run" in replay_commands, "missing Ray replay command")
+        require("/lattice dataops beam run community_truth_demo --runtime prophet-beam-dataops --dry-run" in replay_commands, "missing Beam replay command")
+        replay_safety = replay.get("safety")
+        require(isinstance(replay_safety, dict), "replay safety must be mapping")
+        require(replay_safety.get("network") == "none", "replay network must be none")
+        require(replay_safety.get("secrets") == "none", "replay secrets must be none")
+        require(replay_safety.get("host_mutation") is False, "replay host_mutation must be false")
 
         refs = data.get("required_estate_refs")
         require(isinstance(refs, dict), "required_estate_refs must be mapping")
@@ -168,6 +199,9 @@ def main() -> int:
             "require_shell_command_surface",
             "require_executable_command_bundle",
             "require_ordered_demo_commands",
+            "require_replay_evidence_bundle",
+            "require_lineage_receipts",
+            "require_ray_and_beam_metric_expectations",
             "require_dev_runtime_promotion_allowed",
             "require_stable_runtime_promotion_blocked",
             "require_no_network_secrets_or_host_mutation",


### PR DESCRIPTION
## Summary

Registers `SocioProphet/prophet-platform-fabric-mlops-ts-suite#35` as the replayable Ray/Beam evidence contract closure for the Lattice Studio/Data/GovernAI demo path.

## Updates

- `registry/lattice-demo-readiness.yaml`
- `tools/validate_lattice_demo_readiness.py`

## Enforces

- ReplayEvidenceBundle is present.
- Ray and Beam lineage receipts are present.
- Ray and Beam metric expectations are present.
- Expected artifacts include Ray metrics, Beam quality, and model candidate outputs.
- Replay commands remain dry-run and mapped to the executable demo command bundle.
- No network, secrets, or host mutation.

## Validation

Expected:

```bash
make validate
```

## Tracking

Follows SocioProphet/prophet-platform-fabric-mlops-ts-suite#35 and advances SocioProphet/prophet-platform#291.