### PR TITLE
Register Lattice replay evidence membrane closure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ ui-dev: ui-preflight
 # --- end ui-workbench targets ---
 
 # --- standards validation targets ---
-.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate
+.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate
 
-validate: validate-standards program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate
+validate: validate-standards program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate
 	@echo "OK: validate"
 
 validate-standards:
@@ -48,6 +48,10 @@ lattice-runtime-profile-consumer-parity-validate:
 lattice-demo-readiness-validate:
 	python3 -m pip install --user pyyaml >/dev/null
 	python3 tools/validate_lattice_demo_readiness.py
+
+lattice-replay-evidence-membrane-validate:
+	python3 -m pip install --user pyyaml >/dev/null
+	python3 tools/validate_lattice_replay_evidence_membrane_registration.py
 
 multidomain-geospatial-standards-compliance-validate:
 	python3 tools/check_multidomain_geospatial_standards_compliance.py

--- a/registry/lattice-replay-evidence-membrane.yaml
+++ b/registry/lattice-replay-evidence-membrane.yaml
@@ -1,0 +1,45 @@
+version: "0.1.0"
+updated_at: "2026-05-02"
+kind: LatticeReplayEvidenceMembraneRegistration
+
+umbrella:
+  repo: SocioProphet/prophet-platform
+  issue: 291
+  parent_registry: registry/lattice-demo-readiness.yaml
+  purpose: "Registers New Hope semantic membrane admission for the Lattice ReplayEvidenceBundle."
+
+refs:
+  mlops_replay_evidence: SocioProphet/prophet-platform-fabric-mlops-ts-suite#35
+  sherlock_replay_evidence_index: SocioProphet/sherlock-search#33
+  slash_replay_evidence_topics: SocioProphet/slash-topics#26
+  newhope_replay_evidence_membrane: SocioProphet/new-hope#10
+  demo_readiness_topology: SocioProphet/sociosphere#247
+
+asset:
+  replay_evidence_bundle_ref: urn:srcos:evidence-bundle:lattice-governed-execution-0001
+  topic_ref: slash-topic://lattice/data-governai/replay-evidence
+  runtime_refs:
+    - runtime-asset:prophet-ray-ml:0.1.0
+    - runtime-asset:prophet-beam-dataops:0.1.0
+  artifact_refs:
+    - urn:srcos:artifact:community_truth_demo_ray_metrics
+    - urn:srcos:artifact:community_truth_demo_beam_quality
+    - urn:srcos:model:community_truth_demo_candidate
+  lineage_receipt_refs:
+    - urn:srcos:lineage-receipt:ray-community-truth-demo-0001
+    - urn:srcos:lineage-receipt:beam-community-truth-demo-0001
+  replay_command_refs:
+    - /lattice mlops ray run community_truth_demo --runtime prophet-ray-ml --dry-run
+    - /lattice dataops beam run community_truth_demo --runtime prophet-beam-dataops --dry-run
+
+membrane_decisions:
+  demo_review: allow
+  promotion_review: require-review
+
+validation_requirements:
+  require_replay_evidence_search_index: true
+  require_replay_evidence_topic_governance: true
+  require_replay_evidence_membrane: true
+  require_policy_fabric_decision_before_authoritative_use: true
+  require_no_network_secrets_or_host_mutation: true
+  forbid_runtime_ref_rewrite: true

--- a/tools/validate_lattice_replay_evidence_membrane_registration.py
+++ b/tools/validate_lattice_replay_evidence_membrane_registration.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "registry" / "lattice-replay-evidence-membrane.yaml"
+BUNDLE = "urn:srcos:evidence-bundle:lattice-governed-execution-0001"
+RAY = "runtime-asset:prophet-ray-ml:0.1.0"
+BEAM = "runtime-asset:prophet-beam-dataops:0.1.0"
+REQUIRED_REFS = {
+    "SocioProphet/prophet-platform-fabric-mlops-ts-suite#35",
+    "SocioProphet/sherlock-search#33",
+    "SocioProphet/slash-topics#26",
+    "SocioProphet/new-hope#10",
+    "SocioProphet/sociosphere#247",
+}
+REQUIRED_ARTIFACTS = {
+    "urn:srcos:artifact:community_truth_demo_ray_metrics",
+    "urn:srcos:artifact:community_truth_demo_beam_quality",
+    "urn:srcos:model:community_truth_demo_candidate",
+}
+REQUIRED_RECEIPTS = {
+    "urn:srcos:lineage-receipt:ray-community-truth-demo-0001",
+    "urn:srcos:lineage-receipt:beam-community-truth-demo-0001",
+}
+REQUIRED_COMMANDS = {
+    "/lattice mlops ray run community_truth_demo --runtime prophet-ray-ml --dry-run",
+    "/lattice dataops beam run community_truth_demo --runtime prophet-beam-dataops --dry-run",
+}
+
+
+def fail(message: str) -> int:
+    print(f"ERR: {message}", file=sys.stderr)
+    return 1
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def as_list(value: Any, field: str) -> list[Any]:
+    require(isinstance(value, list) and bool(value), f"{field} must be non-empty list")
+    return value
+
+
+def main() -> int:
+    if yaml is None:
+        return fail("PyYAML is required for replay evidence membrane registration validation")
+    if not REGISTRY.exists():
+        return fail(f"missing {REGISTRY}")
+    try:
+        data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+        require(isinstance(data, dict), "registry must be mapping")
+        require(data.get("kind") == "LatticeReplayEvidenceMembraneRegistration", "kind mismatch")
+        require(data.get("version") == "0.1.0", "version mismatch")
+        umbrella = data.get("umbrella")
+        require(isinstance(umbrella, dict), "umbrella must be mapping")
+        require(umbrella.get("repo") == "SocioProphet/prophet-platform", "umbrella.repo mismatch")
+        require(umbrella.get("issue") == 291, "umbrella.issue mismatch")
+        require(umbrella.get("parent_registry") == "registry/lattice-demo-readiness.yaml", "parent registry mismatch")
+
+        refs = data.get("refs")
+        require(isinstance(refs, dict), "refs must be mapping")
+        actual_refs = set(refs.values())
+        missing_refs = sorted(REQUIRED_REFS - actual_refs)
+        require(not missing_refs, f"missing refs: {missing_refs}")
+
+        asset = data.get("asset")
+        require(isinstance(asset, dict), "asset must be mapping")
+        require(asset.get("replay_evidence_bundle_ref") == BUNDLE, "bundle ref mismatch")
+        require(asset.get("topic_ref") == "slash-topic://lattice/data-governai/replay-evidence", "topic ref mismatch")
+        require(set(as_list(asset.get("runtime_refs"), "asset.runtime_refs")) == {RAY, BEAM}, "runtime refs mismatch")
+        require(REQUIRED_ARTIFACTS <= set(as_list(asset.get("artifact_refs"), "asset.artifact_refs")), "artifact refs incomplete")
+        require(REQUIRED_RECEIPTS <= set(as_list(asset.get("lineage_receipt_refs"), "asset.lineage_receipt_refs")), "lineage receipts incomplete")
+        require(REQUIRED_COMMANDS <= set(as_list(asset.get("replay_command_refs"), "asset.replay_command_refs")), "replay commands incomplete")
+
+        decisions = data.get("membrane_decisions")
+        require(isinstance(decisions, dict), "membrane_decisions must be mapping")
+        require(decisions.get("demo_review") == "allow", "demo_review decision mismatch")
+        require(decisions.get("promotion_review") == "require-review", "promotion_review decision mismatch")
+
+        validation = data.get("validation_requirements")
+        require(isinstance(validation, dict), "validation_requirements must be mapping")
+        for key in [
+            "require_replay_evidence_search_index",
+            "require_replay_evidence_topic_governance",
+            "require_replay_evidence_membrane",
+            "require_policy_fabric_decision_before_authoritative_use",
+            "require_no_network_secrets_or_host_mutation",
+            "forbid_runtime_ref_rewrite",
+        ]:
+            require(validation.get(key) is True, f"{key} must be true")
+    except Exception as exc:  # noqa: BLE001
+        return fail(str(exc))
+    print("OK: validated Lattice replay evidence membrane registration")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Registers `SocioProphet/new-hope#10` as the semantic membrane closure for Lattice ReplayEvidenceBundle use.

## Adds

- `registry/lattice-replay-evidence-membrane.yaml`
- `tools/validate_lattice_replay_evidence_membrane_registration.py`
- Makefile validation hook

## Enforces

- replay evidence is indexed by Sherlock
- replay evidence is classified by Slash Topics
- replay evidence has New Hope membrane admission
- demo review is allowed
- promotion use requires review
- Policy Fabric remains required before authoritative use
- no network, secrets, host mutation, or runtime-ref rewrite

## Validation

Expected:

```bash
make validate
```

## Tracking

Follows SocioProphet/new-hope#10 and advances SocioProphet/prophet-platform#291.