### PR TITLE
Register Lattice product readiness program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ ui-dev: ui-preflight
 # --- end ui-workbench targets ---
 
 # --- standards validation targets ---
-.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate
+.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate
 
-validate: validate-standards program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate
+validate: validate-standards program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate
 	@echo "OK: validate"
 
 validate-standards:
@@ -56,6 +56,10 @@ lattice-replay-evidence-membrane-validate:
 lattice-runtime-release-readiness-validate:
 	python3 -m pip install --user pyyaml >/dev/null
 	python3 tools/validate_lattice_runtime_release_readiness.py
+
+lattice-product-readiness-program-validate:
+	python3 -m pip install --user pyyaml >/dev/null
+	python3 tools/validate_lattice_product_readiness_program.py
 
 multidomain-geospatial-standards-compliance-validate:
 	python3 tools/check_multidomain_geospatial_standards_compliance.py

--- a/registry/lattice-product-readiness-program.yaml
+++ b/registry/lattice-product-readiness-program.yaml
@@ -1,0 +1,208 @@
+version: "0.1.0"
+updated_at: "2026-05-02"
+kind: LatticeProductReadinessProgramRegistration
+
+umbrella:
+  repo: SocioProphet/prophet-platform
+  issue: 291
+  parent_registries:
+    - registry/lattice-data-governai-lanes.yaml
+    - registry/lattice-demo-readiness.yaml
+    - registry/lattice-runtime-release-readiness.yaml
+  purpose: "Registers the next-phase Lattice Studio/Data/GovernAI product readiness program across operating model, product surface, enterprise governance, execution, programmable access, and market proof."
+
+turn_budget:
+  estimate_total_turns: "45-65"
+  phase_0_and_a_turns: "10-14"
+  assumptions:
+    - one_or_more_ci_gated_prs_per_turn
+    - no_large_unplanned_repo_migration
+    - live_infrastructure_contracts_before_live_infrastructure_rollout
+    - topology_registration_after_each_major_lane
+
+work_orders:
+  - id: work-order-0
+    name: operating-model-security-deployment-baseline
+    priority: 0
+    status: approved-for-execution
+    objective: "Define deployable operating model, environment lifecycle, security baseline, release and rollback posture, and observability baseline before broad live product rollout."
+    owner_repos:
+      - SocioProphet/sociosphere
+      - SocioProphet/policy-fabric
+      - SocioProphet/agentplane
+      - SocioProphet/cloudshell-fog
+      - SocioProphet/prophet-platform
+      - SourceOS-Linux/sourceos-spec
+    required_lanes:
+      - product-operating-model
+      - deployment-topology
+      - security-isolation-threat-model
+      - observability-sre-control-loops
+      - release-rollback-control
+    acceptance_gates:
+      - environments-defined
+      - tenant-sandbox-defined
+      - release-candidate-flow-defined
+      - rollback-flow-defined
+      - security-baseline-defined
+      - observability-baseline-defined
+      - topology-registered
+      - ci-validated
+
+  - id: work-order-a
+    name: product-surface-and-notebook-execution
+    priority: 1
+    status: approved-for-execution
+    objective: "Make Lattice Studio visible and touchable through hosted product surfaces and governed notebook execution."
+    owner_repos:
+      - SocioProphet/prophet-platform
+      - SocioProphet/cloudshell-fog
+      - SocioProphet/lattice-forge
+      - SocioProphet/agentplane
+      - SocioProphet/sociosphere
+    required_lanes:
+      - hosted-product-surface
+      - jupyterhub-jupyterlab-deployment-contract
+      - runtime-selector-ux
+      - command-launcher-surface
+      - notebook-session-receipts
+    acceptance_gates:
+      - product-shell-renders
+      - runtime-cards-visible
+      - notebook-launch-contract-present
+      - notebook-session-receipt-present
+      - policy-gated-launch
+      - agentplane-execution-routing
+      - ci-validated
+
+  - id: work-order-b
+    name: enterprise-governance-and-catalog
+    priority: 2
+    status: planned
+    objective: "Add tenant, workspace, RBAC, catalog ingestion, connector certification, and privacy/legal data governance controls."
+    owner_repos:
+      - SourceOS-Linux/sourceos-spec
+      - SocioProphet/prophet-platform
+      - SocioProphet/policy-fabric
+      - SocioProphet/sherlock-search
+      - SocioProphet/slash-topics
+      - SocioProphet/new-hope
+      - SocioProphet/sociosphere
+    required_lanes:
+      - tenant-workspace-rbac
+      - production-catalog-ingestion
+      - connector-registry-certification
+      - privacy-legal-controls
+      - ckan-compatible-metadata
+    acceptance_gates:
+      - tenant-workspace-schema-present
+      - rbac-policy-subjects-present
+      - catalog-ingestion-contract-present
+      - connector-health-receipts-present
+      - pii-license-retention-controls-present
+      - ci-validated
+
+  - id: work-order-c
+    name: runtime-mlops-and-production-execution
+    priority: 3
+    status: planned
+    objective: "Move from fixture-level execution to controlled live Ray/Beam execution, runtime release authority, model lifecycle, and endpoint lifecycle."
+    owner_repos:
+      - SocioProphet/lattice-forge
+      - SocioProphet/agentplane
+      - SocioProphet/prophet-platform-fabric-mlops-ts-suite
+      - SocioProphet/prophet-platform
+      - SocioProphet/policy-fabric
+      - SocioProphet/sociosphere
+    required_lanes:
+      - provider-backed-runtime-release-authority
+      - live-ray-execution-contract
+      - live-beam-execution-contract
+      - model-candidate-lifecycle
+      - endpoint-lifecycle
+      - quota-and-cost-controls
+    acceptance_gates:
+      - live-execution-contracts-present
+      - job-status-receipts-present
+      - rollback-kill-switch-present
+      - quota-policy-present
+      - artifact-retention-policy-present
+      - ci-validated
+
+  - id: work-order-d
+    name: api-sdk-cli-chatops
+    priority: 4
+    status: planned
+    objective: "Expose Lattice Studio through stable programmable interfaces beyond UI and shell fixtures."
+    owner_repos:
+      - SocioProphet/prophet-platform
+      - SocioProphet/cloudshell-fog
+      - SocioProphet/agentplane
+      - SocioProphet/sociosphere
+    required_lanes:
+      - openapi-contract
+      - python-sdk-contract
+      - cli-command-contract
+      - matrix-chatops-contract
+      - webhook-event-surface
+    acceptance_gates:
+      - api-contract-present
+      - sdk-fixture-present
+      - cli-contract-present
+      - chatops-contract-present
+      - event-contract-present
+      - ci-validated
+
+  - id: work-order-e
+    name: market-readiness-and-proof
+    priority: 5
+    status: planned
+    objective: "Make the product externally legible, evaluable, benchmarkable, and fundable."
+    owner_repos:
+      - SocioProphet/prophet-platform
+      - SocioProphet/sociosphere
+      - mdheller/socioprophet-web
+    required_lanes:
+      - product-documentation
+      - evaluator-sandbox
+      - executable-benchmark-harness
+      - competitor-proof-matrix
+      - pricing-sku-support-model
+    acceptance_gates:
+      - product-brief-present
+      - demo-script-present
+      - evaluator-guide-present
+      - benchmark-harness-contract-present
+      - claim-confidence-matrix-present
+      - ci-validated
+
+execution_rules:
+  next_approved_scope:
+    - work-order-0
+    - work-order-a
+  topology_registration_required_after_each_lane: true
+  ci_required_before_merge: true
+  fixture_before_live_infrastructure: true
+  no_parallel_metadata_spines: true
+  policy_fabric_required_for_authoritative_actions: true
+  agentplane_required_for_execution: true
+  slash_topics_public_surface: true
+  new_hope_semantic_membrane: true
+
+validation_requirements:
+  required_work_orders:
+    - work-order-0
+    - work-order-a
+    - work-order-b
+    - work-order-c
+    - work-order-d
+    - work-order-e
+  required_next_scope:
+    - work-order-0
+    - work-order-a
+  require_turn_budget: true
+  require_acceptance_gates: true
+  require_owner_repos: true
+  require_topology_registration: true
+  require_ci_before_merge: true
+  forbid_live_execution_without_policy_and_agentplane: true

--- a/tools/validate_lattice_product_readiness_program.py
+++ b/tools/validate_lattice_product_readiness_program.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "registry" / "lattice-product-readiness-program.yaml"
+REQUIRED_WORK_ORDERS = {
+    "work-order-0",
+    "work-order-a",
+    "work-order-b",
+    "work-order-c",
+    "work-order-d",
+    "work-order-e",
+}
+REQUIRED_NEXT_SCOPE = {"work-order-0", "work-order-a"}
+REQUIRED_PARENT_REGISTRIES = {
+    "registry/lattice-data-governai-lanes.yaml",
+    "registry/lattice-demo-readiness.yaml",
+    "registry/lattice-runtime-release-readiness.yaml",
+}
+
+
+def fail(message: str) -> int:
+    print(f"ERR: {message}", file=sys.stderr)
+    return 1
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def as_list(value: Any, field: str) -> list[Any]:
+    require(isinstance(value, list) and value, f"{field} must be non-empty list")
+    return value
+
+
+def main() -> int:
+    if yaml is None:
+        return fail("PyYAML is required for product readiness validation")
+    if not REGISTRY.exists():
+        return fail(f"missing {REGISTRY}")
+    try:
+        data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+        require(isinstance(data, dict), "registry must be mapping")
+        require(data.get("kind") == "LatticeProductReadinessProgramRegistration", "kind mismatch")
+        require(data.get("version") == "0.1.0", "version mismatch")
+        umbrella = data.get("umbrella")
+        require(isinstance(umbrella, dict), "umbrella must be mapping")
+        require(umbrella.get("repo") == "SocioProphet/prophet-platform", "umbrella.repo mismatch")
+        require(umbrella.get("issue") == 291, "umbrella.issue mismatch")
+        parents = set(as_list(umbrella.get("parent_registries"), "umbrella.parent_registries"))
+        require(REQUIRED_PARENT_REGISTRIES <= parents, "parent registries incomplete")
+
+        budget = data.get("turn_budget")
+        require(isinstance(budget, dict), "turn_budget must be mapping")
+        require(budget.get("estimate_total_turns") == "45-65", "total turn estimate mismatch")
+        require(budget.get("phase_0_and_a_turns") == "10-14", "phase turn estimate mismatch")
+        as_list(budget.get("assumptions"), "turn_budget.assumptions")
+
+        work_orders = as_list(data.get("work_orders"), "work_orders")
+        ids = {item.get("id") for item in work_orders if isinstance(item, dict)}
+        require(ids == REQUIRED_WORK_ORDERS, f"work order ids mismatch: {ids}")
+        for item in work_orders:
+            require(isinstance(item, dict), "work order must be mapping")
+            require(isinstance(item.get("priority"), int), f"{item.get('id')}: priority must be int")
+            require(item.get("status") in {"approved-for-execution", "planned"}, f"{item.get('id')}: invalid status")
+            as_list(item.get("owner_repos"), f"{item.get('id')}.owner_repos")
+            as_list(item.get("required_lanes"), f"{item.get('id')}.required_lanes")
+            as_list(item.get("acceptance_gates"), f"{item.get('id')}.acceptance_gates")
+
+        approved = {item["id"] for item in work_orders if item.get("status") == "approved-for-execution"}
+        require(approved == REQUIRED_NEXT_SCOPE, f"approved scope mismatch: {approved}")
+
+        rules = data.get("execution_rules")
+        require(isinstance(rules, dict), "execution_rules must be mapping")
+        require(set(as_list(rules.get("next_approved_scope"), "execution_rules.next_approved_scope")) == REQUIRED_NEXT_SCOPE, "next approved scope mismatch")
+        for key in [
+            "topology_registration_required_after_each_lane",
+            "ci_required_before_merge",
+            "fixture_before_live_infrastructure",
+            "no_parallel_metadata_spines",
+            "policy_fabric_required_for_authoritative_actions",
+            "agentplane_required_for_execution",
+            "slash_topics_public_surface",
+            "new_hope_semantic_membrane",
+        ]:
+            require(rules.get(key) is True, f"execution_rules.{key} must be true")
+
+        validation = data.get("validation_requirements")
+        require(isinstance(validation, dict), "validation_requirements must be mapping")
+        require(set(as_list(validation.get("required_work_orders"), "validation.required_work_orders")) == REQUIRED_WORK_ORDERS, "required work orders mismatch")
+        require(set(as_list(validation.get("required_next_scope"), "validation.required_next_scope")) == REQUIRED_NEXT_SCOPE, "required next scope mismatch")
+        for key in [
+            "require_turn_budget",
+            "require_acceptance_gates",
+            "require_owner_repos",
+            "require_topology_registration",
+            "require_ci_before_merge",
+            "forbid_live_execution_without_policy_and_agentplane",
+        ]:
+            require(validation.get(key) is True, f"validation.{key} must be true")
+    except Exception as exc:  # noqa: BLE001
+        return fail(str(exc))
+    print("OK: validated Lattice product readiness program")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Registers the next-phase Lattice Studio/Data/GovernAI product readiness program.

## Adds

- `registry/lattice-product-readiness-program.yaml`
- `tools/validate_lattice_product_readiness_program.py`
- Makefile validation hook

## Scope

Defines six work orders from operating model through market proof, with Work Order 0 and Work Order A approved for immediate execution.

## Turn budget

- Full program estimate: 45-65 turns
- Work Order 0 + A estimate: 10-14 turns

## Validation

Expected:

```bash
make validate
```

## Tracking

Advances SocioProphet/prophet-platform#291.