### PR TITLE
Register Lattice environment fingerprint schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ ui-dev: ui-preflight
 # --- end ui-workbench targets ---
 
 # --- standards validation targets ---
-.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate
+.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate
 
-validate: validate-standards program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate
+validate: validate-standards program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate
 	@echo "OK: validate"
 
 validate-standards:
@@ -80,6 +80,10 @@ lattice-observability-sre-validate:
 lattice-release-rollback-controls-validate:
 	python3 -m pip install --user pyyaml >/dev/null
 	python3 tools/validate_lattice_release_rollback_controls.py
+
+lattice-environment-fingerprints-validate:
+	python3 -m pip install --user pyyaml >/dev/null
+	python3 tools/validate_lattice_environment_fingerprints.py
 
 multidomain-geospatial-standards-compliance-validate:
 	python3 tools/check_multidomain_geospatial_standards_compliance.py

--- a/registry/lattice-environment-fingerprints.yaml
+++ b/registry/lattice-environment-fingerprints.yaml
@@ -1,0 +1,167 @@
+version: "0.1.0"
+updated_at: "2026-05-02"
+kind: LatticeEnvironmentFingerprintRegistration
+
+umbrella:
+  repo: SocioProphet/prophet-platform
+  issue: 291
+  product_program_ref: registry/lattice-product-readiness-program.yaml
+  operating_model_ref: registry/lattice-operating-model.yaml
+  deployment_topology_ref: registry/lattice-deployment-topology.yaml
+  security_isolation_ref: registry/lattice-security-isolation-model.yaml
+  release_rollback_controls_ref: registry/lattice-release-rollback-controls.yaml
+  work_order: work-order-0
+  purpose: "Defines environment fingerprint schema and provenance binding for Lattice Studio/Data/GovernAI product readiness."
+
+fingerprint_kinds:
+  - id: SystemFingerprint
+    owner_repo: SocioProphet/lattice-forge
+    required_fields:
+      - system_fingerprint_id
+      - system_target_ref
+      - ostree_commit_ref
+      - kernel_ref
+      - boot_release_set_ref
+      - secure_boot_state
+      - measured_boot_digest
+      - hardware_profile_ref
+      - generated_at
+      - digest
+  - id: UserEnvironmentFingerprint
+    owner_repo: SocioProphet/prophet-platform
+    required_fields:
+      - user_environment_fingerprint_id
+      - workspace_ref
+      - user_closure_ref
+      - nix_generation_ref
+      - runtime_profile_refs
+      - policy_bundle_ref
+      - generated_at
+      - digest
+  - id: AgentEnvironmentFingerprint
+    owner_repo: SocioProphet/agentplane
+    required_fields:
+      - agent_environment_fingerprint_id
+      - agent_closure_ref
+      - capability_manifest_ref
+      - isolation_profile_ref
+      - policy_decision_ref
+      - runtime_refs
+      - generated_at
+      - digest
+  - id: ReleaseSetFingerprint
+    owner_repo: SocioProphet/prophet-platform
+    required_fields:
+      - release_set_fingerprint_id
+      - release_set_ref
+      - boot_release_set_ref
+      - policy_bundle_ref
+      - bom_ref
+      - manifest_digest
+      - signature_ref
+      - generated_at
+      - digest
+  - id: ArtifactFingerprint
+    owner_repo: SocioProphet/prophet-platform
+    required_fields:
+      - artifact_fingerprint_id
+      - artifact_ref
+      - artifact_kind
+      - content_digest
+      - producer_ref
+      - policy_ref
+      - evidence_ref
+      - generated_at
+  - id: PolicyFingerprint
+    owner_repo: SocioProphet/policy-fabric
+    required_fields:
+      - policy_fingerprint_id
+      - policy_bundle_ref
+      - policy_subject_refs
+      - rule_digest
+      - decision_model_ref
+      - generated_at
+      - digest
+  - id: TenantWorkspaceFingerprint
+    owner_repo: SocioProphet/prophet-platform
+    required_fields:
+      - tenant_workspace_fingerprint_id
+      - tenant_ref
+      - workspace_ref
+      - data_residency_ref
+      - rbac_policy_ref
+      - catalog_scope_ref
+      - generated_at
+      - digest
+  - id: RollbackFingerprint
+    owner_repo: SocioProphet/sociosphere
+    required_fields:
+      - rollback_fingerprint_id
+      - rollback_receipt_ref
+      - previous_release_ref
+      - target_release_ref
+      - policy_decision_ref
+      - post_rollback_health_ref
+      - generated_at
+      - digest
+
+fingerprint_rules:
+  content_address_required: true
+  canonical_json_required: true
+  actor_ref_required_for_mutating_fingerprints: true
+  generated_at_required: true
+  policy_decision_ref_required_for_execution_and_release: true
+  topology_ref_required_for_release_and_rollback: true
+  digest_algorithm: sha256
+  digest_prefix: sha256:
+
+provenance_bindings:
+  release:
+    required_fingerprints:
+      - SystemFingerprint
+      - UserEnvironmentFingerprint
+      - AgentEnvironmentFingerprint
+      - ReleaseSetFingerprint
+      - PolicyFingerprint
+  execution:
+    required_fingerprints:
+      - UserEnvironmentFingerprint
+      - AgentEnvironmentFingerprint
+      - PolicyFingerprint
+      - ArtifactFingerprint
+  catalog_ingestion:
+    required_fingerprints:
+      - TenantWorkspaceFingerprint
+      - ArtifactFingerprint
+      - PolicyFingerprint
+  rollback:
+    required_fingerprints:
+      - RollbackFingerprint
+      - ReleaseSetFingerprint
+      - PolicyFingerprint
+
+receipt_links:
+  required_receipt_fields:
+    - fingerprint_ref
+    - fingerprint_digest
+    - policy_decision_ref
+    - topology_ref
+    - actor_ref
+    - timestamp
+  receipt_types:
+    - deployment-receipt
+    - execution-receipt
+    - rollback-receipt
+    - evidence-bundle-receipt
+    - compliance-receipt
+
+validation_requirements:
+  require_fingerprint_kinds: true
+  require_required_fields: true
+  require_fingerprint_rules: true
+  require_provenance_bindings: true
+  require_receipt_links: true
+  require_sha256_digest_prefix: true
+  require_policy_decision_binding: true
+  require_topology_binding_for_release_and_rollback: true
+  forbid_mutating_receipts_without_actor: true

--- a/tools/validate_lattice_environment_fingerprints.py
+++ b/tools/validate_lattice_environment_fingerprints.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "registry" / "lattice-environment-fingerprints.yaml"
+REQUIRED_KINDS = {
+    "SystemFingerprint",
+    "UserEnvironmentFingerprint",
+    "AgentEnvironmentFingerprint",
+    "ReleaseSetFingerprint",
+    "ArtifactFingerprint",
+    "PolicyFingerprint",
+    "TenantWorkspaceFingerprint",
+    "RollbackFingerprint",
+}
+REQUIRED_BINDINGS = {"release", "execution", "catalog_ingestion", "rollback"}
+REQUIRED_RECEIPTS = {
+    "deployment-receipt",
+    "execution-receipt",
+    "rollback-receipt",
+    "evidence-bundle-receipt",
+    "compliance-receipt",
+}
+REQUIRED_RECEIPT_FIELDS = {
+    "fingerprint_ref",
+    "fingerprint_digest",
+    "policy_decision_ref",
+    "topology_ref",
+    "actor_ref",
+    "timestamp",
+}
+
+
+def fail(message: str) -> int:
+    print(f"ERR: {message}", file=sys.stderr)
+    return 1
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def as_list(value: Any, field: str) -> list[Any]:
+    require(isinstance(value, list) and value, f"{field} must be non-empty list")
+    return value
+
+
+def require_mapping(value: Any, field: str) -> dict[str, Any]:
+    require(isinstance(value, dict), f"{field} must be mapping")
+    return value
+
+
+def main() -> int:
+    if yaml is None:
+        return fail("PyYAML is required for environment fingerprint validation")
+    if not REGISTRY.exists():
+        return fail(f"missing {REGISTRY}")
+    try:
+        data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+        require(isinstance(data, dict), "registry must be mapping")
+        require(data.get("kind") == "LatticeEnvironmentFingerprintRegistration", "kind mismatch")
+        require(data.get("version") == "0.1.0", "version mismatch")
+        umbrella = require_mapping(data.get("umbrella"), "umbrella")
+        require(umbrella.get("repo") == "SocioProphet/prophet-platform", "umbrella repo mismatch")
+        require(umbrella.get("issue") == 291, "umbrella issue mismatch")
+        require(umbrella.get("work_order") == "work-order-0", "work order mismatch")
+        require(umbrella.get("release_rollback_controls_ref") == "registry/lattice-release-rollback-controls.yaml", "release rollback ref mismatch")
+
+        kinds = as_list(data.get("fingerprint_kinds"), "fingerprint_kinds")
+        kind_ids = {item.get("id") for item in kinds if isinstance(item, dict)}
+        require(kind_ids == REQUIRED_KINDS, f"fingerprint kind ids mismatch: {kind_ids}")
+        for item in kinds:
+            item = require_mapping(item, "fingerprint kind")
+            require("owner_repo" in item, f"{item.get('id')} missing owner_repo")
+            fields = set(as_list(item.get("required_fields"), f"{item.get('id')}.required_fields"))
+            require("generated_at" in fields, f"{item.get('id')} missing generated_at")
+            if item.get("id") != "ArtifactFingerprint":
+                require("digest" in fields, f"{item.get('id')} missing digest")
+        by_id = {item["id"]: item for item in kinds if isinstance(item, dict)}
+        require("measured_boot_digest" in by_id["SystemFingerprint"].get("required_fields", []), "SystemFingerprint missing measured_boot_digest")
+        require("isolation_profile_ref" in by_id["AgentEnvironmentFingerprint"].get("required_fields", []), "AgentEnvironmentFingerprint missing isolation profile")
+        require("previous_release_ref" in by_id["RollbackFingerprint"].get("required_fields", []), "RollbackFingerprint missing previous release")
+        require("rbac_policy_ref" in by_id["TenantWorkspaceFingerprint"].get("required_fields", []), "TenantWorkspaceFingerprint missing RBAC policy")
+
+        rules = require_mapping(data.get("fingerprint_rules"), "fingerprint_rules")
+        for key in [
+            "content_address_required",
+            "canonical_json_required",
+            "actor_ref_required_for_mutating_fingerprints",
+            "generated_at_required",
+            "policy_decision_ref_required_for_execution_and_release",
+            "topology_ref_required_for_release_and_rollback",
+        ]:
+            require(rules.get(key) is True, f"fingerprint_rules.{key} must be true")
+        require(rules.get("digest_algorithm") == "sha256", "digest algorithm mismatch")
+        require(rules.get("digest_prefix") == "sha256:", "digest prefix mismatch")
+
+        bindings = require_mapping(data.get("provenance_bindings"), "provenance_bindings")
+        require(set(bindings) == REQUIRED_BINDINGS, f"provenance bindings mismatch: {set(bindings)}")
+        for key, binding in bindings.items():
+            binding = require_mapping(binding, f"provenance_bindings.{key}")
+            required = set(as_list(binding.get("required_fingerprints"), f"{key}.required_fingerprints"))
+            require(required <= REQUIRED_KINDS, f"{key} contains unknown fingerprint kinds")
+        require("ReleaseSetFingerprint" in bindings["release"]["required_fingerprints"], "release binding missing ReleaseSetFingerprint")
+        require("AgentEnvironmentFingerprint" in bindings["execution"]["required_fingerprints"], "execution binding missing AgentEnvironmentFingerprint")
+        require("TenantWorkspaceFingerprint" in bindings["catalog_ingestion"]["required_fingerprints"], "catalog binding missing TenantWorkspaceFingerprint")
+        require("RollbackFingerprint" in bindings["rollback"]["required_fingerprints"], "rollback binding missing RollbackFingerprint")
+
+        receipts = require_mapping(data.get("receipt_links"), "receipt_links")
+        receipt_fields = set(as_list(receipts.get("required_receipt_fields"), "receipt_links.required_receipt_fields"))
+        missing_fields = sorted(REQUIRED_RECEIPT_FIELDS - receipt_fields)
+        require(not missing_fields, f"missing receipt fields: {missing_fields}")
+        receipt_types = set(as_list(receipts.get("receipt_types"), "receipt_links.receipt_types"))
+        missing_receipts = sorted(REQUIRED_RECEIPTS - receipt_types)
+        require(not missing_receipts, f"missing receipt types: {missing_receipts}")
+
+        validation = require_mapping(data.get("validation_requirements"), "validation_requirements")
+        for key in [
+            "require_fingerprint_kinds",
+            "require_required_fields",
+            "require_fingerprint_rules",
+            "require_provenance_bindings",
+            "require_receipt_links",
+            "require_sha256_digest_prefix",
+            "require_policy_decision_binding",
+            "require_topology_binding_for_release_and_rollback",
+            "forbid_mutating_receipts_without_actor",
+        ]:
+            require(validation.get(key) is True, f"validation {key} must be true")
+    except Exception as exc:
+        return fail(str(exc))
+    print("OK: validated Lattice environment fingerprints")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Registers the Work Order 0 environment fingerprint schema for Lattice Studio/Data/GovernAI product readiness.

## Adds

- `registry/lattice-environment-fingerprints.yaml`
- `tools/validate_lattice_environment_fingerprints.py`
- Makefile validation hook

## Coverage

Defines system, user, agent, release set, artifact, policy, tenant/workspace, and rollback fingerprints with provenance bindings and receipt links.

## Validation

Expected:

```bash
make validate
```

## Tracking

Follows SocioProphet/sociosphere#250 through #257.