### PR TITLE
fix(workspace): track socioprophet web on master

### DIFF
--- a/manifest/workspace.lock.json
+++ b/manifest/workspace.lock.json
@@ -40,7 +40,7 @@
       "name": "socioprophet_web",
       "role": "component",
       "url": "https://github.com/SocioProphet/socioprophet",
-      "ref": "main",
+      "ref": "master",
       "rev": "04614b5fe876999abeb1e92348d47e453f981537",
       "local_path": "components/socioprophet-web",
       "tree_hash": null,

--- a/manifest/workspace.toml
+++ b/manifest/workspace.toml
@@ -65,7 +65,7 @@ name = "socioprophet_web"
 role = "component"
 local_path = "components/socioprophet-web"
 url = "https://github.com/SocioProphet/socioprophet"
-ref = "main"
+ref = "master"
 license_hint = "MIT"
 
 [[repos]]


### PR DESCRIPTION
## Summary

Fix the remaining live workspace-ref drift for the `socioprophet_web` entry.

## Changes

- Updates `manifest/workspace.toml` so `socioprophet_web` tracks `ref = "master"` instead of `main`.
- Updates `manifest/workspace.lock.json` with the same `ref = "master"` correction.

## Why

The current upstream repo `SocioProphet/socioprophet` uses `master` as its default tracked branch. The previous broader manifest-canonicalization note already identified this as the remaining stale declaration after duplicate `agentplane` and zero-trust identity cleanup.

## Scope

This PR is intentionally narrow:

- no repo additions
- no lock SHA refresh
- no role changes
- no topology changes
- no generated registry update

It only corrects the tracked branch declaration while preserving the existing pinned revision.

## Validation

Connector-side checks:

- fetched current `main` manifest and lock
- confirmed duplicate `agentplane` and zero-trust entries are already resolved upstream
- patched only `socioprophet_web.ref` in manifest and lock
