### PR TITLE
fix(workspace): track socioprophet web on master

### DIFF
--- a/manifest/workspace.lock.json
+++ b/manifest/workspace.lock.json
@@ -40,7 +40,7 @@
       "name": "socioprophet_web",
       "role": "component",
       "url": "https://github.com/SocioProphet/socioprophet",
-      "ref": "main",
+      "ref": "master",
       "rev": "04614b5fe876999abeb1e92348d47e453f981537",
       "local_path": "components/socioprophet-web",
       "tree_hash": null,

--- a/manifest/workspace.toml
+++ b/manifest/workspace.toml
@@ -65,7 +65,7 @@ name = "socioprophet_web"
 role = "component"
 local_path = "components/socioprophet-web"
 url = "https://github.com/SocioProphet/socioprophet"
-ref = "main"
+ref = "master"
 license_hint = "MIT"
 
 [[repos]]


### PR DESCRIPTION
## Summary

Ready replacement for draft PR #261.

Fixes the remaining live workspace-ref drift for the `socioprophet_web` entry:

- `manifest/workspace.toml`: `socioprophet_web.ref` changes from `main` to `master`
- `manifest/workspace.lock.json`: matching `ref` correction from `main` to `master`

## Why

`SocioProphet/socioprophet` uses `master` as its tracked/default branch. Current `sociosphere/main` still records `socioprophet_web.ref = "main"`, which was the final directly visible item from the earlier workspace-manifest canonicalization intent.

## Scope

This PR is intentionally narrow:

- no repo additions
- no lock SHA refresh
- no role changes
- no topology changes
- no generated registry update

It only corrects the tracked branch declaration while preserving the existing pinned revision.

## Relationship to prior work

- Supersedes draft PR #261 with a ready PR carrying the same one-commit fix.
- Duplicate `agentplane` identity is already resolved on `main`.
- Duplicate zero-trust identity is already resolved on `main`.
- UI salvage relocation/cleanup is already resolved by `socioprophet#283` and `sociosphere#81`.

## Validation

Connector-side validation:

- PR #261 was confirmed cleanly ahead of current `main` by 1 commit and behind by 0.
- Changed files are limited to `manifest/workspace.toml` and `manifest/workspace.lock.json`.
