### PR TITLE
registry: add evidence fabric repo family

### DIFF
--- a/registry/evidence-fabric-repos.yaml
+++ b/registry/evidence-fabric-repos.yaml
@@ -1,0 +1,171 @@
+version: "0.1.0"
+updated_at: "2026-05-04"
+program: evidence-fabric
+status: planned
+
+purpose: >-
+  Register the planned SocioProphet evidence fabric repo family before
+  implementation repos are created. These repos will own evidence contracts,
+  brokered ingest, storage infrastructure, source connectors, and validation.
+
+upstream_sources:
+  standards_storage:
+    repo: SocioProphet/socioprophet-standards-storage
+    role: storage standards, evidence bootstrap contracts, ingest architecture
+    merged_prs: [51, 65, 68]
+  sourceos_spec:
+    repo: SourceOS-Linux/sourceos-spec
+    role: umbrella metadata plane, SourceChannel, sync, policy, audit contracts
+  standards_knowledge:
+    repo: SocioProphet/socioprophet-standards-knowledge
+    role: Knowledge Context, SHACL, semantic validation, executable fixtures
+  ontogenesis:
+    repo: SocioProphet/ontogenesis
+    role: SHIR and ontology projection target
+  tritrpc:
+    repo: SocioProphet/TriTRPC
+    role: deterministic transport and policy/evidence AUX carriage
+  prophet_platform:
+    repo: SocioProphet/prophet-platform
+    role: runtime proof, receipt, parity, and preflight evidence patterns
+  socios_linux_source_os:
+    repo: SociOS-Linux/source-os
+    role: Linux realization, scoped local paths, workstation and office shell surfaces
+
+planned_repositories:
+  - id: evidence-contracts
+    name: evidence-contracts
+    org: SocioProphet
+    layer: standards
+    status: planned
+    role: contracts
+    purpose: >-
+      Canonical evidence object schemas, examples, Avro twins, and compatibility
+      gates for ConnectorProfile, AcquisitionRun, EvidenceBlob, EvidenceItem,
+      EvidenceEntity, EvidenceEvent, ParserRun, and ValidationResult.
+    source_of_truth: true
+    temporary_landing: SocioProphet/socioprophet-standards-storage:schemas/evidence
+    depends_on:
+      - SocioProphet/socioprophet-standards-storage
+      - SourceOS-Linux/sourceos-spec
+    produces:
+      - json-schema
+      - avro
+      - examples
+      - compatibility-notes
+
+  - id: evidence-broker
+    name: evidence-broker
+    org: SocioProphet
+    layer: data-plane
+    status: planned
+    role: ingest-broker
+    purpose: >-
+      Brokered evidence ingest service for local files and source connectors.
+      It stages raw blobs immutably, computes hashes, emits manifests, records
+      parser runs, and registers metadata in Postgres.
+    depends_on:
+      - SocioProphet/evidence-contracts
+      - SocioProphet/evidence-storage-infra
+      - SourceOS-Linux/sourceos-spec
+      - SocioProphet/TriTRPC
+    produces:
+      - acquisition-runs
+      - evidence-blobs
+      - parser-runs
+      - validation-results
+      - content-root-manifests
+
+  - id: evidence-storage-infra
+    name: evidence-storage-infra
+    org: SocioProphet
+    layer: infrastructure
+    status: planned
+    role: storage-infra
+    purpose: >-
+      Deployment and operations package for the phase-1 raw object store plus
+      Postgres metadata/control plane. The phase-1 target is SeaweedFS plus
+      Postgres, with Ceph RGW reserved as the heavier later option.
+    depends_on:
+      - SocioProphet/socioprophet-standards-storage
+      - SourceOS-Linux/sourceos-spec
+    produces:
+      - object-store-config
+      - postgres-schema
+      - backup-policy
+      - lifecycle-policy
+      - local-dev-compose
+
+  - id: evidence-connectors-gdrive
+    name: evidence-connectors-gdrive
+    org: SocioProphet
+    layer: adapter
+    status: planned
+    role: source-connector
+    purpose: >-
+      Google Drive ingress adapter around rclone first, with optional desktop
+      GOA/GVfs integration later. Google Drive remains an ingress surface and
+      is not core authority.
+    depends_on:
+      - SocioProphet/evidence-broker
+      - SocioProphet/evidence-contracts
+    external_surface: Google Drive
+    provider_posture: ingress-only
+
+  - id: evidence-connectors-icloud
+    name: evidence-connectors-icloud
+    org: SocioProphet
+    layer: adapter
+    status: planned
+    role: source-connector
+    purpose: >-
+      iCloud Drive ingress adapter around rclone after the local-file and
+      Google Drive paths are stable. iCloud remains an ingress surface and is
+      not core authority.
+    depends_on:
+      - SocioProphet/evidence-broker
+      - SocioProphet/evidence-contracts
+    external_surface: iCloud Drive
+    provider_posture: ingress-only
+    risk_notes:
+      - session-volatility
+      - two-factor-authentication
+      - advanced-data-protection-web-access-limits
+
+  - id: evidence-validator
+    name: evidence-validator
+    org: SocioProphet
+    layer: governance
+    status: planned
+    role: validator
+    purpose: >-
+      Evidence validation package for schema checks, hash consistency,
+      timestamp sanity, source alias integrity, parser-run consistency, and
+      later SHIR/Knowledge Context projection checks.
+    depends_on:
+      - SocioProphet/evidence-contracts
+      - SocioProphet/socioprophet-standards-knowledge
+      - SocioProphet/ontogenesis
+    produces:
+      - validation-results
+      - fixture-gates
+      - projection-checks
+
+architecture_rules:
+  - source systems are ingress only
+  - raw object identity is content-addressed by SHA-256
+  - source aliases are preserved, not collapsed away
+  - Postgres owns metadata, provenance, routing, and processing state
+  - chunking and enrichment are derivative, never primary custody
+  - graph and semantic projection target SHIR and standards-knowledge later
+  - TriTRPC provides deterministic transport only, not evidence semantics
+  - Sociosphere registers topology and workspace control
+  - SourceOS/SociOS enforce local path and mount boundaries
+
+phase_1_acceptance:
+  - local-file ingest produces one EvidenceBlob and one content-root manifest
+  - re-ingest of the same file is idempotent by hash
+  - parser failure preserves raw blob custody
+  - source aliases remain attached to deduped blobs
+  - Postgres records acquisition, blob, source, item, parser, and validation state
+  - Google Drive rclone ingest uses the same broker path as local-file ingest

--- a/registry/evidence-fabric-surface-integrations.yaml
+++ b/registry/evidence-fabric-surface-integrations.yaml
@@ -1,0 +1,209 @@
+version: "0.1.0"
+updated_at: "2026-05-05"
+program: evidence-fabric
+status: planned
+
+purpose: >-
+  Plan evidence-fabric integration across user-facing workspace, email,
+  office/document, browser, terminal, cloud-drive, local-file, mobile/device,
+  and Exodus migration surfaces. The goal is to accelerate user exodus from
+  closed vendor control surfaces while preserving custody, metadata, and
+  proof-grade migration evidence.
+
+principles:
+  - source systems are ingress only
+  - user-facing migration must be guided, explainable, and reversible
+  - raw evidence custody must precede parsing, chunking, and semantic projection
+  - email, documents, notes, media, console logs, browser exports, and cloud-drive objects use one broker path
+  - duplicate content collapses by hash while all source aliases remain preserved
+  - provider APIs and accounts are quarantine/ingress surfaces, not platform authority
+  - workspace UX should expose status, next actions, blockers, and proof packs
+  - no source-system deletion occurs before mirror parity, manifest parity, and cooling-off checks
+
+surface_integrations:
+  - id: exodus-dashboard
+    owning_repo: SocioProphet/exodus
+    surface_type: migration-dashboard
+    status: planned
+    user_value: >-
+      Primary user-facing dashboard for provider topology, exit readiness,
+      control-surface scoring, migration waves, blockers, and proof of progress.
+    evidence_fabric_role:
+      - display acquisition progress
+      - display dedupe and mirror parity
+      - display ingestion wave plans
+      - display provider lock-in blockers
+      - export proof packs and status reports
+    phase: 1
+
+  - id: sociosphere-workspace
+    owning_repo: SocioProphet/sociosphere
+    surface_type: workspace-control
+    status: planned
+    user_value: >-
+      Registers and orchestrates evidence-fabric repos, manifests, validation,
+      workspace state, and cross-repo execution order.
+    evidence_fabric_role:
+      - repo-family registration
+      - validation and topology checks
+      - work-order tracking
+      - CI/PR state visibility
+    phase: 1
+
+  - id: email-ingest
+    owning_repo: SocioProphet/evidence-connectors-email
+    surface_type: email
+    status: proposed
+    user_value: >-
+      Ingest, archive, dedupe, and normalize email exports and mailbox evidence
+      from Gmail, Apple Mail/iCloud Mail, Outlook, IMAP, MBOX, Maildir, and EML.
+    evidence_fabric_role:
+      - source alias capture
+      - message/thread attachment preservation
+      - header and timestamp normalization
+      - attachment blob dedupe
+      - migration readiness scoring
+    planned_connectors:
+      - gmail-export
+      - google-takeout-mail
+      - apple-mail-export
+      - icloud-mail-imap
+      - outlook-pst-or-eml
+      - generic-imap
+      - mbox
+      - maildir
+    phase: 1
+
+  - id: cloud-drive-ingest
+    owning_repo: SocioProphet/evidence-connectors-gdrive
+    companion_repo: SocioProphet/evidence-connectors-icloud
+    surface_type: cloud-drive
+    status: planned
+    user_value: >-
+      Consolidate Google Drive and iCloud Drive into the canonical raw object
+      store while preserving provider IDs, revisions, paths, and aliases.
+    evidence_fabric_role:
+      - rclone-based source traversal
+      - hash-first landing
+      - source path and provider metadata preservation
+      - duplicate collapse by blob hash
+      - parity and cooling-off checks before deletion
+    phase: 1
+
+  - id: local-file-ingest
+    owning_repo: SocioProphet/evidence-broker
+    surface_type: local-files
+    status: planned
+    user_value: >-
+      Pull user-selected local folders, USB exports, notes dumps, device console
+      captures, browser console captures, screenshots, and text logs into the
+      same custody path as cloud-drive content.
+    evidence_fabric_role:
+      - local-file acquisition run
+      - immutable staging
+      - content-root manifest generation
+      - parser-failure custody preservation
+    phase: 1
+
+  - id: sourceos-office-shell
+    owning_repo: SociOS-Linux/source-os
+    surface_type: office-documents
+    status: planned
+    user_value: >-
+      Let users create, open, verify, search, and export documents through the
+      SourceOS office shell while preserving open-format migration outputs.
+    evidence_fabric_role:
+      - document export capture
+      - writeback and version record linkage
+      - proof-pack friendly report generation
+      - default output path integration
+    default_paths:
+      - ~/Documents/SourceOS/agent-output
+      - ~/Downloads/SourceOS/agent-downloads
+    phase: 2
+
+  - id: browser-and-terminal-capture
+    owning_repo: SociOS-Linux/source-os
+    companion_repos:
+      - SocioProphet/cloudshell-fog
+      - SocioProphet/prophet-platform
+    surface_type: browser-terminal
+    status: planned
+    user_value: >-
+      Capture browser exports, web-console text, terminal/device-console logs,
+      screenshots, and command outputs into the evidence broker without granting
+      whole-home or ambient host access.
+    evidence_fabric_role:
+      - scoped capture directories
+      - console-log parser dispatch
+      - screenshot/media metadata capture
+      - shell/browser action receipts
+    phase: 2
+
+  - id: notes-and-mobile-device-exports
+    owning_repo: SocioProphet/exodus
+    surface_type: notes-mobile
+    status: planned
+    user_value: >-
+      Migrate Apple Notes, Google Keep-like exports, voice memos, photos,
+      mobile backups, and text-note archives into open raw and derived stores.
+    evidence_fabric_role:
+      - source export manifest capture
+      - raw media preservation
+      - transcript/OCR derivative routing
+      - note/document normalization
+    phase: 2
+
+  - id: search-and-knowledge-projection
+    owning_repo: SocioProphet/socioprophet-standards-knowledge
+    companion_repo: SocioProphet/ontogenesis
+    surface_type: search-knowledge
+    status: planned
+    user_value: >-
+      Make migrated content searchable and later semantically projectable while
+      keeping raw custody separate from search, vector, and graph projections.
+    evidence_fabric_role:
+      - Knowledge Context projection
+      - SHIR projection
+      - SHACL/shape validation
+      - query/search enrichment after custody
+    phase: 3
+
+  - id: proof-pack-export
+    owning_repo: SocioProphet/evidence-validator
+    companion_repo: SocioProphet/exodus
+    surface_type: proof-export
+    status: planned
+    user_value: >-
+      Export user-readable and machine-readable proof packs for migration waves,
+      duplicate collapse, provider parity, custody, and readiness to delete or
+      downgrade source-provider accounts.
+    evidence_fabric_role:
+      - validation results
+      - content-root manifests
+      - mirror parity summaries
+      - provider-exit proof reports
+    phase: 3
+
+exodus_acceleration_metrics:
+  - provider_control_surface_score
+  - exit_readiness_index
+  - migrated_blob_count
+  - migrated_unique_bytes
+  - duplicate_bytes_eliminated
+  - source_aliases_preserved
+  - blocked_objects_count
+  - open_format_conversion_count
+  - proof_pack_count
+  - source_deletion_eligible_count
+
+minimum_user_workflows:
+  - connect source account or select local export
+  - preview provider topology and estimated size
+  - choose migration wave
+  - land raw content into canonical object store
+  - review dedupe and source aliases
+  - process text/log/document/media derivatives
+  - review blockers and next best actions
+  - export proof pack
+  - mark source provider as retained, downgraded, or deletion-eligible after cooling-off

--- a/tools/validate_evidence_fabric_repos.py
+++ b/tools/validate_evidence_fabric_repos.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Validate the evidence fabric repo-family registry slice."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("PyYAML is required: python3 -m pip install pyyaml") from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "registry" / "evidence-fabric-repos.yaml"
+
+REQUIRED_REPOS = {
+    "evidence-contracts",
+    "evidence-broker",
+    "evidence-storage-infra",
+    "evidence-connectors-gdrive",
+    "evidence-connectors-icloud",
+    "evidence-validator",
+}
+
+REQUIRED_ARCHITECTURE_RULES = {
+    "source systems are ingress only",
+    "raw object identity is content-addressed by SHA-256",
+    "source aliases are preserved, not collapsed away",
+    "Postgres owns metadata, provenance, routing, and processing state",
+    "chunking and enrichment are derivative, never primary custody",
+    "graph and semantic projection target SHIR and standards-knowledge later",
+    "TriTRPC provides deterministic transport only, not evidence semantics",
+    "Sociosphere registers topology and workspace control",
+    "SourceOS/SociOS enforce local path and mount boundaries",
+}
+
+
+def fail(message: str) -> None:
+    print(f"ERR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> int:
+    if not REGISTRY.exists():
+        fail(f"missing {REGISTRY.relative_to(ROOT)}")
+
+    data = yaml.safe_load(REGISTRY.read_text())
+    if not isinstance(data, dict):
+        fail("registry must be a mapping")
+
+    if data.get("program") != "evidence-fabric":
+        fail("program must be evidence-fabric")
+
+    repos = data.get("planned_repositories")
+    if not isinstance(repos, list):
+        fail("planned_repositories must be a list")
+
+    ids = {repo.get("id") for repo in repos if isinstance(repo, dict)}
+    missing = REQUIRED_REPOS - ids
+    extra_empty = {repo.get("id") for repo in repos if not repo.get("purpose")}
+
+    if missing:
+        fail(f"missing planned repositories: {sorted(missing)}")
+    if extra_empty:
+        fail(f"repositories missing purpose: {sorted(extra_empty)}")
+
+    for repo in repos:
+        for field in ("id", "name", "org", "layer", "status", "role", "purpose"):
+            if field not in repo:
+                fail(f"repo {repo.get('id')} missing field {field}")
+        if repo.get("org") != "SocioProphet":
+            fail(f"repo {repo.get('id')} must be in SocioProphet org")
+        if repo.get("status") != "planned":
+            fail(f"repo {repo.get('id')} must be planned until created")
+
+    rules = set(data.get("architecture_rules") or [])
+    missing_rules = REQUIRED_ARCHITECTURE_RULES - rules
+    if missing_rules:
+        fail(f"missing architecture rules: {sorted(missing_rules)}")
+
+    acceptance = data.get("phase_1_acceptance") or []
+    if len(acceptance) < 5:
+        fail("phase_1_acceptance must contain at least five gates")
+
+    print("OK: evidence fabric repo registry is valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_evidence_fabric_surface_integrations.py
+++ b/tools/validate_evidence_fabric_surface_integrations.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Validate the evidence fabric surface-integration registry slice."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("PyYAML is required: python3 -m pip install pyyaml") from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "registry" / "evidence-fabric-surface-integrations.yaml"
+
+REQUIRED_SURFACES = {
+    "exodus-dashboard",
+    "sociosphere-workspace",
+    "email-ingest",
+    "cloud-drive-ingest",
+    "local-file-ingest",
+    "sourceos-office-shell",
+    "browser-and-terminal-capture",
+    "notes-and-mobile-device-exports",
+    "search-and-knowledge-projection",
+    "proof-pack-export",
+}
+
+REQUIRED_PRINCIPLES = {
+    "source systems are ingress only",
+    "user-facing migration must be guided, explainable, and reversible",
+    "raw evidence custody must precede parsing, chunking, and semantic projection",
+    "email, documents, notes, media, console logs, browser exports, and cloud-drive objects use one broker path",
+    "duplicate content collapses by hash while all source aliases remain preserved",
+    "provider APIs and accounts are quarantine/ingress surfaces, not platform authority",
+    "workspace UX should expose status, next actions, blockers, and proof packs",
+    "no source-system deletion occurs before mirror parity, manifest parity, and cooling-off checks",
+}
+
+REQUIRED_METRICS = {
+    "provider_control_surface_score",
+    "exit_readiness_index",
+    "migrated_blob_count",
+    "migrated_unique_bytes",
+    "duplicate_bytes_eliminated",
+    "source_aliases_preserved",
+    "blocked_objects_count",
+    "open_format_conversion_count",
+    "proof_pack_count",
+    "source_deletion_eligible_count",
+}
+
+REQUIRED_WORKFLOW_PHRASES = {
+    "connect source account or select local export",
+    "preview provider topology and estimated size",
+    "choose migration wave",
+    "land raw content into canonical object store",
+    "review dedupe and source aliases",
+    "process text/log/document/media derivatives",
+    "review blockers and next best actions",
+    "export proof pack",
+    "mark source provider as retained, downgraded, or deletion-eligible after cooling-off",
+}
+
+
+def fail(message: str) -> None:
+    print(f"ERR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> int:
+    if not REGISTRY.exists():
+        fail(f"missing {REGISTRY.relative_to(ROOT)}")
+
+    data = yaml.safe_load(REGISTRY.read_text())
+    if not isinstance(data, dict):
+        fail("surface integration registry must be a mapping")
+
+    if data.get("program") != "evidence-fabric":
+        fail("program must be evidence-fabric")
+
+    principles = set(data.get("principles") or [])
+    missing_principles = REQUIRED_PRINCIPLES - principles
+    if missing_principles:
+        fail(f"missing principles: {sorted(missing_principles)}")
+
+    integrations = data.get("surface_integrations")
+    if not isinstance(integrations, list):
+        fail("surface_integrations must be a list")
+
+    ids = {item.get("id") for item in integrations if isinstance(item, dict)}
+    missing_surfaces = REQUIRED_SURFACES - ids
+    if missing_surfaces:
+        fail(f"missing required surfaces: {sorted(missing_surfaces)}")
+
+    for item in integrations:
+        for field in ("id", "owning_repo", "surface_type", "status", "user_value", "evidence_fabric_role", "phase"):
+            if field not in item:
+                fail(f"surface {item.get('id')} missing field {field}")
+        roles = item.get("evidence_fabric_role")
+        if not isinstance(roles, list) or not roles:
+            fail(f"surface {item.get('id')} must define at least one evidence_fabric_role")
+
+    metrics = set(data.get("exodus_acceleration_metrics") or [])
+    missing_metrics = REQUIRED_METRICS - metrics
+    if missing_metrics:
+        fail(f"missing exodus metrics: {sorted(missing_metrics)}")
+
+    workflows = set(data.get("minimum_user_workflows") or [])
+    missing_workflows = REQUIRED_WORKFLOW_PHRASES - workflows
+    if missing_workflows:
+        fail(f"missing workflow steps: {sorted(missing_workflows)}")
+
+    print("OK: evidence fabric surface integrations are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Ready replacement for draft PR #265.

Registers the planned evidence-fabric repo family in SocioSphere as a focused registry lane before the dedicated implementation repositories are created.

## Adds

- `registry/evidence-fabric-repos.yaml`
- `registry/evidence-fabric-surface-integrations.yaml`
- `tools/validate_evidence_fabric_repos.py`
- `tools/validate_evidence_fabric_surface_integrations.py`

## Why

The evidence bootstrap is now upstream in `socioprophet-standards-storage`, but the future repo family still needs to be visible to the workspace controller before implementation work begins.

This registry slice captures:

- planned repos: `evidence-contracts`, `evidence-broker`, `evidence-storage-infra`, `evidence-connectors-gdrive`, `evidence-connectors-icloud`, and `evidence-validator`
- user-facing surface integrations across Exodus, workspace control, email, cloud drive, local files, office/documents, browser/terminal capture, notes/mobile exports, search/knowledge projection, and proof-pack export
- upstream dependencies across standards-storage, sourceos-spec, standards-knowledge, ontogenesis, TriTRPC, prophet-platform, and SociOS-Linux/source-os
- architecture rules for custody, hashing, dedupe, source aliases, Postgres, SHIR projection, and SourceOS/SociOS mount boundaries
- phase-1 acceptance gates for local-file ingest and Google Drive broker parity

## Scope discipline

This PR intentionally follows the newer focused registry-slice pattern used by Lattice lanes. It does not edit the monolithic canonical registry and does not yet wire validators into `make validate`; that remains a narrow follow-up once the focused slice is accepted.

## Relationship to prior work

- Supersedes draft PR #265.
- Follows the Work Order 0 Lattice closeout through PR #258.
- Advances the evidence-fabric/exodus migration path without pretending the implementation repos already exist.

## Follow-on

1. Wire both validators into `make validate` in a focused follow-up.
2. Create dedicated evidence-fabric repositories when repo-creation access is available.
3. Split temporary evidence schema assets out of standards-storage into `evidence-contracts` once the repo exists.
