### PR TITLE
validation: wire evidence fabric validators into make validate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ ui-dev: ui-preflight
 # --- end ui-workbench targets ---
 
 # --- standards validation targets ---
-.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate
+.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate evidence-fabric-repos-validate evidence-fabric-surface-integrations-validate
 
-validate: validate-standards program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate
+validate: validate-standards program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate evidence-fabric-repos-validate evidence-fabric-surface-integrations-validate
 	@echo "OK: validate"
 
 validate-standards:
@@ -84,6 +84,14 @@ lattice-release-rollback-controls-validate:
 lattice-environment-fingerprints-validate:
 	python3 -m pip install --user pyyaml >/dev/null
 	python3 tools/validate_lattice_environment_fingerprints.py
+
+evidence-fabric-repos-validate:
+	python3 -m pip install --user pyyaml >/dev/null
+	python3 tools/validate_evidence_fabric_repos.py
+
+evidence-fabric-surface-integrations-validate:
+	python3 -m pip install --user pyyaml >/dev/null
+	python3 tools/validate_evidence_fabric_surface_integrations.py
 
 multidomain-geospatial-standards-compliance-validate:
 	python3 tools/check_multidomain_geospatial_standards_compliance.py


### PR DESCRIPTION
## Summary

Follow-up to PR #266.

Wires the evidence-fabric registry validators into the top-level validation path.

## Changes

- Adds `evidence-fabric-repos-validate` to `.PHONY`.
- Adds `evidence-fabric-surface-integrations-validate` to `.PHONY`.
- Adds both targets to the top-level `validate` target.
- Defines both targets using the focused validators introduced by PR #266:
  - `tools/validate_evidence_fabric_repos.py`
  - `tools/validate_evidence_fabric_surface_integrations.py`

## Why

PR #266 intentionally kept evidence-fabric registration focused and deferred Makefile validation wiring. This PR closes that follow-up so `make validate` covers the new registry slices.

## Scope

Makefile-only validation wiring. No registry semantics changed.