### PR TITLE
Route agent harness metrics to Delivery Excellence

### DIFF
--- a/docs/INTEGRATION_STATUS.md
+++ b/docs/INTEGRATION_STATUS.md
@@ -25,6 +25,17 @@ facts that were previously repeated in multiple places.
 - Fast-LLM baseline: `ServiceNow/Fast-LLM main @ 7a7129d7775cea459cb19a48be0d831ccc7b4e7d`
 - Status: captured in repo; policy disposition lives in the architecture note and operational baseline lives in the registry + drift check tool
 
+### Agent harness delivery routing
+- Routing doc: `docs/integration/agent-harness-delivery-routing.md`
+- Delivery/performance authority: `SocioProphet/delivery-excellence`
+- Delivery automation authority: `SocioProphet/delivery-excellence-automation`
+- Runtime evidence producer: `SocioProphet/agentplane`
+- Policy/guardrail producers: `SocioProphet/policy-fabric`, `SocioProphet/guardrail-fabric`
+- Memory/context producer: `SocioProphet/memory-mesh`
+- Browser and terminal producers: `SourceOS-Linux/BearBrowser`, `SourceOS-Linux/TurtleTerm`, `SourceOS-Linux/agent-term`
+- Security validation producer: `SocioProphet/SCOPE-D`
+- Status: routing captured in repo; Delivery Excellence owns scoreboards, KPI/OKR definitions, customer-proof readouts, and operating cadence; SocioSphere owns topology and must not duplicate scoreboards
+
 ## Resolved migration timeline
 
 | Stage | Snapshot |
@@ -44,3 +55,7 @@ treat that content as historical context. Current behavior is defined by
 For edge-capability upstreams, treat the registry file plus drift-check tool as
 the operational baseline, and treat the narrative binding doc as the policy /
 disposition explanation.
+
+For agent harness delivery routing, treat `docs/integration/agent-harness-delivery-routing.md`
+as the topology and boundary source. Delivery Excellence remains the performance,
+scoreboard, KPI/OKR, work packaging, and customer-proof authority.

--- a/docs/integration/agent-harness-delivery-routing.md
+++ b/docs/integration/agent-harness-delivery-routing.md
@@ -1,0 +1,77 @@
+# Agent Harness Delivery Routing
+
+Status: v0.1 routing baseline  
+Owner plane: SocioSphere for topology and workspace routing  
+Metrics authority: `SocioProphet/delivery-excellence` and `SocioProphet/delivery-excellence-automation`
+
+## Purpose
+
+This document records the cross-estate routing decision for the Aden/Hive-derived agent harness lessons.
+
+The lessons are useful across the estate, not only development. Runtime execution, policy gates, browser/terminal surfaces, memory, security checks, product proof, customer-safe readouts, bounties, inner-source collaboration, and corporate scoreboards all need a common operating loop.
+
+SocioSphere records the topology and dependency direction. Delivery Excellence owns the performance stack, metrics, KPI/OKR scoreboards, operating cadence, work packaging, and customer-proof readouts.
+
+## Routing decision
+
+Use this authority split:
+
+| Plane | Canonical authority | Role |
+|---|---|---|
+| Workspace topology | `SocioProphet/sociosphere` | declares repo roles, dependency direction, cross-estate routing, source exposure, and integration status |
+| Delivery performance | `SocioProphet/delivery-excellence` | owns KPI/OKR definitions, scoreboards, operating cadence, work packaging, and proof-of-value readouts |
+| Delivery automation | `SocioProphet/delivery-excellence-automation` | owns machine-readable contracts for recent repo activity, delivery metrics, scoreboards, customer proof, human-control events, and skill/MCP scoring |
+| Runtime execution | `SocioProphet/agentplane` | owns bundles, execution, placement, run control, evidence, replay, session, promotion, and reversal artifacts |
+| Policy and guardrails | `SocioProphet/policy-fabric`; `SocioProphet/guardrail-fabric` | owns policy gates, admission, grants, guardrails, judge/eval posture, and promotion policy |
+| Agent identity and authority | `SocioProphet/agent-registry`; `SocioProphet/socioprophet-agent-standards`; `SourceOS-Linux/agent-machine` | owns agent identities, grants, activation decisions, revocation, and host/runtime activation semantics |
+| Memory and context | `SocioProphet/memory-mesh` | owns recall/writeback, memory profiles, context packs, artifact pointers, and retention/sensitive-payload posture |
+| Browser surface | `SourceOS-Linux/BearBrowser`; `SociOS-Linux/browser-use` | owns governed browser automation, browser events, credential posture, and browser evidence |
+| Terminal/operator surface | `SourceOS-Linux/TurtleTerm`; `SourceOS-Linux/agent-term`; `SociOS-Linux/workstation-contracts` | owns operator commands, shell receipts, IPC conformance, terminal evidence, and local operator smoke paths |
+| Security validation | `SocioProphet/SCOPE-D`; `SocioProphet/global-devsecops-intelligence` | owns skill/MCP/tool/browser/memory/graph risk validation and defensive security evidence |
+| Product/customer surfaces | `SocioProphet/socioprophet`; `SocioProphet/prophet-platform`; `SocioProphet/prophet-workspace`; `mdheller/socioprophet-web`; `SociOS-Linux/socioslinux-web` | owns customer/operator-facing UX, proof surfaces, and product demos |
+
+## Operating loop
+
+The shared cross-estate loop is:
+
+```text
+Outcome -> Work Item -> Plan Graph -> Policy Gate -> Run -> Evidence -> Scoreboard -> Review -> Evolution Patch -> Promotion Gate
+```
+
+Delivery Excellence consumes evidence from runtime, policy, SourceOS, security, browser, terminal, memory, and product repos, then emits management-facing and customer-safe readouts.
+
+SocioSphere should never duplicate Delivery Excellence scoreboards. It should link to them and enforce that repos are routed to the correct owner plane.
+
+## Initial consumed signals
+
+Delivery Excellence should consume at least these signal families:
+
+- recent repo activity from GitHub commits, PRs, issues, releases, and workflow runs
+- AgentPlane validation/run/replay/session/promotion artifacts
+- Policy Fabric decisions, reports, exceptions, and promotion gates
+- SourceOS activation decisions, release evidence, local-first service manifests, and shell receipts
+- BearBrowser browser events, credential posture, automation compatibility, and build readiness
+- TurtleTerm/agent-term operator smoke events, terminal receipts, and IPC/workstation conformance
+- Memory Mesh context-pack refs, recall/writeback posture, and sensitive-payload decisions
+- SCOPE-D security assessments for skills, MCP servers, tools, memory, browser, graph robustness, and prompt/tool poisoning
+- product proof, demo readiness, and customer-safe readout artifacts
+
+## Current integration artifacts
+
+- `SocioProphet/delivery-excellence#9` — adds the agent harness delivery operating model.
+- `SocioProphet/delivery-excellence-automation#7` — adds machine-readable agent harness metric contracts and examples.
+
+## Non-goals
+
+- Do not move scoreboards or KPI/OKR definitions into SocioSphere.
+- Do not move runtime execution into Delivery Excellence.
+- Do not make delivery metrics depend on proprietary cloud services.
+- Do not count logs as evidence unless they are linked to validated evidence artifacts.
+- Do not treat generated agent work as complete unless acceptance criteria and validation pass.
+
+## Next routing tasks
+
+1. Register Delivery Excellence as the explicit performance-stack owner in the integration ledger.
+2. Register the agent harness metric contracts as a cross-estate consumed contract family.
+3. Require new agent-harness work to declare owner plane, signal producer, scoreboard consumer, and proof-of-value readout path.
+4. Generate a first cross-estate scoreboard snapshot from recent repo activity and known evidence refs.


### PR DESCRIPTION
## Summary

Records the cross-estate routing decision for the Aden/Hive-derived agent harness lessons.

SocioSphere keeps topology and boundary authority. Delivery Excellence becomes the explicit performance-stack authority for scoreboards, KPI/OKR definitions, customer-proof readouts, work packaging, and operating cadence.

## Scope

- Adds `docs/integration/agent-harness-delivery-routing.md`.
- Updates `docs/INTEGRATION_STATUS.md` with the routing baseline.
- Keeps runtime ownership with AgentPlane.
- Keeps policy/guardrail ownership with Policy Fabric and Guardrail Fabric.
- Keeps delivery metrics and scoreboards out of SocioSphere.

## Validation

Docs-only routing change. No runtime behavior changed.

Branch note: this branch is 2 commits ahead and 1 behind current `main`; if GitHub reports it as unmergeable, rebase/update before merge.

## Related

- SocioProphet/delivery-excellence#9
- SocioProphet/delivery-excellence-automation#7