### PR TITLE
registry: add FogStack state coherence record

### DIFF
--- a/.github/workflows/state-coherence-registry.yml
+++ b/.github/workflows/state-coherence-registry.yml
@@ -1,0 +1,26 @@
+name: state-coherence-registry
+
+on:
+  pull_request:
+    paths:
+      - "registry/state-coherence/**"
+      - "tools/validate_state_coherence_registry.py"
+      - ".github/workflows/state-coherence-registry.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "registry/state-coherence/**"
+      - "tools/validate_state_coherence_registry.py"
+      - ".github/workflows/state-coherence-registry.yml"
+
+jobs:
+  validate-state-coherence-registry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate state coherence registry
+        run: python3 tools/validate_state_coherence_registry.py

--- a/registry/state-coherence/fogstack-local-demo-state-coherence-v0.1.json
+++ b/registry/state-coherence/fogstack-local-demo-state-coherence-v0.1.json
@@ -1,0 +1,62 @@
+{
+  "kind": "SociosphereStateCoherenceRecord",
+  "schema_version": "v0.1",
+  "record_id": "state-coherence:fogstack-local-demo:2026-05-05",
+  "subject_ref": "github://SocioProphet/prophet-platform/pull/420",
+  "subject_commit": "5ba5b28f65545cc700da82b53186337c3bac1af9",
+  "status": "merged",
+  "posture": "compressed-estate-demo-coherence",
+  "demo_boundary": "bounded-local-non-mutating",
+  "production_boundary": "live mutation, production signing, network registry publication, and managed multi-tenant operations remain post-MVP",
+  "canonical_demo_command": "make fogstack-local-demo-full",
+  "emitted_summary": "build/fogstack-local-demo/fogstack-local-demo.full.summary.json",
+  "emitted_section": "state_coherence",
+  "repo_refs": [
+    "github://SocioProphet/prophet-platform",
+    "github://SocioProphet/sociosphere",
+    "github://SourceOS-Linux/sourceos-syncd",
+    "github://SourceOS-Linux/agent-machine",
+    "github://SourceOS-Linux/BearBrowser",
+    "github://SocioProphet/guardrail-fabric",
+    "github://SocioProphet/agentplane",
+    "github://SocioProphet/ontogenesis"
+  ],
+  "integration_surfaces": [
+    "release-proof-to-runtime-evidence",
+    "gitops-readiness-to-local-demo-summary",
+    "runtime-dry-run-to-agentplane-run-linkage",
+    "runtime-dry-run-to-policyplane-decision-linkage",
+    "agent-machine-node-profile-to-runtime-adapter",
+    "immutable-update-readiness-to-demo-artifact-index",
+    "sourceos-state-integrity-to-supporting-evidence-plane",
+    "guardrail-decision-abi-to-policy-boundary",
+    "operator-surfaces-to-sourceos-node-profile",
+    "semantic-contracts-to-governed-evidence-plane"
+  ],
+  "validation_evidence": {
+    "prophet_platform_pr": 420,
+    "merged_commit": "5ba5b28f65545cc700da82b53186337c3bac1af9",
+    "checks": [
+      "validate",
+      "ci",
+      "FogStack Local Demo",
+      "FogStack Release Proof",
+      "FogStack Release Proof Canonical Refs",
+      "FogStack Wider Release Graph",
+      "platform-contracts-check",
+      "premerge-audit",
+      "brokerage-validation",
+      "platform-wave1-stubs",
+      "workspace-operation-runtime",
+      "cloudshell-fog structural conformance v2",
+      "cloudshell-fog structural conformance v3"
+    ]
+  },
+  "acceptance": [
+    "FogStack full local demo summary emits state_coherence",
+    "state_coherence names the compressed estate repo refs",
+    "state_coherence names the required integration surfaces",
+    "focused test asserts the state_coherence posture and repo refs",
+    "superseded stale PR 417 is closed"
+  ]
+}

--- a/tools/validate_state_coherence_registry.py
+++ b/tools/validate_state_coherence_registry.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_DIR = ROOT / "registry" / "state-coherence"
+
+REQUIRED_REPO_REFS = {
+    "github://SocioProphet/prophet-platform",
+    "github://SocioProphet/sociosphere",
+    "github://SourceOS-Linux/sourceos-syncd",
+    "github://SourceOS-Linux/agent-machine",
+    "github://SourceOS-Linux/BearBrowser",
+    "github://SocioProphet/guardrail-fabric",
+    "github://SocioProphet/agentplane",
+    "github://SocioProphet/ontogenesis",
+}
+
+REQUIRED_SURFACES = {
+    "release-proof-to-runtime-evidence",
+    "gitops-readiness-to-local-demo-summary",
+    "runtime-dry-run-to-agentplane-run-linkage",
+    "runtime-dry-run-to-policyplane-decision-linkage",
+    "agent-machine-node-profile-to-runtime-adapter",
+    "immutable-update-readiness-to-demo-artifact-index",
+    "sourceos-state-integrity-to-supporting-evidence-plane",
+    "guardrail-decision-abi-to-policy-boundary",
+    "operator-surfaces-to-sourceos-node-profile",
+    "semantic-contracts-to-governed-evidence-plane",
+}
+
+REQUIRED_CHECKS = {
+    "validate",
+    "ci",
+    "FogStack Local Demo",
+    "FogStack Release Proof",
+    "FogStack Release Proof Canonical Refs",
+    "FogStack Wider Release Graph",
+    "platform-contracts-check",
+    "premerge-audit",
+    "brokerage-validation",
+    "platform-wave1-stubs",
+    "workspace-operation-runtime",
+}
+
+
+def fail(path: Path, message: str) -> None:
+    raise SystemExit(f"{path}: {message}")
+
+
+def require_str(record: dict[str, Any], key: str, path: Path) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(path, f"missing non-empty string field: {key}")
+    return value
+
+
+def require_list(record: dict[str, Any], key: str, path: Path) -> list[Any]:
+    value = record.get(key)
+    if not isinstance(value, list) or not value:
+        fail(path, f"missing non-empty list field: {key}")
+    return value
+
+
+def validate_record(path: Path) -> None:
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(path, f"invalid JSON: {exc}")
+
+    if not isinstance(record, dict):
+        fail(path, "record must be a JSON object")
+
+    if record.get("kind") != "SociosphereStateCoherenceRecord":
+        fail(path, "kind must be SociosphereStateCoherenceRecord")
+    if record.get("schema_version") != "v0.1":
+        fail(path, "schema_version must be v0.1")
+    if record.get("status") not in {"proposed", "merged", "superseded"}:
+        fail(path, "status must be proposed, merged, or superseded")
+
+    for key in (
+        "record_id",
+        "subject_ref",
+        "subject_commit",
+        "posture",
+        "demo_boundary",
+        "production_boundary",
+        "canonical_demo_command",
+        "emitted_summary",
+        "emitted_section",
+    ):
+        require_str(record, key, path)
+
+    if record["posture"] != "compressed-estate-demo-coherence":
+        fail(path, "posture must be compressed-estate-demo-coherence")
+    if record["demo_boundary"] != "bounded-local-non-mutating":
+        fail(path, "demo_boundary must be bounded-local-non-mutating")
+    if record["canonical_demo_command"] != "make fogstack-local-demo-full":
+        fail(path, "canonical_demo_command must be make fogstack-local-demo-full")
+    if record["emitted_section"] != "state_coherence":
+        fail(path, "emitted_section must be state_coherence")
+
+    repo_refs = set(require_list(record, "repo_refs", path))
+    if not REQUIRED_REPO_REFS.issubset(repo_refs):
+        missing = sorted(REQUIRED_REPO_REFS - repo_refs)
+        fail(path, f"missing required repo_refs: {missing}")
+
+    integration_surfaces = set(require_list(record, "integration_surfaces", path))
+    if not REQUIRED_SURFACES.issubset(integration_surfaces):
+        missing = sorted(REQUIRED_SURFACES - integration_surfaces)
+        fail(path, f"missing required integration_surfaces: {missing}")
+
+    validation_evidence = record.get("validation_evidence")
+    if not isinstance(validation_evidence, dict):
+        fail(path, "validation_evidence must be an object")
+    if validation_evidence.get("prophet_platform_pr") != 420:
+        fail(path, "validation_evidence.prophet_platform_pr must be 420")
+    if validation_evidence.get("merged_commit") != record.get("subject_commit"):
+        fail(path, "validation_evidence.merged_commit must match subject_commit")
+    checks = set(validation_evidence.get("checks", []))
+    if not REQUIRED_CHECKS.issubset(checks):
+        missing = sorted(REQUIRED_CHECKS - checks)
+        fail(path, f"missing validation checks: {missing}")
+
+    acceptance = require_list(record, "acceptance", path)
+    if len(acceptance) < 3:
+        fail(path, "acceptance must contain at least three statements")
+
+
+def main() -> int:
+    if not REGISTRY_DIR.exists():
+        fail(REGISTRY_DIR, "registry directory missing")
+    records = sorted(REGISTRY_DIR.glob("*.json"))
+    if not records:
+        fail(REGISTRY_DIR, "no state coherence records found")
+    for record in records:
+        validate_record(record)
+    print(f"validated {len(records)} state coherence record(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Registers the merged Prophet Platform FogStack state-coherence local demo patch in Sociosphere.

## What changed

Adds:
- `registry/state-coherence/fogstack-local-demo-state-coherence-v0.1.json`
- `tools/validate_state_coherence_registry.py`
- `.github/workflows/state-coherence-registry.yml`

The record points to `SocioProphet/prophet-platform` PR #420 and merge commit `5ba5b28f65545cc700da82b53186337c3bac1af9`, and captures the state-coherence repo refs plus integration surfaces now emitted by the full FogStack local demo summary.

## Boundary

Registry and validation only. No runtime mutation and no product-surface change.

## State coherence impact

Moves the new Prophet Platform state-coherence summary from platform-local output into Sociosphere control-plane visibility.

Estimated remaining turns to stable state coherence v1 after this PR: 2.