### PR TITLE
Scaffold Identity Is Prime, Regis, and ACR conformance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,12 @@ topology-check:
 proof-slice-smoke:
 	python3 tools/runner/proof_slice_smoke.py
 
+# --- identity conformance targets ---
+.PHONY: identity-prime-conformance
+
+identity-prime-conformance:
+	python3 tools/conformance/validate_identity_is_prime_fixtures.py
+
 # --- hygiene targets ---
 .PHONY: hygiene-check
 
@@ -190,5 +196,5 @@ hygiene-check:
 # --- full workspace check (run in CI) ---
 .PHONY: workspace-check
 
-workspace-check: validate registry-validate build-intelligence-validate deployment-topology-validate contract-lock-validate compliance-check source-exposure-check lock-verify topology-check hygiene-check
+workspace-check: validate registry-validate build-intelligence-validate deployment-topology-validate contract-lock-validate compliance-check source-exposure-check lock-verify topology-check hygiene-check identity-prime-conformance
 	@echo "OK: workspace-check passed"

--- a/docs/architecture/identity-is-prime-regis-acr-sociosphere.md
+++ b/docs/architecture/identity-is-prime-regis-acr-sociosphere.md
@@ -4,7 +4,7 @@ Issue: https://github.com/SocioProphet/sociosphere/issues/284
 
 ## Purpose
 
-This document defines the Sociosphere integration spine for the Identity Is Prime reference implementation, Regis Entity Graph, Authority Concordance Rex (ACR), and Agent Registry. Sociosphere is the cross-repo workspace controller: it pins repositories, executes validation, records conformance, and provides deterministic retest lanes.
+This document defines the Sociosphere integration spine for the Identity Is Prime reference implementation, Regis Entity Graph, Authority Concordance Rex (ACR), Agent Registry, Holmes, and Sherlock Search. Sociosphere is the cross-repo workspace controller: it pins repositories, executes validation, records conformance, and provides deterministic retest lanes.
 
 The integration is not a centralized lakehouse design. The runtime target is local-first and cache-first: assertion cache, crosswalk cache, golden projection cache, delta cursors, proof artifacts, and certificate ledgers. Sociosphere coordinates the workspace and retest evidence; it does not become the data warehouse.
 
@@ -13,8 +13,10 @@ The integration is not a centralized lakehouse design. The runtime target is loc
 1. Identity Is Prime is the doctrine and reference implementation. It defines prime-topic identity, Event-IR, policy polytopes, congruence lanes, non-escape semantics, proof artifacts, and fog-first deployment.
 2. Regis Entity Graph is the graph implementation surface. It stores canonical entities, source records, identity states, concordance links, transition edges, decision ledger entries, and proof certificates.
 3. ACR is the authority concordance service profile. It owns versioned authority templates, connector schema evolution, entity resolution, crosswalks, golden projections, and point-in-time proofs.
-4. Agent Registry declares the agents that observe, normalize, classify, resolve, evaluate, prove, and audit. Agents submit observations, decisions, proposed graph mutations, and certificates. They do not free-write canonical truth.
-5. Sociosphere coordinates and retests the full estate through its manifest, lock file, runner, workspace policy, and protocol fixtures.
+4. Holmes is the investigative/evidence-reasoning layer for Regis. It should consume Regis graph state, proof artifacts, ledger entries, policy decisions, and contradiction/refutation events to form explainable investigative cases.
+5. Sherlock Search is the retrieval and search surface for Regis/Holmes evidence. It should index entities, events, assertions, certificates, source records, crosswalks, and decision-ledger entries without becoming canonical truth.
+6. Agent Registry declares the agents that observe, normalize, classify, resolve, retrieve, reason, prove, and audit. Agents submit observations, search results, decisions, proposed graph mutations, and certificates. They do not free-write canonical truth.
+7. Sociosphere coordinates and retests the full estate through its manifest, lock file, runner, workspace policy, and protocol fixtures.
 
 ## Existing upstream anchors
 
@@ -30,7 +32,7 @@ The Sociosphere manifest already contains the following relevant repositories:
 - `sourceos-spec`
 - `policy-fabric`
 
-The manifest should also include `agent-registry` as a first-class component if it is not already materialized through another repo entry.
+The manifest should also include `agent-registry`, `holmes`, and `sherlock-search` as first-class components or focused lane overlay entries if they are not already materialized through another repo entry.
 
 ## Integration contracts
 
@@ -67,6 +69,33 @@ Regis consumes Identity Is Prime as graph semantics. Required graph object famil
 - `TransitionCertificate`
 - `NonEscapeCertificate`
 - `ConcordanceDecisionCertificate`
+- `SearchIndexRecord`
+- `InvestigationCase`
+- `EvidenceFinding`
+
+### Holmes reasoning layer
+
+Holmes should be the Regis-native investigative reasoning surface. Its responsibilities are:
+
+- consume Regis graph snapshots and ledger/certificate pointers
+- assemble evidence findings into investigation cases
+- explain why a linkage was verified, refuted, undecidable, stale, or review-bound
+- detect contradictions across ACR concordance, identity polytope policy, token non-escape, and source assertions
+- emit proposed graph annotations or case findings, not canonical truth
+
+Holmes outputs must be reducible to Regis evidence objects and must carry policy/schema/resolver/template version pins.
+
+### Sherlock Search retrieval layer
+
+Sherlock Search should be the retrieval layer for evidence discovery and operator/user query. Its responsibilities are:
+
+- index canonical entities, source records, identity states, worldline events, ledger entries, certificates, and Holmes findings
+- provide search over proof and evidence surfaces
+- return cited graph pointers, source pointers, and ledger pointers
+- support delta indexing for local-first/cache-first runtime
+- avoid writing canonical entity truth directly
+
+Sherlock Search should be treated as an indexing and retrieval adapter for Regis/Holmes, not as the system of record.
 
 ### ACR service profile
 
@@ -97,8 +126,12 @@ Required agent families:
 - `regis-proof-agent`
 - `regis-policy-agent`
 - `regis-steward-agent`
+- `holmes-case-agent`
+- `holmes-contradiction-agent`
+- `sherlock-index-agent`
+- `sherlock-query-agent`
 
-Each manifest must declare input schemas, output schemas, graph write permissions, policy scopes, TRIT RPC bindings, and evidence outputs. A manifest that lacks the required policy scope must be rejected by conformance.
+Each manifest must declare input schemas, output schemas, graph write permissions, policy scopes, TRIT RPC bindings, retrieval permissions, and evidence outputs. A manifest that lacks the required policy scope or graph/search permission must be rejected by conformance.
 
 ## Sociosphere conformance lanes
 
@@ -110,10 +143,12 @@ The Sociosphere retest controller should expose these lanes:
 4. `identity-prime-token`: validates congruence and token non-escape cases.
 5. `identity-prime-audit`: validates zeta-style identity audit summaries.
 6. `regis-graph-contracts`: validates Regis graph objects and proof certificate pointers.
-7. `agent-registry-identity`: validates agent manifests and policy scopes.
-8. `acr-concordance-profile`: validates source assertion, crosswalk, golden projection, and proof fixtures.
-9. `tritrpc-wire`: verifies deterministic request/response fixture encoding.
-10. `workspace-identity-conformance`: runs the clean end-to-end lane across pinned repos.
+7. `holmes-case-contracts`: validates Holmes case/finding outputs against Regis evidence semantics.
+8. `sherlock-index-contracts`: validates Sherlock index records, search result pointers, and delta indexing receipts.
+9. `agent-registry-identity`: validates agent manifests and policy scopes.
+10. `acr-concordance-profile`: validates source assertion, crosswalk, golden projection, and proof fixtures.
+11. `tritrpc-wire`: verifies deterministic request/response fixture encoding.
+12. `workspace-identity-conformance`: runs the clean end-to-end lane across pinned repos.
 
 ## Required fixture families
 
@@ -127,6 +162,8 @@ Fixtures live under `protocol/identity-is-prime/` and should be portable across 
 - token non-escape violation examples
 - zeta audit windows
 - ACR concordance and golden record proof examples
+- Holmes case and contradiction examples
+- Sherlock search index and query-result pointer examples
 
 ## Determinism requirements
 
@@ -136,6 +173,8 @@ Every conformance result must pin:
 - `policy_version`
 - `resolver_version`
 - `template_version`, when ACR participates
+- `index_version`, when Sherlock Search participates
+- `case_model_version`, when Holmes participates
 - `fixture_version`
 - `input_hash`
 - `result_hash`
@@ -145,17 +184,19 @@ A repeated clean checkout with the same pins must produce equivalent results.
 
 ## Acceptance criteria
 
-- Sociosphere can fetch the pinned repos and execute the Identity Is Prime / Regis / ACR / Agent Registry conformance suite.
+- Sociosphere can fetch the pinned repos and execute the Identity Is Prime / Regis / Holmes / Sherlock / ACR / Agent Registry conformance suite.
 - Identity polytope fixtures return deterministic `VERIFIED` or `REFUTED` results.
 - Token non-escape violations produce structural refutations rather than probabilistic scores.
 - ACR golden record proof fixtures include shared ledger and certificate pointers.
-- Agent manifests without required policy scopes are rejected.
+- Holmes findings cite Regis graph, ledger, certificate, or source pointers.
+- Sherlock search results cite indexed Regis/Holmes pointers and never claim canonical truth without graph/ledger backing.
+- Agent manifests without required policy scopes, graph permissions, or search permissions are rejected.
 - The integration remains local-first and cache-first; no central lakehouse dependency is introduced.
 
 ## Follow-on work
 
-1. Materialize `agent-registry` in `manifest/workspace.toml` if absent.
+1. Materialize `agent-registry`, `holmes`, and `sherlock-search` in `manifest/workspace.toml` or the focused Identity Prime workspace overlay if absent.
 2. Add executable validators under `tools/conformance/`.
 3. Promote the fixture skeleton into schema-backed JSON validation.
-4. Add TRIT RPC fixtures for `identityprime.v1`, `regis.proof.v1`, and `acr.concordance.v1`.
+4. Add TRIT RPC fixtures for `identityprime.v1`, `regis.proof.v1`, `holmes.case.v1`, `sherlock.search.v1`, and `acr.concordance.v1`.
 5. Wire conformance outputs into the Sociosphere registry/evidence pattern.

--- a/docs/architecture/identity-is-prime-regis-acr-sociosphere.md
+++ b/docs/architecture/identity-is-prime-regis-acr-sociosphere.md
@@ -1,0 +1,161 @@
+# Identity Is Prime × Regis × ACR × Sociosphere Integration
+
+Issue: https://github.com/SocioProphet/sociosphere/issues/284
+
+## Purpose
+
+This document defines the Sociosphere integration spine for the Identity Is Prime reference implementation, Regis Entity Graph, Authority Concordance Rex (ACR), and Agent Registry. Sociosphere is the cross-repo workspace controller: it pins repositories, executes validation, records conformance, and provides deterministic retest lanes.
+
+The integration is not a centralized lakehouse design. The runtime target is local-first and cache-first: assertion cache, crosswalk cache, golden projection cache, delta cursors, proof artifacts, and certificate ledgers. Sociosphere coordinates the workspace and retest evidence; it does not become the data warehouse.
+
+## Architectural hierarchy
+
+1. Identity Is Prime is the doctrine and reference implementation. It defines prime-topic identity, Event-IR, policy polytopes, congruence lanes, non-escape semantics, proof artifacts, and fog-first deployment.
+2. Regis Entity Graph is the graph implementation surface. It stores canonical entities, source records, identity states, concordance links, transition edges, decision ledger entries, and proof certificates.
+3. ACR is the authority concordance service profile. It owns versioned authority templates, connector schema evolution, entity resolution, crosswalks, golden projections, and point-in-time proofs.
+4. Agent Registry declares the agents that observe, normalize, classify, resolve, evaluate, prove, and audit. Agents submit observations, decisions, proposed graph mutations, and certificates. They do not free-write canonical truth.
+5. Sociosphere coordinates and retests the full estate through its manifest, lock file, runner, workspace policy, and protocol fixtures.
+
+## Existing upstream anchors
+
+The Sociosphere manifest already contains the following relevant repositories:
+
+- `identity-is-prime-reference`
+- `regis-entity-graph`
+- `tritrpc`
+- `agentplane`
+- `human_digital_twin`
+- `ontogenesis`
+- `socioprophet_standards_storage`
+- `sourceos-spec`
+- `policy-fabric`
+
+The manifest should also include `agent-registry` as a first-class component if it is not already materialized through another repo entry.
+
+## Integration contracts
+
+### Identity Is Prime reference
+
+The reference repo provides the normative behavior for:
+
+- Event-IR ingestion
+- fog-first scope classes
+- prime-topic labeling
+- policy-constrained entity resolution
+- policy polytope checks
+- congruence lanes for modular evidence
+- proof artifact production
+- zeta-style identity-state audit metrics
+
+### Regis Entity Graph
+
+Regis consumes Identity Is Prime as graph semantics. Required graph object families:
+
+- `CanonicalEntity`
+- `SourceRecord`
+- `ConcordanceLink`
+- `DecisionLedgerEntry`
+- `IdentityPrime`
+- `ScopeFlag`
+- `IdentityState`
+- `IdentityMixture`
+- `IdentityPolytope`
+- `WorldlineEvent`
+- `AdmissibleTransition`
+- `TokenLane`
+- `ProofCertificate`
+- `TransitionCertificate`
+- `NonEscapeCertificate`
+- `ConcordanceDecisionCertificate`
+
+### ACR service profile
+
+ACR supplies mastered entity truth and proof-carrying concordance:
+
+- authority template versions
+- connector schema versions
+- schema migration records
+- source assertions
+- source-to-canonical crosswalks
+- golden record projections
+- point-in-time golden record proofs
+- template migration simulations
+
+### Agent Registry
+
+Required agent families:
+
+- `prime-topic-agent`
+- `identity-polytope-agent`
+- `transition-graph-agent`
+- `congruence-non-escape-agent`
+- `zeta-audit-agent`
+- `acr-template-agent`
+- `acr-connector-agent`
+- `acr-concordance-agent`
+- `acr-golden-projection-agent`
+- `regis-proof-agent`
+- `regis-policy-agent`
+- `regis-steward-agent`
+
+Each manifest must declare input schemas, output schemas, graph write permissions, policy scopes, TRIT RPC bindings, and evidence outputs. A manifest that lacks the required policy scope must be rejected by conformance.
+
+## Sociosphere conformance lanes
+
+The Sociosphere retest controller should expose these lanes:
+
+1. `identity-prime-schema`: validates Identity Is Prime fixtures and schemas.
+2. `identity-prime-policy`: evaluates polytope membership and forbidden mixtures.
+3. `identity-prime-transition`: validates admissible transition and no-path cases.
+4. `identity-prime-token`: validates congruence and token non-escape cases.
+5. `identity-prime-audit`: validates zeta-style identity audit summaries.
+6. `regis-graph-contracts`: validates Regis graph objects and proof certificate pointers.
+7. `agent-registry-identity`: validates agent manifests and policy scopes.
+8. `acr-concordance-profile`: validates source assertion, crosswalk, golden projection, and proof fixtures.
+9. `tritrpc-wire`: verifies deterministic request/response fixture encoding.
+10. `workspace-identity-conformance`: runs the clean end-to-end lane across pinned repos.
+
+## Required fixture families
+
+Fixtures live under `protocol/identity-is-prime/` and should be portable across repos.
+
+- polytope valid and invalid examples
+- forbidden mixture examples
+- admissible transition examples
+- no-admissible-path refutations
+- token non-escape valid examples
+- token non-escape violation examples
+- zeta audit windows
+- ACR concordance and golden record proof examples
+
+## Determinism requirements
+
+Every conformance result must pin:
+
+- `schema_version`
+- `policy_version`
+- `resolver_version`
+- `template_version`, when ACR participates
+- `fixture_version`
+- `input_hash`
+- `result_hash`
+- `certificate_hash`, when a proof is emitted
+
+A repeated clean checkout with the same pins must produce equivalent results.
+
+## Acceptance criteria
+
+- Sociosphere can fetch the pinned repos and execute the Identity Is Prime / Regis / ACR / Agent Registry conformance suite.
+- Identity polytope fixtures return deterministic `VERIFIED` or `REFUTED` results.
+- Token non-escape violations produce structural refutations rather than probabilistic scores.
+- ACR golden record proof fixtures include shared ledger and certificate pointers.
+- Agent manifests without required policy scopes are rejected.
+- The integration remains local-first and cache-first; no central lakehouse dependency is introduced.
+
+## Follow-on work
+
+1. Materialize `agent-registry` in `manifest/workspace.toml` if absent.
+2. Add executable validators under `tools/conformance/`.
+3. Promote the fixture skeleton into schema-backed JSON validation.
+4. Add TRIT RPC fixtures for `identityprime.v1`, `regis.proof.v1`, and `acr.concordance.v1`.
+5. Wire conformance outputs into the Sociosphere registry/evidence pattern.

--- a/manifest/identity-prime-workspace.toml
+++ b/manifest/identity-prime-workspace.toml
@@ -1,10 +1,11 @@
-# Identity Is Prime / Regis / ACR conformance workspace overlay.
+# Identity Is Prime / Regis / ACR / Holmes / Sherlock conformance workspace overlay.
 #
 # This overlay records the additional materialized repository dependencies for
 # the Sociosphere conformance lane introduced by issue #284 and PR #285.
 # The canonical workspace manifest already contains identity-is-prime-reference
-# and regis-entity-graph. This overlay adds the Agent Registry materialization
-# requirement without disturbing the broad canonical manifest in this scaffold PR.
+# and regis-entity-graph. This overlay adds the Agent Registry, Holmes, and
+# Sherlock Search materialization requirements without disturbing the broad
+# canonical manifest in this scaffold PR.
 
 [[repos]]
 name = "agent_registry"
@@ -50,4 +51,34 @@ required_capabilities = [
   "concordance_link",
   "decision_ledger",
   "proof_certificate",
+]
+
+[[repos]]
+name = "holmes"
+role = "component"
+url = "https://github.com/SocioProphet/holmes"
+ref = "main"
+local_path = "components/holmes"
+license_hint = "MIT"
+required_capabilities = [
+  "case_reasoning",
+  "evidence_finding",
+  "contradiction_detection",
+  "ledger_pointer",
+  "proof_explanation",
+]
+
+[[repos]]
+name = "sherlock_search"
+role = "component"
+url = "https://github.com/SocioProphet/sherlock-search"
+ref = "main"
+local_path = "components/sherlock_search"
+license_hint = "MIT"
+required_capabilities = [
+  "index_record",
+  "search_query",
+  "delta_indexing",
+  "source_pointer",
+  "ledger_pointer",
 ]

--- a/manifest/identity-prime-workspace.toml
+++ b/manifest/identity-prime-workspace.toml
@@ -1,0 +1,53 @@
+# Identity Is Prime / Regis / ACR conformance workspace overlay.
+#
+# This overlay records the additional materialized repository dependencies for
+# the Sociosphere conformance lane introduced by issue #284 and PR #285.
+# The canonical workspace manifest already contains identity-is-prime-reference
+# and regis-entity-graph. This overlay adds the Agent Registry materialization
+# requirement without disturbing the broad canonical manifest in this scaffold PR.
+
+[[repos]]
+name = "agent_registry"
+role = "component"
+url = "https://github.com/SocioProphet/agent-registry"
+ref = "main"
+local_path = "components/agent_registry"
+license_hint = "MIT"
+trust_zone = "control"
+trust_profile_ref = "protocol/agentic-workbench/v1/trust_profiles/control-plane.v0.1.json"
+required_capabilities = [
+  "agent_manifest",
+  "policy_scope",
+  "tritrpc_binding",
+  "evidence_output",
+]
+
+[[repos]]
+name = "identity_is_prime_reference"
+role = "component"
+url = "https://github.com/SocioProphet/identity-is-prime-reference"
+ref = "main"
+local_path = "components/identity_is_prime_reference"
+license_hint = "MIT"
+required_capabilities = [
+  "event_ir",
+  "prime_topic_labeling",
+  "policy_polytope",
+  "congruence_lane",
+  "proof_artifact",
+]
+
+[[repos]]
+name = "regis_entity_graph"
+role = "component"
+url = "https://github.com/SocioProphet/regis-entity-graph"
+ref = "main"
+local_path = "components/regis_entity_graph"
+license_hint = "MIT"
+required_capabilities = [
+  "canonical_entity",
+  "identity_state",
+  "concordance_link",
+  "decision_ledger",
+  "proof_certificate",
+]

--- a/manifest/identity-prime-workspace.toml
+++ b/manifest/identity-prime-workspace.toml
@@ -1,11 +1,11 @@
-# Identity Is Prime / Regis / ACR / Holmes / Sherlock conformance workspace overlay.
+# Identity Is Prime / Regis / ACR / Holmes / Sherlock / MeshRush conformance workspace overlay.
 #
 # This overlay records the additional materialized repository dependencies for
 # the Sociosphere conformance lane introduced by issue #284 and PR #285.
 # The canonical workspace manifest already contains identity-is-prime-reference
-# and regis-entity-graph. This overlay adds the Agent Registry, Holmes, and
-# Sherlock Search materialization requirements without disturbing the broad
-# canonical manifest in this scaffold PR.
+# and regis-entity-graph. This overlay adds the Agent Registry, Holmes,
+# Sherlock Search, and MeshRush materialization requirements without disturbing
+# the broad canonical manifest in this scaffold PR.
 
 [[repos]]
 name = "agent_registry"
@@ -81,4 +81,21 @@ required_capabilities = [
   "delta_indexing",
   "source_pointer",
   "ledger_pointer",
+]
+
+[[repos]]
+name = "meshrush"
+role = "component"
+url = "https://github.com/SocioProphet/meshrush"
+ref = "main"
+local_path = "components/meshrush"
+license_hint = "MIT"
+required_capabilities = [
+  "graph_entry",
+  "graph_traversal",
+  "bounded_diffusion",
+  "stop_condition",
+  "crystallization",
+  "simulation_trace",
+  "evidence_trace",
 ]

--- a/protocol/identity-is-prime/README.md
+++ b/protocol/identity-is-prime/README.md
@@ -1,0 +1,44 @@
+# Identity Is Prime protocol fixtures
+
+These fixtures anchor the Sociosphere conformance lane for Identity Is Prime, Regis Entity Graph, Authority Concordance Rex (ACR), and Agent Registry integration.
+
+The fixture set is intentionally small in this first pass. It establishes deterministic semantics for:
+
+- policy polytope membership
+- forbidden identity mixtures
+- token congruence and non-escape violations
+- ACR golden-record proof shape
+
+Each fixture should eventually be backed by executable validators under `tools/conformance/` and by TRIT RPC request/response fixtures for the relevant service surfaces.
+
+## Required result vocabulary
+
+- `VERIFIED`: the claim or state satisfies the pinned policy and schema versions.
+- `REFUTED`: the claim or state structurally violates policy, admissibility, or non-escape rules.
+- `UNDECIDABLE`: the current abstraction lacks enough evidence to prove or refute.
+- `STALE`: the fixture or certificate pins outdated schema, policy, resolver, or template versions.
+- `REQUIRES_REVIEW`: the fixture requires steward review before graph mutation or publication.
+
+## Determinism fields
+
+Conformance outputs should pin the following where available:
+
+- `schema_version`
+- `policy_version`
+- `resolver_version`
+- `template_version`
+- `fixture_version`
+- `input_hash`
+- `result_hash`
+- `certificate_hash`
+- `ledger_pointer`
+
+## First fixture families
+
+- `fixtures/polytope.valid.json`
+- `fixtures/polytope.invalid.json`
+- `fixtures/token.non_escape.violation.json`
+- `fixtures/acr.golden_record.proof.json`
+- `expected/polytope.valid.result.json`
+
+Follow-on fixtures should add transition graph, no-admissible-path, zeta audit, agent manifest rejection, and TRIT RPC wire examples.

--- a/protocol/identity-is-prime/expected/polytope.valid.result.json
+++ b/protocol/identity-is-prime/expected/polytope.valid.result.json
@@ -1,0 +1,7 @@
+{
+  "fixture_id": "identity-prime.polytope.valid.v0.1",
+  "result": "VERIFIED",
+  "violations": [],
+  "policy_version": "regis.identity.polytope.core@0.1.0",
+  "schema_version": "identity-mixture.v0.1"
+}

--- a/protocol/identity-is-prime/fixtures/acr.golden_record.proof.json
+++ b/protocol/identity-is-prime/fixtures/acr.golden_record.proof.json
@@ -1,0 +1,45 @@
+{
+  "fixture_id": "acr.golden_record.proof.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "acr-golden-record-proof.v0.1",
+  "template_version": "authority-template@0.1.0",
+  "policy_version": "acr.survivorship.core@0.1.0",
+  "resolver_version": "acr.resolver.reference@0.1.0",
+  "description": "A source record resolves to a canonical entity and produces a point-in-time golden record proof.",
+  "source_records": [
+    {
+      "source_id": "reference_data",
+      "source_record_id": "C1055",
+      "assertions": {
+        "name": "Tesco",
+        "ticker": "TSCO",
+        "country": "UK"
+      }
+    },
+    {
+      "source_id": "crm",
+      "source_record_id": "C1055598",
+      "assertions": {
+        "name": "Tesco Stores",
+        "ticker": "TSC",
+        "country": "United Kingdom"
+      }
+    }
+  ],
+  "crosswalk": [
+    {"source_id": "reference_data", "source_record_id": "C1055", "ceid": "CEID_TESCO_EXAMPLE"},
+    {"source_id": "crm", "source_record_id": "C1055598", "ceid": "CEID_TESCO_EXAMPLE"}
+  ],
+  "golden_record": {
+    "ceid": "CEID_TESCO_EXAMPLE",
+    "name": "Tesco plc",
+    "ticker": "TSCO",
+    "country": "United Kingdom"
+  },
+  "ledger_pointers": ["DID_LINK_REFERENCE_DATA_C1055", "DID_LINK_CRM_C1055598", "DID_ATTRIBUTE_TICKER_TSCO"],
+  "expected": {
+    "result": "VERIFIED",
+    "certificate_type": "ConcordanceDecisionCertificate",
+    "requires_shared_ledger_pointer": true
+  }
+}

--- a/protocol/identity-is-prime/fixtures/agent.manifest.invalid_missing_policy_scope.json
+++ b/protocol/identity-is-prime/fixtures/agent.manifest.invalid_missing_policy_scope.json
@@ -1,0 +1,25 @@
+{
+  "fixture_id": "agent.manifest.invalid_missing_policy_scope.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "agent-manifest.v0.1",
+  "policy_version": "regis.agent.manifest.core@0.1.0",
+  "description": "An invalid agent manifest that attempts to participate in the identity evidence lane without declaring required policy scopes.",
+  "agent": {
+    "agent_id": "unsafe-evidence-agent-without-policy-scope",
+    "version": "0.1.0",
+    "role": "evidence_lane_agent",
+    "inputs": ["RegisGraphView"],
+    "outputs": ["SearchResult"],
+    "policy_scopes": [],
+    "graph_permissions": ["read:regis_graph_view"],
+    "search_permissions": ["write:sherlock_index_record"],
+    "evidence_outputs": ["trace_pointer"],
+    "tritrpc_services": ["sherlock.search.v1.IndexEvidenceRecord"],
+    "cannot_write": ["canonical_entity_truth"]
+  },
+  "expected": {
+    "result": "REFUTED",
+    "artifact_type": "AgentManifest",
+    "violations": ["MISSING_POLICY_SCOPE"]
+  }
+}

--- a/protocol/identity-is-prime/fixtures/agent.manifest.valid.json
+++ b/protocol/identity-is-prime/fixtures/agent.manifest.valid.json
@@ -1,0 +1,62 @@
+{
+  "fixture_id": "agent.manifest.valid.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "agent-manifest.v0.1",
+  "policy_version": "regis.agent.manifest.core@0.1.0",
+  "description": "A valid registered agent manifest for the MeshRush-to-Holmes-to-Sherlock identity evidence lane.",
+  "agent": {
+    "agent_id": "meshrush-holmes-sherlock-evidence-agent",
+    "version": "0.1.0",
+    "role": "evidence_lane_agent",
+    "inputs": [
+      "RegisGraphView",
+      "IdentityState",
+      "TokenLane",
+      "ProofCertificate"
+    ],
+    "outputs": [
+      "MeshRushSimulationTrace",
+      "InvestigationCase",
+      "SearchIndexRecord",
+      "SearchResult"
+    ],
+    "policy_scopes": [
+      "regis.transition.admissibility.core@0.1.0",
+      "regis.token.non_escape.core@0.1.0",
+      "regis.search.evidence_pointer.core@0.1.0"
+    ],
+    "graph_permissions": [
+      "read:regis_graph_view",
+      "write:proposed_graph_annotation"
+    ],
+    "search_permissions": [
+      "write:sherlock_index_record",
+      "read:sherlock_query_result"
+    ],
+    "evidence_outputs": [
+      "ledger_pointer",
+      "certificate_pointer",
+      "trace_pointer"
+    ],
+    "tritrpc_services": [
+      "identityprime.v1.EvaluateIdentityMixture",
+      "regis.proof.v1.VerifyCertificate",
+      "meshrush.simulation.v1.RunGraphExploration",
+      "holmes.case.v1.OpenInvestigationCase",
+      "sherlock.search.v1.IndexEvidenceRecord"
+    ],
+    "cannot_write": [
+      "canonical_entity_truth",
+      "golden_record_truth_without_acr",
+      "regis_graph_truth_without_policy_reducer"
+    ]
+  },
+  "expected": {
+    "result": "VERIFIED",
+    "artifact_type": "AgentManifest",
+    "requires_policy_scope": true,
+    "requires_graph_permission": true,
+    "requires_search_permission": true,
+    "forbids_direct_canonical_truth_write": true
+  }
+}

--- a/protocol/identity-is-prime/fixtures/holmes.case.from_meshrush_trace.json
+++ b/protocol/identity-is-prime/fixtures/holmes.case.from_meshrush_trace.json
@@ -1,0 +1,39 @@
+{
+  "fixture_id": "holmes.case.from_meshrush_trace.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "holmes-investigation-case.v0.1",
+  "policy_version": "regis.transition.admissibility.core@0.1.0",
+  "case_model_version": "holmes.reference@0.1.0",
+  "description": "Holmes consumes a MeshRush simulation trace and opens an investigation case explaining a blocked patient-token-to-adtech edge.",
+  "input_trace": {
+    "trace_id": "meshrush.trace.patient_token_adtech_block.v0.1",
+    "artifact_type": "MeshRushSimulationTrace",
+    "fixture_ref": "meshrush.graph_exploration.simulation.v0.1",
+    "blocked_edges": ["token_patient_hsm->state_adtech"],
+    "reason_codes": ["FORBIDDEN_EDGE_BLOCKED", "TOKEN_NON_ESCAPE_VIOLATION"]
+  },
+  "case": {
+    "case_id": "HOLMES_CASE_PATIENT_TOKEN_ADTECH_BLOCK_V001",
+    "case_type": "TOKEN_NON_ESCAPE_INVESTIGATION",
+    "status": "OPEN",
+    "findings": [
+      {
+        "finding_id": "FINDING_TOKEN_NON_ESCAPE_ADTECH_V001",
+        "finding_type": "STRUCTURAL_REFUTATION",
+        "summary": "Patient-scoped token lane was blocked from ad-tech scope by MeshRush simulation and Regis token non-escape policy.",
+        "severity": "HIGH",
+        "regis_graph_pointers": ["regis://IdentityState/state_adtech", "regis://TokenLane/token_patient_hsm"],
+        "ledger_pointers": ["DID_TOKEN_NON_ESCAPE_PATIENT_HSM_ADTECH"],
+        "certificate_pointers": ["CERT_NON_ESCAPE_PATIENT_HSM_V001"],
+        "trace_pointers": ["meshrush://trace/meshrush.trace.patient_token_adtech_block.v0.1"]
+      }
+    ]
+  },
+  "expected": {
+    "result": "VERIFIED",
+    "requires_trace_pointer": true,
+    "requires_ledger_pointer": true,
+    "requires_certificate_pointer": true,
+    "artifact_type": "InvestigationCase"
+  }
+}

--- a/protocol/identity-is-prime/fixtures/meshrush.graph_exploration.simulation.json
+++ b/protocol/identity-is-prime/fixtures/meshrush.graph_exploration.simulation.json
@@ -1,0 +1,38 @@
+{
+  "fixture_id": "meshrush.graph_exploration.simulation.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "meshrush-simulation.v0.1",
+  "policy_version": "regis.transition.admissibility.core@0.1.0",
+  "simulation_version": "meshrush.reference@0.1.0",
+  "description": "MeshRush explores a Regis identity/evidence graph and crystallizes an admissible evidence cluster without crossing forbidden patient-to-adtech paths.",
+  "graph_view": {
+    "view_id": "regis_identity_evidence_view_example",
+    "nodes": [
+      {"id": "state_patient_fog", "type": "IdentityState", "primes": ["patient"], "scopes": ["citizen_fog"]},
+      {"id": "event_hospital_portal", "type": "WorldlineEvent", "primes": ["patient"], "scopes": ["hospital_portal"]},
+      {"id": "token_patient_hsm", "type": "TokenLane", "token_class": "patient_scoped"},
+      {"id": "state_adtech", "type": "IdentityState", "scopes": ["ad_tech"]},
+      {"id": "cert_non_escape", "type": "NonEscapeCertificate"}
+    ],
+    "edges": [
+      {"from": "state_patient_fog", "to": "event_hospital_portal", "type": "TRANSITIONS_TO", "admissible": true, "cost": 2.0},
+      {"from": "token_patient_hsm", "to": "event_hospital_portal", "type": "OBSERVED_TOKEN", "admissible": true, "cost": 1.0},
+      {"from": "token_patient_hsm", "to": "state_adtech", "type": "OBSERVED_TOKEN", "admissible": false, "cost": 999.0, "reason_codes": ["TOKEN_NON_ESCAPE_VIOLATION"]},
+      {"from": "cert_non_escape", "to": "token_patient_hsm", "type": "PROVES"}
+    ]
+  },
+  "simulation": {
+    "entry_nodes": ["state_patient_fog"],
+    "exploration_mode": "bounded_diffusion",
+    "stop_conditions": ["max_depth:3", "forbidden_edge", "certificate_boundary"],
+    "crystallization_target": "evidence_cluster",
+    "max_depth": 3
+  },
+  "expected": {
+    "result": "VERIFIED",
+    "visited_nodes": ["state_patient_fog", "event_hospital_portal", "token_patient_hsm", "cert_non_escape"],
+    "blocked_edges": ["token_patient_hsm->state_adtech"],
+    "reason_codes": ["FORBIDDEN_EDGE_BLOCKED", "TOKEN_NON_ESCAPE_VIOLATION"],
+    "artifact_type": "MeshRushSimulationTrace"
+  }
+}

--- a/protocol/identity-is-prime/fixtures/polytope.invalid.json
+++ b/protocol/identity-is-prime/fixtures/polytope.invalid.json
@@ -1,0 +1,24 @@
+{
+  "fixture_id": "identity-prime.polytope.invalid.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "identity-mixture.v0.1",
+  "policy_version": "regis.identity.polytope.core@0.1.0",
+  "description": "Patient context mixed with ad-tech is structurally forbidden.",
+  "basis": {
+    "primes": ["founder_engineer", "patient", "parent", "citizen", "creator"],
+    "scopes": ["citizen_fog", "ad_tech", "employer_telemetry", "exact_gps", "external_egress"]
+  },
+  "mixture": {
+    "primes": {"patient": 1},
+    "scopes": {"ad_tech": 1}
+  },
+  "constraints": [
+    {"id": "no_health_adtech", "expr": "patient + ad_tech <= 1"},
+    {"id": "child_health_gps_no_egress", "expr": "parent + patient + exact_gps + external_egress <= 2"},
+    {"id": "citizen_no_employer_telemetry_mix", "expr": "citizen + employer_telemetry <= 1"}
+  ],
+  "expected": {
+    "result": "REFUTED",
+    "violations": ["no_health_adtech"]
+  }
+}

--- a/protocol/identity-is-prime/fixtures/polytope.valid.json
+++ b/protocol/identity-is-prime/fixtures/polytope.valid.json
@@ -1,0 +1,24 @@
+{
+  "fixture_id": "identity-prime.polytope.valid.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "identity-mixture.v0.1",
+  "policy_version": "regis.identity.polytope.core@0.1.0",
+  "description": "Patient context inside citizen fog without ad-tech or external egress is allowed.",
+  "basis": {
+    "primes": ["founder_engineer", "patient", "parent", "citizen", "creator"],
+    "scopes": ["citizen_fog", "ad_tech", "employer_telemetry", "exact_gps", "external_egress"]
+  },
+  "mixture": {
+    "primes": {"patient": 1},
+    "scopes": {"citizen_fog": 1, "ad_tech": 0, "external_egress": 0}
+  },
+  "constraints": [
+    {"id": "no_health_adtech", "expr": "patient + ad_tech <= 1"},
+    {"id": "child_health_gps_no_egress", "expr": "parent + patient + exact_gps + external_egress <= 2"},
+    {"id": "citizen_no_employer_telemetry_mix", "expr": "citizen + employer_telemetry <= 1"}
+  ],
+  "expected": {
+    "result": "VERIFIED",
+    "violations": []
+  }
+}

--- a/protocol/identity-is-prime/fixtures/sherlock.search.from_holmes_meshrush.json
+++ b/protocol/identity-is-prime/fixtures/sherlock.search.from_holmes_meshrush.json
@@ -1,0 +1,50 @@
+{
+  "fixture_id": "sherlock.search.from_holmes_meshrush.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "sherlock-search-result.v0.1",
+  "policy_version": "regis.search.evidence_pointer.core@0.1.0",
+  "index_version": "sherlock.reference@0.1.0",
+  "description": "Sherlock indexes and returns a pointer-backed search result over a Holmes case derived from a MeshRush simulation trace.",
+  "index_record": {
+    "record_id": "SHERLOCK_INDEX_HOLMES_CASE_PATIENT_TOKEN_ADTECH_BLOCK_V001",
+    "record_type": "EvidenceSearchRecord",
+    "indexed_artifacts": [
+      "holmes://case/HOLMES_CASE_PATIENT_TOKEN_ADTECH_BLOCK_V001",
+      "meshrush://trace/meshrush.trace.patient_token_adtech_block.v0.1",
+      "regis://TokenLane/token_patient_hsm",
+      "regis://IdentityState/state_adtech",
+      "did://DID_TOKEN_NON_ESCAPE_PATIENT_HSM_ADTECH",
+      "cert://CERT_NON_ESCAPE_PATIENT_HSM_V001"
+    ],
+    "claims_canonical_truth": false
+  },
+  "query": {
+    "query_id": "QUERY_PATIENT_TOKEN_ADTECH_EVIDENCE_V001",
+    "text": "patient token adtech non escape violation",
+    "filters": {
+      "artifact_types": ["InvestigationCase", "MeshRushSimulationTrace", "NonEscapeCertificate"],
+      "reason_codes": ["TOKEN_NON_ESCAPE_VIOLATION"]
+    }
+  },
+  "results": [
+    {
+      "rank": 1,
+      "title": "Patient token non-escape violation blocked from ad-tech scope",
+      "result_type": "EvidenceFinding",
+      "pointers": {
+        "holmes_case": "holmes://case/HOLMES_CASE_PATIENT_TOKEN_ADTECH_BLOCK_V001",
+        "meshrush_trace": "meshrush://trace/meshrush.trace.patient_token_adtech_block.v0.1",
+        "regis_graph": ["regis://TokenLane/token_patient_hsm", "regis://IdentityState/state_adtech"],
+        "ledger": ["did://DID_TOKEN_NON_ESCAPE_PATIENT_HSM_ADTECH"],
+        "certificate": ["cert://CERT_NON_ESCAPE_PATIENT_HSM_V001"]
+      },
+      "claims_canonical_truth": false
+    }
+  ],
+  "expected": {
+    "result": "VERIFIED",
+    "requires_pointer_backing": true,
+    "forbids_direct_canonical_truth_claim": true,
+    "artifact_type": "SearchResult"
+  }
+}

--- a/protocol/identity-is-prime/fixtures/token.non_escape.violation.json
+++ b/protocol/identity-is-prime/fixtures/token.non_escape.violation.json
@@ -1,0 +1,36 @@
+{
+  "fixture_id": "identity-prime.token.non_escape.violation.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "token-lane.v0.1",
+  "policy_version": "regis.token.non_escape.core@0.1.0",
+  "description": "A patient-scoped token minted in the citizen fog is observed in ad-tech scope and must be refuted.",
+  "token_lane": {
+    "lane_id": "patient_hsm_lane",
+    "token_class": "patient_scoped",
+    "modulus": "2^128",
+    "allowed_scopes": ["citizen_fog", "hospital_portal"],
+    "forbidden_scopes": ["ad_tech", "employer_telemetry"],
+    "checks": ["residue_class_match", "epoch_monotonicity", "replay_window"]
+  },
+  "observations": [
+    {
+      "event_id": "evt_001",
+      "scope": "citizen_fog",
+      "action": "mint_token",
+      "token_class": "patient_scoped",
+      "residue_class": "patient_hsm_lane"
+    },
+    {
+      "event_id": "evt_002",
+      "scope": "ad_tech",
+      "action": "observe_token",
+      "token_class": "patient_scoped",
+      "residue_class": "patient_hsm_lane"
+    }
+  ],
+  "expected": {
+    "result": "REFUTED",
+    "reason_codes": ["TOKEN_NON_ESCAPE_VIOLATION", "FORBIDDEN_SCOPE_OBSERVATION"],
+    "certificate_type": "NonEscapeCertificate"
+  }
+}

--- a/protocol/identity-is-prime/fixtures/transition.admissible.json
+++ b/protocol/identity-is-prime/fixtures/transition.admissible.json
@@ -1,0 +1,34 @@
+{
+  "fixture_id": "transition.admissible.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "admissible-transition.v0.1",
+  "policy_version": "regis.transition.admissibility.core@0.1.0",
+  "description": "A patient-scoped transition from citizen fog to hospital portal is admissible when protected by a patient-scoped token and certificate boundary.",
+  "transition_graph": {
+    "nodes": [
+      {"id": "state_patient_fog", "type": "IdentityState", "primes": ["patient"], "scopes": ["citizen_fog"]},
+      {"id": "event_hospital_portal", "type": "WorldlineEvent", "primes": ["patient"], "scopes": ["hospital_portal"]}
+    ],
+    "edges": [
+      {
+        "from": "state_patient_fog",
+        "to": "event_hospital_portal",
+        "type": "TRANSITIONS_TO",
+        "admissible": true,
+        "cost": 2.0,
+        "required_capabilities": ["patient_scoped_token", "scope_permission_certificate"]
+      }
+    ]
+  },
+  "claim": {
+    "claim_type": "ProveScopePermission",
+    "from": "state_patient_fog",
+    "to": "event_hospital_portal"
+  },
+  "expected": {
+    "result": "VERIFIED",
+    "path": ["state_patient_fog", "event_hospital_portal"],
+    "total_cost": 2.0,
+    "artifact_type": "TransitionCertificate"
+  }
+}

--- a/protocol/identity-is-prime/fixtures/transition.no_admissible_path.json
+++ b/protocol/identity-is-prime/fixtures/transition.no_admissible_path.json
@@ -1,0 +1,35 @@
+{
+  "fixture_id": "transition.no_admissible_path.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "admissible-transition.v0.1",
+  "policy_version": "regis.transition.admissibility.core@0.1.0",
+  "description": "A proposed linkage from patient fog state to ad-tech state is structurally refuted because the only candidate edge is policy-blocked.",
+  "transition_graph": {
+    "nodes": [
+      {"id": "state_patient_fog", "type": "IdentityState", "primes": ["patient"], "scopes": ["citizen_fog"]},
+      {"id": "state_adtech", "type": "IdentityState", "scopes": ["ad_tech"]}
+    ],
+    "edges": [
+      {
+        "from": "state_patient_fog",
+        "to": "state_adtech",
+        "type": "TRANSITIONS_TO",
+        "admissible": false,
+        "cost": 999.0,
+        "reason_codes": ["POLICY_BLOCKED_TRANSITION", "NO_ADMISSIBLE_PATH", "TOKEN_NON_ESCAPE_VIOLATION"]
+      }
+    ]
+  },
+  "claim": {
+    "claim_type": "ProveLinkage",
+    "from": "state_patient_fog",
+    "to": "state_adtech"
+  },
+  "expected": {
+    "result": "REFUTED",
+    "path": [],
+    "blocked_edges": ["state_patient_fog->state_adtech"],
+    "reason_codes": ["POLICY_BLOCKED_TRANSITION", "NO_ADMISSIBLE_PATH", "TOKEN_NON_ESCAPE_VIOLATION"],
+    "artifact_type": "NoAdmissiblePathRefutation"
+  }
+}

--- a/protocol/identity-is-prime/fixtures/zeta.audit.window.json
+++ b/protocol/identity-is-prime/fixtures/zeta.audit.window.json
@@ -1,0 +1,36 @@
+{
+  "fixture_id": "zeta.audit.window.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "identity-zeta-audit.v0.1",
+  "policy_version": "regis.identity.audit.core@0.1.0",
+  "metric_version": "identity-zeta.reference@0.1.0",
+  "description": "A rolling identity-state audit window flags elevated mass near forbidden patient+adtech composites.",
+  "audit_window": {
+    "audit_window_id": "AUDIT_WINDOW_PATIENT_ADTECH_PRESSURE_V001",
+    "window_start": "2026-05-06T00:00:00Z",
+    "window_end": "2026-05-06T01:00:00Z",
+    "basis": {
+      "primes": ["founder_engineer", "patient", "parent", "citizen", "creator"],
+      "scopes": ["citizen_fog", "hospital_portal", "ad_tech", "employer_telemetry", "external_egress"]
+    },
+    "counts": [
+      {"state_id": "patient_citizen_fog", "mixture": {"patient": 1, "citizen_fog": 1}, "count": 64, "distance_to_forbidden": 1},
+      {"state_id": "patient_hospital_portal", "mixture": {"patient": 1, "hospital_portal": 1}, "count": 18, "distance_to_forbidden": 2},
+      {"state_id": "patient_adtech_near_violation", "mixture": {"patient": 1, "ad_tech": 1}, "count": 7, "distance_to_forbidden": 0},
+      {"state_id": "citizen_only", "mixture": {"citizen": 1, "citizen_fog": 1}, "count": 41, "distance_to_forbidden": 3}
+    ],
+    "forbidden_states": ["patient_adtech_near_violation"],
+    "parameters": {
+      "s": 2.0,
+      "near_forbidden_distance_threshold": 1,
+      "forbidden_count_threshold": 0
+    }
+  },
+  "expected": {
+    "result": "REFUTED",
+    "artifact_type": "IdentityZetaAudit",
+    "flags": ["FORBIDDEN_STATE_OBSERVED", "NEAR_FORBIDDEN_PRESSURE"],
+    "forbidden_observations": ["patient_adtech_near_violation"],
+    "requires_metric_version": true
+  }
+}

--- a/protocol/identity-is-prime/tritrpc/acr.concordance.v1.prove_golden_record_at_time.json
+++ b/protocol/identity-is-prime/tritrpc/acr.concordance.v1.prove_golden_record_at_time.json
@@ -1,0 +1,27 @@
+{
+  "fixture_id": "tritrpc.acr.concordance.prove_golden_record_at_time.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "tritrpc-fixture.v0.1",
+  "policy_version": "acr.survivorship.core@0.1.0",
+  "service": "acr.concordance.v1.AcrConcordanceService",
+  "method": "ProveGoldenRecordAtTime",
+  "request": {
+    "request_id": "REQ_ACR_GOLDEN_TESCO_V001",
+    "ceid": "CEID_TESCO_EXAMPLE",
+    "as_of_time": "2026-05-06T00:00:00Z",
+    "template_version": "authority-template@0.1.0",
+    "resolver_version": "acr.resolver.reference@0.1.0"
+  },
+  "response": {
+    "result": "VERIFIED",
+    "schema_version": "acr-golden-record-proof.v0.1",
+    "policy_version": "acr.survivorship.core@0.1.0",
+    "template_version": "authority-template@0.1.0",
+    "resolver_version": "acr.resolver.reference@0.1.0",
+    "fixture_version": "0.1.0",
+    "artifact_type": "ConcordanceDecisionCertificate",
+    "golden_record_pointer": "acr://golden/CEID_TESCO_EXAMPLE?as_of=2026-05-06T00:00:00Z",
+    "ledger_pointers": ["DID_LINK_REFERENCE_DATA_C1055", "DID_LINK_CRM_C1055598", "DID_ATTRIBUTE_TICKER_TSCO"],
+    "certificate_hash": "sha256:acr-golden-record-placeholder"
+  }
+}

--- a/protocol/identity-is-prime/tritrpc/holmes.case.v1.open_investigation_case.json
+++ b/protocol/identity-is-prime/tritrpc/holmes.case.v1.open_investigation_case.json
@@ -1,0 +1,25 @@
+{
+  "fixture_id": "tritrpc.holmes.case.open_investigation_case.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "tritrpc-fixture.v0.1",
+  "policy_version": "regis.transition.admissibility.core@0.1.0",
+  "service": "holmes.case.v1.HolmesCaseService",
+  "method": "OpenInvestigationCase",
+  "request": {
+    "request_id": "REQ_HOLMES_CASE_PATIENT_TOKEN_ADTECH_V001",
+    "trace_pointer": "meshrush://trace/meshrush.trace.patient_token_adtech_block.v0.1",
+    "reason_codes": ["FORBIDDEN_EDGE_BLOCKED", "TOKEN_NON_ESCAPE_VIOLATION"]
+  },
+  "response": {
+    "result": "VERIFIED",
+    "schema_version": "holmes-investigation-case.v0.1",
+    "policy_version": "regis.transition.admissibility.core@0.1.0",
+    "case_model_version": "holmes.reference@0.1.0",
+    "fixture_version": "0.1.0",
+    "artifact_type": "InvestigationCase",
+    "holmes_case": "holmes://case/HOLMES_CASE_PATIENT_TOKEN_ADTECH_BLOCK_V001",
+    "trace_pointer": "meshrush://trace/meshrush.trace.patient_token_adtech_block.v0.1",
+    "ledger_pointer": "did://DID_TOKEN_NON_ESCAPE_PATIENT_HSM_ADTECH",
+    "certificate_hash": "sha256:holmes-case-placeholder"
+  }
+}

--- a/protocol/identity-is-prime/tritrpc/identityprime.v1.evaluate_identity_mixture.json
+++ b/protocol/identity-is-prime/tritrpc/identityprime.v1.evaluate_identity_mixture.json
@@ -1,0 +1,25 @@
+{
+  "fixture_id": "tritrpc.identityprime.evaluate_identity_mixture.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "tritrpc-fixture.v0.1",
+  "policy_version": "regis.identity.polytope.core@0.1.0",
+  "service": "identityprime.v1.IdentityPrimeService",
+  "method": "EvaluateIdentityMixture",
+  "request": {
+    "request_id": "REQ_IDENTITY_MIXTURE_PATIENT_ADTECH_V001",
+    "basis_version": "identity-prime-basis@0.1.0",
+    "mixture": {
+      "primes": {"patient": 1},
+      "scopes": {"ad_tech": 1}
+    }
+  },
+  "response": {
+    "result": "REFUTED",
+    "schema_version": "identity-mixture.v0.1",
+    "policy_version": "regis.identity.polytope.core@0.1.0",
+    "fixture_version": "0.1.0",
+    "reason_codes": ["FORBIDDEN_IDENTITY_MIXTURE"],
+    "violations": ["no_health_adtech"],
+    "certificate_hash": "sha256:identityprime-evaluate-mixture-placeholder"
+  }
+}

--- a/protocol/identity-is-prime/tritrpc/meshrush.simulation.v1.run_graph_exploration.json
+++ b/protocol/identity-is-prime/tritrpc/meshrush.simulation.v1.run_graph_exploration.json
@@ -1,0 +1,27 @@
+{
+  "fixture_id": "tritrpc.meshrush.simulation.run_graph_exploration.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "tritrpc-fixture.v0.1",
+  "policy_version": "regis.transition.admissibility.core@0.1.0",
+  "service": "meshrush.simulation.v1.MeshRushSimulationService",
+  "method": "RunGraphExploration",
+  "request": {
+    "request_id": "REQ_MESHRUSH_PATIENT_TOKEN_TRACE_V001",
+    "graph_view": "regis://GraphView/regis_identity_evidence_view_example",
+    "entry_nodes": ["state_patient_fog"],
+    "exploration_mode": "bounded_diffusion",
+    "max_depth": 3
+  },
+  "response": {
+    "result": "VERIFIED",
+    "schema_version": "meshrush-simulation.v0.1",
+    "policy_version": "regis.transition.admissibility.core@0.1.0",
+    "simulation_version": "meshrush.reference@0.1.0",
+    "fixture_version": "0.1.0",
+    "artifact_type": "MeshRushSimulationTrace",
+    "trace_pointer": "meshrush://trace/meshrush.trace.patient_token_adtech_block.v0.1",
+    "blocked_edges": ["token_patient_hsm->state_adtech"],
+    "reason_codes": ["FORBIDDEN_EDGE_BLOCKED", "TOKEN_NON_ESCAPE_VIOLATION"],
+    "certificate_hash": "sha256:meshrush-graph-exploration-placeholder"
+  }
+}

--- a/protocol/identity-is-prime/tritrpc/regis.proof.v1.prove_no_admissible_path.json
+++ b/protocol/identity-is-prime/tritrpc/regis.proof.v1.prove_no_admissible_path.json
@@ -1,0 +1,24 @@
+{
+  "fixture_id": "tritrpc.regis.proof.prove_no_admissible_path.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "tritrpc-fixture.v0.1",
+  "policy_version": "regis.transition.admissibility.core@0.1.0",
+  "service": "regis.proof.v1.RegisProofService",
+  "method": "ProveNoAdmissiblePath",
+  "request": {
+    "request_id": "REQ_NO_PATH_PATIENT_ADTECH_V001",
+    "from_state": "regis://IdentityState/state_patient_fog",
+    "to_state": "regis://IdentityState/state_adtech",
+    "graph_snapshot": "regis://GraphSnapshot/identity_prime_demo_v001"
+  },
+  "response": {
+    "result": "REFUTED",
+    "schema_version": "admissible-transition.v0.1",
+    "policy_version": "regis.transition.admissibility.core@0.1.0",
+    "fixture_version": "0.1.0",
+    "reason_codes": ["NO_ADMISSIBLE_PATH", "POLICY_BLOCKED_TRANSITION", "TOKEN_NON_ESCAPE_VIOLATION"],
+    "refutation_type": "NoAdmissiblePathRefutation",
+    "ledger_pointer": "did://DID_NO_PATH_PATIENT_ADTECH_V001",
+    "certificate_hash": "sha256:regis-no-admissible-path-placeholder"
+  }
+}

--- a/protocol/identity-is-prime/tritrpc/sherlock.search.v1.index_evidence_record.json
+++ b/protocol/identity-is-prime/tritrpc/sherlock.search.v1.index_evidence_record.json
@@ -1,0 +1,30 @@
+{
+  "fixture_id": "tritrpc.sherlock.search.index_evidence_record.v0.1",
+  "fixture_version": "0.1.0",
+  "schema_version": "tritrpc-fixture.v0.1",
+  "policy_version": "regis.search.evidence_pointer.core@0.1.0",
+  "service": "sherlock.search.v1.SherlockSearchService",
+  "method": "IndexEvidenceRecord",
+  "request": {
+    "request_id": "REQ_SHERLOCK_INDEX_HOLMES_MESHRUSH_V001",
+    "artifact_pointer": "holmes://case/HOLMES_CASE_PATIENT_TOKEN_ADTECH_BLOCK_V001",
+    "indexed_pointers": [
+      "meshrush://trace/meshrush.trace.patient_token_adtech_block.v0.1",
+      "regis://TokenLane/token_patient_hsm",
+      "did://DID_TOKEN_NON_ESCAPE_PATIENT_HSM_ADTECH",
+      "cert://CERT_NON_ESCAPE_PATIENT_HSM_V001"
+    ]
+  },
+  "response": {
+    "result": "VERIFIED",
+    "schema_version": "sherlock-search-result.v0.1",
+    "policy_version": "regis.search.evidence_pointer.core@0.1.0",
+    "index_version": "sherlock.reference@0.1.0",
+    "fixture_version": "0.1.0",
+    "artifact_type": "SearchIndexRecord",
+    "search_record": "sherlock://record/SHERLOCK_INDEX_HOLMES_CASE_PATIENT_TOKEN_ADTECH_BLOCK_V001",
+    "claims_canonical_truth": false,
+    "ledger_pointer": "did://DID_TOKEN_NON_ESCAPE_PATIENT_HSM_ADTECH",
+    "certificate_hash": "sha256:sherlock-index-placeholder"
+  }
+}

--- a/tools/conformance/validate_identity_is_prime_fixtures.py
+++ b/tools/conformance/validate_identity_is_prime_fixtures.py
@@ -27,6 +27,8 @@ REQUIRED_FIXTURES = {
     "meshrush.graph_exploration.simulation.json",
     "holmes.case.from_meshrush_trace.json",
     "sherlock.search.from_holmes_meshrush.json",
+    "agent.manifest.valid.json",
+    "agent.manifest.invalid_missing_policy_scope.json",
 }
 
 
@@ -79,7 +81,6 @@ def validate_common(path: Path, fixture: dict[str, Any]) -> dict[str, Any]:
 
 
 def eval_linear_expr(expr: str, values: dict[str, int]) -> bool:
-    # Minimal evaluator for fixtures shaped as: "a + b + c <= N".
     if "<=" not in expr:
         raise ValueError("only <= constraints are supported in fixture validator")
     left, right = expr.split("<=", 1)
@@ -269,6 +270,56 @@ def validate_sherlock(path: Path, fixture: dict[str, Any]) -> None:
         fail(path, "Sherlock expected.forbids_direct_canonical_truth_claim must be true")
 
 
+def validate_agent_manifest(path: Path, fixture: dict[str, Any]) -> None:
+    expected = validate_common(path, fixture)
+    agent = require_obj(fixture, "agent", path)
+    require_str(agent, "agent_id", path)
+    require_str(agent, "version", path)
+    inputs = require_list(agent, "inputs", path)
+    outputs = require_list(agent, "outputs", path)
+    policy_scopes = require_list(agent, "policy_scopes", path)
+    graph_permissions = require_list(agent, "graph_permissions", path)
+    search_permissions = require_list(agent, "search_permissions", path)
+    evidence_outputs = require_list(agent, "evidence_outputs", path)
+    tritrpc_services = require_list(agent, "tritrpc_services", path)
+    cannot_write = set(require_list(agent, "cannot_write", path))
+    violations = []
+    if not inputs:
+        violations.append("MISSING_INPUTS")
+    if not outputs:
+        violations.append("MISSING_OUTPUTS")
+    if not policy_scopes:
+        violations.append("MISSING_POLICY_SCOPE")
+    if not graph_permissions:
+        violations.append("MISSING_GRAPH_PERMISSION")
+    if not search_permissions:
+        violations.append("MISSING_SEARCH_PERMISSION")
+    if not evidence_outputs:
+        violations.append("MISSING_EVIDENCE_OUTPUT")
+    if not tritrpc_services:
+        violations.append("MISSING_TRITRPC_SERVICE")
+    forbidden_writes = {"canonical_entity_truth", "regis_graph_truth_without_policy_reducer"}
+    if not forbidden_writes.intersection(cannot_write):
+        violations.append("MISSING_CANONICAL_TRUTH_WRITE_GUARD")
+    expected_violations = sorted(expected.get("violations", []))
+    if violations:
+        if expected["result"] != "REFUTED":
+            fail(path, f"agent manifest violations {violations} require expected.result REFUTED")
+        if sorted(violations) != expected_violations:
+            fail(path, f"expected.violations must be {violations}")
+    else:
+        if expected["result"] != "VERIFIED":
+            fail(path, "valid agent manifest must expect VERIFIED")
+        for key in (
+            "requires_policy_scope",
+            "requires_graph_permission",
+            "requires_search_permission",
+            "forbids_direct_canonical_truth_write",
+        ):
+            if not expected.get(key):
+                fail(path, f"agent expected.{key} must be true")
+
+
 def validate_expected_files() -> None:
     path = EXPECTED_DIR / "polytope.valid.result.json"
     expected = load_json(path)
@@ -298,6 +349,8 @@ def main() -> None:
             validate_holmes(path, fixture)
         elif name.startswith("sherlock."):
             validate_sherlock(path, fixture)
+        elif name.startswith("agent."):
+            validate_agent_manifest(path, fixture)
         else:
             fail(path, "no validator registered for fixture family")
 

--- a/tools/conformance/validate_identity_is_prime_fixtures.py
+++ b/tools/conformance/validate_identity_is_prime_fixtures.py
@@ -31,6 +31,7 @@ REQUIRED_FIXTURES = {
     "agent.manifest.invalid_missing_policy_scope.json",
     "transition.admissible.json",
     "transition.no_admissible_path.json",
+    "zeta.audit.window.json",
 }
 
 
@@ -268,6 +269,46 @@ def validate_transition(path: Path, fixture: dict[str, Any]) -> None:
         fail(path, "transition fixture must expect VERIFIED or REFUTED")
 
 
+def validate_zeta(path: Path, fixture: dict[str, Any]) -> None:
+    expected = validate_common(path, fixture)
+    require_str(fixture, "metric_version", path)
+    audit_window = require_obj(fixture, "audit_window", path)
+    require_str(audit_window, "audit_window_id", path)
+    require_str(audit_window, "window_start", path)
+    require_str(audit_window, "window_end", path)
+    counts = require_list(audit_window, "counts", path)
+    forbidden_states = set(require_list(audit_window, "forbidden_states", path))
+    parameters = require_obj(audit_window, "parameters", path)
+    if not counts:
+        fail(path, "zeta audit counts must not be empty")
+    threshold = int(parameters.get("forbidden_count_threshold", 0))
+    near_threshold = int(parameters.get("near_forbidden_distance_threshold", 1))
+    forbidden_observed = []
+    near_forbidden_pressure = False
+    for item in counts:
+        if not isinstance(item, dict):
+            fail(path, "zeta counts entries must be objects")
+        state_id = require_str(item, "state_id", path)
+        count = int(item.get("count", 0))
+        distance = int(item.get("distance_to_forbidden", 999))
+        if state_id in forbidden_states and count > threshold:
+            forbidden_observed.append(state_id)
+        if distance <= near_threshold and count > threshold:
+            near_forbidden_pressure = True
+    flags = set(expected.get("flags", []))
+    if forbidden_observed:
+        if expected["result"] != "REFUTED":
+            fail(path, "forbidden zeta observations require expected.result REFUTED")
+        if "FORBIDDEN_STATE_OBSERVED" not in flags:
+            fail(path, "zeta expected.flags must include FORBIDDEN_STATE_OBSERVED")
+    if near_forbidden_pressure and "NEAR_FORBIDDEN_PRESSURE" not in flags:
+        fail(path, "zeta expected.flags must include NEAR_FORBIDDEN_PRESSURE")
+    if sorted(expected.get("forbidden_observations", [])) != sorted(forbidden_observed):
+        fail(path, f"zeta expected.forbidden_observations must be {forbidden_observed}")
+    if not expected.get("requires_metric_version"):
+        fail(path, "zeta expected.requires_metric_version must be true")
+
+
 def validate_holmes(path: Path, fixture: dict[str, Any]) -> None:
     expected = validate_common(path, fixture)
     require_str(fixture, "case_model_version", path)
@@ -400,6 +441,8 @@ def main() -> None:
             validate_meshrush(path, fixture)
         elif name.startswith("transition."):
             validate_transition(path, fixture)
+        elif name.startswith("zeta."):
+            validate_zeta(path, fixture)
         elif name.startswith("holmes."):
             validate_holmes(path, fixture)
         elif name.startswith("sherlock."):

--- a/tools/conformance/validate_identity_is_prime_fixtures.py
+++ b/tools/conformance/validate_identity_is_prime_fixtures.py
@@ -29,6 +29,8 @@ REQUIRED_FIXTURES = {
     "sherlock.search.from_holmes_meshrush.json",
     "agent.manifest.valid.json",
     "agent.manifest.invalid_missing_policy_scope.json",
+    "transition.admissible.json",
+    "transition.no_admissible_path.json",
 }
 
 
@@ -215,6 +217,57 @@ def validate_meshrush(path: Path, fixture: dict[str, Any]) -> None:
         fail(path, "MeshRush fixture with blocked edges must include FORBIDDEN_EDGE_BLOCKED")
 
 
+def validate_transition(path: Path, fixture: dict[str, Any]) -> None:
+    expected = validate_common(path, fixture)
+    graph = require_obj(fixture, "transition_graph", path)
+    claim = require_obj(fixture, "claim", path)
+    nodes = require_list(graph, "nodes", path)
+    edges = require_list(graph, "edges", path)
+    if not nodes:
+        fail(path, "transition_graph.nodes must not be empty")
+    if not edges:
+        fail(path, "transition_graph.edges must not be empty")
+    node_ids = {node.get("id") for node in nodes if isinstance(node, dict)}
+    claim_from = require_str(claim, "from", path)
+    claim_to = require_str(claim, "to", path)
+    if claim_from not in node_ids or claim_to not in node_ids:
+        fail(path, "claim endpoints must exist in transition_graph.nodes")
+    admissible_edges = []
+    blocked_edges = []
+    total_cost = 0.0
+    for edge in edges:
+        if not isinstance(edge, dict):
+            fail(path, "transition_graph.edges entries must be objects")
+        edge_from = require_str(edge, "from", path)
+        edge_to = require_str(edge, "to", path)
+        if edge_from not in node_ids or edge_to not in node_ids:
+            fail(path, "transition edge endpoints must exist in transition_graph.nodes")
+        if edge.get("admissible") is True:
+            admissible_edges.append(f"{edge_from}->{edge_to}")
+            total_cost += float(edge.get("cost", 0.0))
+        elif edge.get("admissible") is False:
+            blocked_edges.append(f"{edge_from}->{edge_to}")
+    expected_result = expected["result"]
+    if expected_result == "VERIFIED":
+        expected_path = require_list(expected, "path", path)
+        if expected_path != [claim_from, claim_to]:
+            fail(path, "verified transition expected.path must match claim endpoints")
+        if f"{claim_from}->{claim_to}" not in admissible_edges:
+            fail(path, "verified transition requires an admissible claim edge")
+        if float(expected.get("total_cost", -1.0)) != total_cost:
+            fail(path, f"expected.total_cost must be {total_cost}")
+    elif expected_result == "REFUTED":
+        if f"{claim_from}->{claim_to}" not in blocked_edges:
+            fail(path, "refuted transition requires a blocked claim edge")
+        if sorted(expected.get("blocked_edges", [])) != sorted(blocked_edges):
+            fail(path, f"expected.blocked_edges must be {blocked_edges}")
+        reason_codes = set(expected.get("reason_codes", []))
+        if "NO_ADMISSIBLE_PATH" not in reason_codes:
+            fail(path, "refuted transition must include NO_ADMISSIBLE_PATH")
+    else:
+        fail(path, "transition fixture must expect VERIFIED or REFUTED")
+
+
 def validate_holmes(path: Path, fixture: dict[str, Any]) -> None:
     expected = validate_common(path, fixture)
     require_str(fixture, "case_model_version", path)
@@ -345,6 +398,8 @@ def main() -> None:
             validate_acr(path, fixture)
         elif name.startswith("meshrush."):
             validate_meshrush(path, fixture)
+        elif name.startswith("transition."):
+            validate_transition(path, fixture)
         elif name.startswith("holmes."):
             validate_holmes(path, fixture)
         elif name.startswith("sherlock."):

--- a/tools/conformance/validate_identity_is_prime_fixtures.py
+++ b/tools/conformance/validate_identity_is_prime_fixtures.py
@@ -24,6 +24,7 @@ REQUIRED_FIXTURES = {
     "polytope.invalid.json",
     "token.non_escape.violation.json",
     "acr.golden_record.proof.json",
+    "meshrush.graph_exploration.simulation.json",
 }
 
 
@@ -174,6 +175,43 @@ def validate_acr(path: Path, fixture: dict[str, Any]) -> None:
         fail(path, "ACR proof fixture must require shared ledger pointer")
 
 
+def validate_meshrush(path: Path, fixture: dict[str, Any]) -> None:
+    expected = validate_common(path, fixture)
+    require_str(fixture, "simulation_version", path)
+    graph_view = require_obj(fixture, "graph_view", path)
+    simulation = require_obj(fixture, "simulation", path)
+    nodes = require_list(graph_view, "nodes", path)
+    edges = require_list(graph_view, "edges", path)
+    entry_nodes = set(require_list(simulation, "entry_nodes", path))
+    stop_conditions = require_list(simulation, "stop_conditions", path)
+    if not nodes:
+        fail(path, "graph_view.nodes must not be empty")
+    if not edges:
+        fail(path, "graph_view.edges must not be empty")
+    node_ids = {node.get("id") for node in nodes if isinstance(node, dict)}
+    if not entry_nodes.issubset(node_ids):
+        fail(path, "simulation.entry_nodes must all exist in graph_view.nodes")
+    if not stop_conditions:
+        fail(path, "simulation.stop_conditions must not be empty")
+    blocked_edges = []
+    for edge in edges:
+        if not isinstance(edge, dict):
+            fail(path, "graph_view.edges entries must be objects")
+        edge_from = require_str(edge, "from", path)
+        edge_to = require_str(edge, "to", path)
+        if edge_from not in node_ids or edge_to not in node_ids:
+            fail(path, "edge endpoints must exist in graph_view.nodes")
+        if edge.get("admissible") is False:
+            blocked_edges.append(f"{edge_from}->{edge_to}")
+    if expected["result"] != "VERIFIED":
+        fail(path, "current MeshRush simulation fixture must expect VERIFIED")
+    if sorted(expected.get("blocked_edges", [])) != sorted(blocked_edges):
+        fail(path, f"expected.blocked_edges must be {blocked_edges}")
+    reason_codes = set(expected.get("reason_codes", []))
+    if blocked_edges and "FORBIDDEN_EDGE_BLOCKED" not in reason_codes:
+        fail(path, "MeshRush fixture with blocked edges must include FORBIDDEN_EDGE_BLOCKED")
+
+
 def validate_expected_files() -> None:
     path = EXPECTED_DIR / "polytope.valid.result.json"
     expected = load_json(path)
@@ -197,6 +235,8 @@ def main() -> None:
             validate_token_non_escape(path, fixture)
         elif name.startswith("acr."):
             validate_acr(path, fixture)
+        elif name.startswith("meshrush."):
+            validate_meshrush(path, fixture)
         else:
             fail(path, "no validator registered for fixture family")
 

--- a/tools/conformance/validate_identity_is_prime_fixtures.py
+++ b/tools/conformance/validate_identity_is_prime_fixtures.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Validate Identity Is Prime / Regis / ACR conformance fixtures.
+
+This validator is intentionally dependency-free. It is the first Sociosphere-side
+conformance gate for the fixture skeleton under protocol/identity-is-prime/.
+It does not try to reimplement the full Identity Is Prime reference analyzer;
+it enforces fixture shape, deterministic result vocabulary, and the core
+structural expectations needed before TRIT RPC wire fixtures are added.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_DIR = ROOT / "protocol" / "identity-is-prime" / "fixtures"
+EXPECTED_DIR = ROOT / "protocol" / "identity-is-prime" / "expected"
+
+RESULTS = {"VERIFIED", "REFUTED", "UNDECIDABLE", "STALE", "REQUIRES_REVIEW"}
+REQUIRED_FIXTURES = {
+    "polytope.valid.json",
+    "polytope.invalid.json",
+    "token.non_escape.violation.json",
+    "acr.golden_record.proof.json",
+}
+
+
+def fail(path: Path, message: str) -> None:
+    raise SystemExit(f"{path}: {message}")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(path, f"invalid JSON: {exc}")
+    if not isinstance(data, dict):
+        fail(path, "top-level JSON value must be an object")
+    return data
+
+
+def require_str(obj: dict[str, Any], key: str, path: Path) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value:
+        fail(path, f"{key} must be a non-empty string")
+    return value
+
+
+def require_obj(obj: dict[str, Any], key: str, path: Path) -> dict[str, Any]:
+    value = obj.get(key)
+    if not isinstance(value, dict):
+        fail(path, f"{key} must be an object")
+    return value
+
+
+def require_list(obj: dict[str, Any], key: str, path: Path) -> list[Any]:
+    value = obj.get(key)
+    if not isinstance(value, list):
+        fail(path, f"{key} must be a list")
+    return value
+
+
+def validate_common(path: Path, fixture: dict[str, Any]) -> dict[str, Any]:
+    require_str(fixture, "fixture_id", path)
+    require_str(fixture, "fixture_version", path)
+    require_str(fixture, "schema_version", path)
+    require_str(fixture, "policy_version", path)
+    require_str(fixture, "description", path)
+    expected = require_obj(fixture, "expected", path)
+    result = require_str(expected, "result", path)
+    if result not in RESULTS:
+        fail(path, f"expected.result must be one of {sorted(RESULTS)}")
+    return expected
+
+
+def eval_linear_expr(expr: str, values: dict[str, int]) -> bool:
+    # Minimal evaluator for fixtures shaped as: "a + b + c <= N".
+    if "<=" not in expr:
+        raise ValueError("only <= constraints are supported in fixture validator")
+    left, right = expr.split("<=", 1)
+    rhs = int(right.strip())
+    total = 0
+    for term in left.split("+"):
+        name = term.strip()
+        if not name:
+            continue
+        total += int(values.get(name, 0))
+    return total <= rhs
+
+
+def validate_polytope(path: Path, fixture: dict[str, Any]) -> None:
+    expected = validate_common(path, fixture)
+    basis = require_obj(fixture, "basis", path)
+    primes = require_list(basis, "primes", path)
+    scopes = require_list(basis, "scopes", path)
+    mixture = require_obj(fixture, "mixture", path)
+    prime_values = require_obj(mixture, "primes", path)
+    scope_values = require_obj(mixture, "scopes", path)
+    constraints = require_list(fixture, "constraints", path)
+
+    values: dict[str, int] = {}
+    for name in primes + scopes:
+        if not isinstance(name, str):
+            fail(path, "basis entries must be strings")
+        values[name] = int(prime_values.get(name, scope_values.get(name, 0)))
+
+    violations: list[str] = []
+    for constraint in constraints:
+        if not isinstance(constraint, dict):
+            fail(path, "constraints entries must be objects")
+        cid = require_str(constraint, "id", path)
+        expr = require_str(constraint, "expr", path)
+        try:
+            ok = eval_linear_expr(expr, values)
+        except Exception as exc:  # noqa: BLE001 - report fixture failure with context.
+            fail(path, f"unsupported constraint expression {expr!r}: {exc}")
+        if not ok:
+            violations.append(cid)
+
+    expected_result = expected["result"]
+    if violations and expected_result != "REFUTED":
+        fail(path, f"violations {violations} require expected.result REFUTED")
+    if not violations and expected_result != "VERIFIED":
+        fail(path, "no violations require expected.result VERIFIED")
+    if sorted(expected.get("violations", [])) != sorted(violations):
+        fail(path, f"expected.violations must be {violations}")
+
+
+def validate_token_non_escape(path: Path, fixture: dict[str, Any]) -> None:
+    expected = validate_common(path, fixture)
+    lane = require_obj(fixture, "token_lane", path)
+    allowed = set(require_list(lane, "allowed_scopes", path))
+    forbidden = set(require_list(lane, "forbidden_scopes", path))
+    observations = require_list(fixture, "observations", path)
+    observed_forbidden = []
+    for obs in observations:
+        if not isinstance(obs, dict):
+            fail(path, "observations entries must be objects")
+        scope = require_str(obs, "scope", path)
+        if scope in forbidden or (allowed and scope not in allowed):
+            observed_forbidden.append(scope)
+    if observed_forbidden and expected["result"] != "REFUTED":
+        fail(path, "forbidden token observation requires expected.result REFUTED")
+    reason_codes = set(expected.get("reason_codes", []))
+    if observed_forbidden and "TOKEN_NON_ESCAPE_VIOLATION" not in reason_codes:
+        fail(path, "expected.reason_codes must include TOKEN_NON_ESCAPE_VIOLATION")
+
+
+def validate_acr(path: Path, fixture: dict[str, Any]) -> None:
+    expected = validate_common(path, fixture)
+    require_str(fixture, "template_version", path)
+    require_str(fixture, "resolver_version", path)
+    source_records = require_list(fixture, "source_records", path)
+    crosswalk = require_list(fixture, "crosswalk", path)
+    golden = require_obj(fixture, "golden_record", path)
+    ledger = require_list(fixture, "ledger_pointers", path)
+    if not source_records:
+        fail(path, "source_records must not be empty")
+    if not crosswalk:
+        fail(path, "crosswalk must not be empty")
+    if not ledger:
+        fail(path, "ledger_pointers must not be empty")
+    ceid = require_str(golden, "ceid", path)
+    for link in crosswalk:
+        if not isinstance(link, dict):
+            fail(path, "crosswalk entries must be objects")
+        if link.get("ceid") != ceid:
+            fail(path, "all crosswalk entries must point to golden_record.ceid")
+    if expected["result"] != "VERIFIED":
+        fail(path, "current ACR golden proof fixture must expect VERIFIED")
+    if not expected.get("requires_shared_ledger_pointer"):
+        fail(path, "ACR proof fixture must require shared ledger pointer")
+
+
+def validate_expected_files() -> None:
+    path = EXPECTED_DIR / "polytope.valid.result.json"
+    expected = load_json(path)
+    if expected.get("result") != "VERIFIED":
+        fail(path, "polytope valid expected result must be VERIFIED")
+    for key in ("fixture_id", "policy_version", "schema_version"):
+        require_str(expected, key, path)
+
+
+def main() -> None:
+    missing = sorted(name for name in REQUIRED_FIXTURES if not (FIXTURE_DIR / name).exists())
+    if missing:
+        raise SystemExit(f"missing required Identity Is Prime fixtures: {missing}")
+
+    for name in sorted(REQUIRED_FIXTURES):
+        path = FIXTURE_DIR / name
+        fixture = load_json(path)
+        if name.startswith("polytope."):
+            validate_polytope(path, fixture)
+        elif name.startswith("token."):
+            validate_token_non_escape(path, fixture)
+        elif name.startswith("acr."):
+            validate_acr(path, fixture)
+        else:
+            fail(path, "no validator registered for fixture family")
+
+    validate_expected_files()
+    print("OK: identity-is-prime conformance fixtures validated")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/conformance/validate_identity_is_prime_fixtures.py
+++ b/tools/conformance/validate_identity_is_prime_fixtures.py
@@ -17,6 +17,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_DIR = ROOT / "protocol" / "identity-is-prime" / "fixtures"
 EXPECTED_DIR = ROOT / "protocol" / "identity-is-prime" / "expected"
+TRITRPC_DIR = ROOT / "protocol" / "identity-is-prime" / "tritrpc"
 
 RESULTS = {"VERIFIED", "REFUTED", "UNDECIDABLE", "STALE", "REQUIRES_REVIEW"}
 REQUIRED_FIXTURES = {
@@ -32,6 +33,14 @@ REQUIRED_FIXTURES = {
     "transition.admissible.json",
     "transition.no_admissible_path.json",
     "zeta.audit.window.json",
+}
+REQUIRED_TRITRPC_FIXTURES = {
+    "identityprime.v1.evaluate_identity_mixture.json",
+    "regis.proof.v1.prove_no_admissible_path.json",
+    "meshrush.simulation.v1.run_graph_exploration.json",
+    "holmes.case.v1.open_investigation_case.json",
+    "sherlock.search.v1.index_evidence_record.json",
+    "acr.concordance.v1.prove_golden_record_at_time.json",
 }
 
 
@@ -81,6 +90,29 @@ def validate_common(path: Path, fixture: dict[str, Any]) -> dict[str, Any]:
     if result not in RESULTS:
         fail(path, f"expected.result must be one of {sorted(RESULTS)}")
     return expected
+
+
+def validate_rpc_common(path: Path, fixture: dict[str, Any]) -> dict[str, Any]:
+    require_str(fixture, "fixture_id", path)
+    require_str(fixture, "fixture_version", path)
+    require_str(fixture, "schema_version", path)
+    require_str(fixture, "policy_version", path)
+    require_str(fixture, "service", path)
+    require_str(fixture, "method", path)
+    request = require_obj(fixture, "request", path)
+    response = require_obj(fixture, "response", path)
+    require_str(request, "request_id", path)
+    result = require_str(response, "result", path)
+    if result not in RESULTS:
+        fail(path, f"response.result must be one of {sorted(RESULTS)}")
+    for key in ("schema_version", "policy_version", "fixture_version"):
+        require_str(response, key, path)
+    if response["policy_version"] != fixture["policy_version"]:
+        fail(path, "response.policy_version must match fixture.policy_version")
+    if response["fixture_version"] != fixture["fixture_version"]:
+        fail(path, "response.fixture_version must match fixture.fixture_version")
+    require_str(response, "certificate_hash", path)
+    return response
 
 
 def eval_linear_expr(expr: str, values: dict[str, int]) -> bool:
@@ -414,6 +446,33 @@ def validate_agent_manifest(path: Path, fixture: dict[str, Any]) -> None:
                 fail(path, f"agent expected.{key} must be true")
 
 
+def validate_tritrpc_fixture(path: Path) -> None:
+    fixture = load_json(path)
+    response = validate_rpc_common(path, fixture)
+    service = fixture["service"]
+    if service.startswith("acr."):
+        for key in ("template_version", "resolver_version", "ledger_pointers"):
+            if key == "ledger_pointers":
+                require_list(response, key, path)
+            else:
+                require_str(response, key, path)
+    if service.startswith("meshrush."):
+        require_str(response, "simulation_version", path)
+        require_str(response, "trace_pointer", path)
+    if service.startswith("holmes."):
+        require_str(response, "case_model_version", path)
+        require_str(response, "holmes_case", path)
+    if service.startswith("sherlock."):
+        require_str(response, "index_version", path)
+        if response.get("claims_canonical_truth") is not False:
+            fail(path, "Sherlock TRIT response must not claim canonical truth")
+    if service.startswith("regis.proof."):
+        require_str(response, "ledger_pointer", path)
+        require_str(response, "refutation_type", path)
+    if service.startswith("identityprime."):
+        require_list(response, "reason_codes", path)
+
+
 def validate_expected_files() -> None:
     path = EXPECTED_DIR / "polytope.valid.result.json"
     expected = load_json(path)
@@ -421,6 +480,14 @@ def validate_expected_files() -> None:
         fail(path, "polytope valid expected result must be VERIFIED")
     for key in ("fixture_id", "policy_version", "schema_version"):
         require_str(expected, key, path)
+
+
+def validate_tritrpc_files() -> None:
+    missing = sorted(name for name in REQUIRED_TRITRPC_FIXTURES if not (TRITRPC_DIR / name).exists())
+    if missing:
+        raise SystemExit(f"missing required Identity Is Prime TRIT RPC fixtures: {missing}")
+    for name in sorted(REQUIRED_TRITRPC_FIXTURES):
+        validate_tritrpc_fixture(TRITRPC_DIR / name)
 
 
 def main() -> None:
@@ -453,6 +520,7 @@ def main() -> None:
             fail(path, "no validator registered for fixture family")
 
     validate_expected_files()
+    validate_tritrpc_files()
     print("OK: identity-is-prime conformance fixtures validated")
 
 

--- a/tools/conformance/validate_identity_is_prime_fixtures.py
+++ b/tools/conformance/validate_identity_is_prime_fixtures.py
@@ -25,6 +25,8 @@ REQUIRED_FIXTURES = {
     "token.non_escape.violation.json",
     "acr.golden_record.proof.json",
     "meshrush.graph_exploration.simulation.json",
+    "holmes.case.from_meshrush_trace.json",
+    "sherlock.search.from_holmes_meshrush.json",
 }
 
 
@@ -212,6 +214,61 @@ def validate_meshrush(path: Path, fixture: dict[str, Any]) -> None:
         fail(path, "MeshRush fixture with blocked edges must include FORBIDDEN_EDGE_BLOCKED")
 
 
+def validate_holmes(path: Path, fixture: dict[str, Any]) -> None:
+    expected = validate_common(path, fixture)
+    require_str(fixture, "case_model_version", path)
+    input_trace = require_obj(fixture, "input_trace", path)
+    case = require_obj(fixture, "case", path)
+    require_str(input_trace, "trace_id", path)
+    if input_trace.get("artifact_type") != "MeshRushSimulationTrace":
+        fail(path, "Holmes fixture input_trace.artifact_type must be MeshRushSimulationTrace")
+    findings = require_list(case, "findings", path)
+    if not findings:
+        fail(path, "Holmes case.findings must not be empty")
+    for finding in findings:
+        if not isinstance(finding, dict):
+            fail(path, "Holmes findings entries must be objects")
+        for key in ("regis_graph_pointers", "ledger_pointers", "certificate_pointers", "trace_pointers"):
+            if not require_list(finding, key, path):
+                fail(path, f"Holmes finding {key} must not be empty")
+    if expected["result"] != "VERIFIED":
+        fail(path, "current Holmes fixture must expect VERIFIED")
+    for key in ("requires_trace_pointer", "requires_ledger_pointer", "requires_certificate_pointer"):
+        if not expected.get(key):
+            fail(path, f"Holmes expected.{key} must be true")
+
+
+def validate_sherlock(path: Path, fixture: dict[str, Any]) -> None:
+    expected = validate_common(path, fixture)
+    require_str(fixture, "index_version", path)
+    index_record = require_obj(fixture, "index_record", path)
+    require_obj(fixture, "query", path)
+    results = require_list(fixture, "results", path)
+    indexed = require_list(index_record, "indexed_artifacts", path)
+    if not indexed:
+        fail(path, "Sherlock index_record.indexed_artifacts must not be empty")
+    if index_record.get("claims_canonical_truth") is not False:
+        fail(path, "Sherlock index_record must not claim canonical truth")
+    if not results:
+        fail(path, "Sherlock results must not be empty")
+    for result in results:
+        if not isinstance(result, dict):
+            fail(path, "Sherlock result entries must be objects")
+        if result.get("claims_canonical_truth") is not False:
+            fail(path, "Sherlock results must not claim canonical truth")
+        pointers = require_obj(result, "pointers", path)
+        required_pointer_keys = {"holmes_case", "meshrush_trace", "regis_graph", "ledger", "certificate"}
+        missing = sorted(required_pointer_keys - set(pointers))
+        if missing:
+            fail(path, f"Sherlock result pointers missing: {missing}")
+    if expected["result"] != "VERIFIED":
+        fail(path, "current Sherlock fixture must expect VERIFIED")
+    if not expected.get("requires_pointer_backing"):
+        fail(path, "Sherlock expected.requires_pointer_backing must be true")
+    if not expected.get("forbids_direct_canonical_truth_claim"):
+        fail(path, "Sherlock expected.forbids_direct_canonical_truth_claim must be true")
+
+
 def validate_expected_files() -> None:
     path = EXPECTED_DIR / "polytope.valid.result.json"
     expected = load_json(path)
@@ -237,6 +294,10 @@ def main() -> None:
             validate_acr(path, fixture)
         elif name.startswith("meshrush."):
             validate_meshrush(path, fixture)
+        elif name.startswith("holmes."):
+            validate_holmes(path, fixture)
+        elif name.startswith("sherlock."):
+            validate_sherlock(path, fixture)
         else:
             fail(path, "no validator registered for fixture family")
 


### PR DESCRIPTION
## Summary

Scaffold the Sociosphere integration spine for Identity Is Prime, Regis Entity Graph, Authority Concordance Rex (ACR), and Agent Registry conformance.

This PR follows issue #284 and now adds both fixture scaffolding and the first executable conformance validator.

Adds:

- architecture document for Identity Is Prime × Regis × ACR × Sociosphere integration
- initial protocol fixture directory under `protocol/identity-is-prime/`
- valid and invalid policy polytope fixtures
- token non-escape violation fixture
- ACR golden-record proof fixture
- initial expected result fixture
- dependency-free fixture validator under `tools/conformance/`
- Makefile target `identity-prime-conformance`
- `workspace-check` wiring for the new conformance lane

## Why

Sociosphere is the cross-repo workspace controller and retest surface. Identity Is Prime already exists as a reference implementation, and Regis/ACR need a deterministic conformance lane that tests graph semantics, policy refutations, proof artifacts, and local-first/cache-first concordance behavior.

## What the validator currently checks

- required Identity Is Prime / ACR fixture files exist
- deterministic metadata fields are present
- current simple policy polytope constraints evaluate to expected `VERIFIED` / `REFUTED` results
- forbidden patient + ad-tech mixture is structurally refuted
- patient-scoped token observed in ad-tech scope produces `TOKEN_NON_ESCAPE_VIOLATION`
- ACR golden-record proof fixture has source records, crosswalk, golden record, resolver/template versions, and shared ledger pointers

## Scope

This remains a scaffold PR. It introduces the first executable conformance lane, but follow-on work should still:

1. Confirm/materialize `agent-registry` in `manifest/workspace.toml` if absent.
2. Add transition graph, no-admissible-path, zeta audit, agent manifest rejection, and TRIT RPC wire fixtures.
3. Wire conformance outputs into the Sociosphere evidence/registry pattern.
4. Expand validator coverage from fixture-shape checks into reference-runner checks against `identity-is-prime-reference`.

## Acceptance checks introduced

- `VERIFIED` for allowed identity mixtures
- `REFUTED` for forbidden patient + ad-tech mixtures
- `REFUTED` for patient token observation in ad-tech scope
- `VERIFIED` ACR golden-record proof with shared ledger pointers
- `make identity-prime-conformance` validates the current fixture set
- `make workspace-check` includes identity-prime conformance

## Related

- Tracks #284