### PR TITLE
Add agent reliability governance queue contract

### DIFF
--- a/.github/workflows/agent-reliability-governance-queue.yml
+++ b/.github/workflows/agent-reliability-governance-queue.yml
@@ -1,0 +1,28 @@
+name: agent-reliability-governance-queue
+
+on:
+  pull_request:
+    paths:
+      - "standards/agent-reliability/**"
+      - "tools/validate_agent_reliability_governance_queue.py"
+      - ".github/workflows/agent-reliability-governance-queue.yml"
+      - "Makefile"
+  push:
+    branches:
+      - main
+    paths:
+      - "standards/agent-reliability/**"
+      - "tools/validate_agent_reliability_governance_queue.py"
+      - ".github/workflows/agent-reliability-governance-queue.yml"
+      - "Makefile"
+
+jobs:
+  validate-agent-reliability-governance-queue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate Agent Reliability governance queue
+        run: make agent-reliability-governance-queue-validate

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,16 @@ ui-dev: ui-preflight
 # --- end ui-workbench targets ---
 
 # --- standards validation targets ---
-.PHONY: validate validate-standards multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate
+.PHONY: validate validate-standards agent-reliability-governance-queue-validate multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate
 
-validate: validate-standards program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate
+validate: validate-standards agent-reliability-governance-queue-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate
 	@echo "OK: validate"
 
 validate-standards:
 	@ok=1; if [ -f tools/validate_adaptation_program.py ]; then python3 tools/validate_adaptation_program.py standards/examples/adaptation/program.example.v1.json || ok=0; else echo "ERR: tools/validate_adaptation_program.py missing"; ok=0; fi; if [ -f standards/qes/tools/validate_qes_contracts.py ]; then python3 standards/qes/tools/validate_qes_contracts.py || ok=0; else echo "WARN: standards/qes/tools/validate_qes_contracts.py missing (skipping)"; fi; if [ -f tools/check_multidomain_geospatial_standards_compliance.py ]; then python3 tools/check_multidomain_geospatial_standards_compliance.py || ok=0; else echo "ERR: tools/check_multidomain_geospatial_standards_compliance.py missing"; ok=0; fi; test $$ok -eq 1
+
+agent-reliability-governance-queue-validate:
+	python3 tools/validate_agent_reliability_governance_queue.py
 
 program-dashboard-validate:
 	python3 tools/validate_program_dashboard.py

--- a/standards/agent-reliability/README.md
+++ b/standards/agent-reliability/README.md
@@ -1,0 +1,42 @@
+# Agent Reliability Governance Queue
+
+SocioSphere owns the cross-repo review queue contract for the SourceOS Agent Reliability Control Plane.
+
+This contract turns disconnected evidence artifacts into visible review items:
+
+- PolicyFabric `BreakGlassOverride` artifacts become `break-glass-approval` queue items.
+- MemoryMesh `AgentLearningProposal` artifacts become `memory-learning-review` queue items.
+- AgentPlane stop-gate failures can become `stop-gate-waiver` queue items.
+- External draft/publication artifacts can become `external-action-review` queue items.
+
+## Files
+
+- `governance-queue.schema.v0.1.json` — queue schema.
+- `examples/governance-queue.example.v0.1.json` — example queue with break-glass and memory-learning review items.
+- `../../tools/validate_agent_reliability_governance_queue.py` — dependency-free validator.
+
+## Validate
+
+```bash
+make agent-reliability-governance-queue-validate
+```
+
+or run it as part of the normal SocioSphere standards validation:
+
+```bash
+make validate
+```
+
+## Required safety posture
+
+Example queue items must remain pending by default. Approval and rejection are later governance actions and should produce their own evidence.
+
+Every item requires:
+
+- source artifact system/repo/kind/ref;
+- risk classification;
+- required reviewers;
+- evidence references;
+- policy decision references.
+
+Break-glass approval items must reference PolicyFabric `BreakGlassOverride` artifacts and carry high or critical risk. Memory learning review items must reference MemoryMesh `AgentLearningProposal` artifacts and use `actionClass=memory`.

--- a/standards/agent-reliability/examples/governance-queue.example.v0.1.json
+++ b/standards/agent-reliability/examples/governance-queue.example.v0.1.json
@@ -1,0 +1,94 @@
+{
+  "apiVersion": "sociosphere.governance-queue/v1",
+  "kind": "AgentReliabilityGovernanceQueue",
+  "queueId": "urn:sociosphere:queue:sourceos-agent-reliability-example",
+  "createdAt": "2026-05-07T00:00:00Z",
+  "owner": "SocioProphet/sociosphere",
+  "sourceLane": "sourceos-agent-reliability-control-plane",
+  "items": [
+    {
+      "itemId": "urn:sociosphere:queue-item:break-glass-example",
+      "itemType": "break-glass-approval",
+      "status": "pending",
+      "priority": "high",
+      "title": "Review PolicyFabric break-glass override",
+      "summary": "A repository-scoped git break-glass override requires human review before a stop-gate waiver can be trusted by AgentPlane.",
+      "sourceArtifact": {
+        "system": "policy-fabric",
+        "repo": "SocioProphet/policy-fabric",
+        "artifactKind": "BreakGlassOverride",
+        "artifactRef": "examples/policy_fabric_break_glass_override_example.json",
+        "displayRef": "SocioProphet/policy-fabric#64"
+      },
+      "risk": {
+        "severity": "high",
+        "actionClass": "git",
+        "resource": "SocioProphet/agentplane:work/example-break-glass",
+        "reason": "Break-glass overrides waive normal stop-gate failure behavior and must be scoped, expiring, auditable, and human-approved."
+      },
+      "review": {
+        "required": true,
+        "reviewerRefs": [
+          "human:repo-maintainer"
+        ],
+        "approvalRef": null,
+        "decisionRef": null,
+        "dueAt": null,
+        "reviewNotes": "Confirm scope, expiry, approver, audit ref, and allowed action class before approval."
+      },
+      "evidenceRefs": [
+        "contracts/policy_fabric_break_glass_override_v1.schema.json",
+        "examples/policy_fabric_break_glass_override_example.json"
+      ],
+      "policyDecisionRefs": [
+        "policyfabric/break-glass/validate-active-human-approved"
+      ],
+      "links": [
+        "https://github.com/SocioProphet/policy-fabric/pull/64"
+      ]
+    },
+    {
+      "itemId": "urn:sociosphere:queue-item:memory-learning-example",
+      "itemType": "memory-learning-review",
+      "status": "pending",
+      "priority": "medium",
+      "title": "Review MemoryMesh agent learning proposal",
+      "summary": "A guarded AgentPlane session proposed a repo-local playbook update. MemoryMesh must keep it review-only until a human approves durable writeback.",
+      "sourceArtifact": {
+        "system": "memory-mesh",
+        "repo": "SocioProphet/memory-mesh",
+        "artifactKind": "AgentLearningProposal",
+        "artifactRef": "examples/agent-learning/proposal.example.json",
+        "displayRef": "SocioProphet/memory-mesh#27"
+      },
+      "risk": {
+        "severity": "medium",
+        "actionClass": "memory",
+        "resource": "SocioProphet/agentplane:AGENTS.md",
+        "reason": "Durable repo memory changes alter future agent behavior and require review before writeback."
+      },
+      "review": {
+        "required": true,
+        "reviewerRefs": [
+          "human:repo-maintainer",
+          "memory-steward:memory-mesh"
+        ],
+        "approvalRef": null,
+        "decisionRef": null,
+        "dueAt": null,
+        "reviewNotes": "Verify evidence refs, policy decision refs, destination path, and proposed diff before approving writeback."
+      },
+      "evidenceRefs": [
+        "schemas/agent-learning-proposal.schema.json",
+        "examples/agent-learning/proposal.example.json"
+      ],
+      "policyDecisionRefs": [
+        "memorymesh/agent-learning/review-only",
+        "memorymesh/agent-learning/no-raw-sensitive-payload"
+      ],
+      "links": [
+        "https://github.com/SocioProphet/memory-mesh/pull/27"
+      ]
+    }
+  ]
+}

--- a/standards/agent-reliability/governance-queue.schema.v0.1.json
+++ b/standards/agent-reliability/governance-queue.schema.v0.1.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/sociosphere/agent-reliability/governance-queue.schema.v0.1.json",
+  "title": "SocioSphere Agent Reliability Governance Queue v0.1",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "queueId",
+    "createdAt",
+    "owner",
+    "sourceLane",
+    "items"
+  ],
+  "properties": {
+    "apiVersion": { "const": "sociosphere.governance-queue/v1" },
+    "kind": { "const": "AgentReliabilityGovernanceQueue" },
+    "queueId": { "type": "string", "minLength": 1 },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "owner": { "type": "string", "minLength": 1 },
+    "sourceLane": { "const": "sourceos-agent-reliability-control-plane" },
+    "items": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "itemId",
+          "itemType",
+          "status",
+          "priority",
+          "title",
+          "summary",
+          "sourceArtifact",
+          "risk",
+          "review",
+          "evidenceRefs",
+          "policyDecisionRefs"
+        ],
+        "properties": {
+          "itemId": { "type": "string", "minLength": 1 },
+          "itemType": { "enum": ["break-glass-approval", "memory-learning-review", "stop-gate-waiver", "external-action-review"] },
+          "status": { "enum": ["pending", "approved", "rejected", "superseded"] },
+          "priority": { "enum": ["low", "medium", "high", "critical"] },
+          "title": { "type": "string", "minLength": 1 },
+          "summary": { "type": "string", "minLength": 1 },
+          "sourceArtifact": {
+            "type": "object",
+            "required": ["system", "repo", "artifactKind", "artifactRef"],
+            "properties": {
+              "system": { "enum": ["policy-fabric", "memory-mesh", "agentplane", "guardrail-fabric"] },
+              "repo": { "type": "string", "minLength": 1 },
+              "artifactKind": { "enum": ["BreakGlassOverride", "AgentLearningProposal", "StopGateArtifact", "GuardedInvocationArtifact", "PolicyDecisionArtifact", "ExternalActionDraft"] },
+              "artifactRef": { "type": "string", "minLength": 1 },
+              "displayRef": { "type": ["string", "null"] }
+            },
+            "additionalProperties": false
+          },
+          "risk": {
+            "type": "object",
+            "required": ["severity", "actionClass", "resource", "reason"],
+            "properties": {
+              "severity": { "enum": ["low", "medium", "high", "critical"] },
+              "actionClass": { "enum": ["shell", "filesystem", "git", "network", "model", "browser", "infra", "database", "package", "runtime", "memory", "external", "unknown"] },
+              "resource": { "type": "string", "minLength": 1 },
+              "reason": { "type": "string", "minLength": 1 }
+            },
+            "additionalProperties": false
+          },
+          "review": {
+            "type": "object",
+            "required": ["required", "reviewerRefs", "approvalRef", "decisionRef"],
+            "properties": {
+              "required": { "type": "boolean" },
+              "reviewerRefs": { "type": "array", "items": { "type": "string" } },
+              "approvalRef": { "type": ["string", "null"] },
+              "decisionRef": { "type": ["string", "null"] },
+              "dueAt": { "type": ["string", "null"], "format": "date-time" },
+              "reviewNotes": { "type": ["string", "null"] }
+            },
+            "additionalProperties": false
+          },
+          "evidenceRefs": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "policyDecisionRefs": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "links": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/validate_agent_reliability_governance_queue.py
+++ b/tools/validate_agent_reliability_governance_queue.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Validate SocioSphere Agent Reliability governance queue fixtures.
+
+The validator is dependency-free by design. It validates the schema/example
+contract shape plus the semantic invariants required for SourceOS Agent
+Reliability review queues.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "standards" / "agent-reliability" / "governance-queue.schema.v0.1.json"
+EXAMPLE = ROOT / "standards" / "agent-reliability" / "examples" / "governance-queue.example.v0.1.json"
+
+VALID_ITEM_TYPES = {"break-glass-approval", "memory-learning-review", "stop-gate-waiver", "external-action-review"}
+VALID_STATUSES = {"pending", "approved", "rejected", "superseded"}
+VALID_PRIORITIES = {"low", "medium", "high", "critical"}
+VALID_SYSTEMS = {"policy-fabric", "memory-mesh", "agentplane", "guardrail-fabric"}
+VALID_ARTIFACT_KINDS = {"BreakGlassOverride", "AgentLearningProposal", "StopGateArtifact", "GuardedInvocationArtifact", "PolicyDecisionArtifact", "ExternalActionDraft"}
+VALID_ACTION_CLASSES = {"shell", "filesystem", "git", "network", "model", "browser", "infra", "database", "package", "runtime", "memory", "external", "unknown"}
+
+
+def die(message: str) -> None:
+    print(f"[agent-reliability-governance-queue] ERROR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        die(f"missing file: {path.relative_to(ROOT)}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        die(f"invalid JSON in {path.relative_to(ROOT)}: {exc}")
+    if not isinstance(data, dict):
+        die(f"expected JSON object in {path.relative_to(ROOT)}")
+    return data
+
+
+def require_keys(obj: dict[str, Any], keys: list[str], path: str) -> None:
+    missing = [key for key in keys if key not in obj]
+    if missing:
+        die(f"{path} missing keys: {missing}")
+
+
+def validate_schema_shape(schema: dict[str, Any]) -> None:
+    require_keys(schema, ["$schema", "$id", "title", "type", "required", "properties"], "schema")
+    for field in ["apiVersion", "kind", "queueId", "createdAt", "owner", "sourceLane", "items"]:
+        if field not in schema.get("required", []):
+            die(f"schema.required missing {field}")
+
+
+def validate_item(item: dict[str, Any], seen_ids: set[str], index: int) -> None:
+    path = f"items[{index}]"
+    require_keys(
+        item,
+        ["itemId", "itemType", "status", "priority", "title", "summary", "sourceArtifact", "risk", "review", "evidenceRefs", "policyDecisionRefs"],
+        path,
+    )
+    item_id = item["itemId"]
+    if item_id in seen_ids:
+        die(f"duplicate queue item id: {item_id}")
+    seen_ids.add(item_id)
+    if item["itemType"] not in VALID_ITEM_TYPES:
+        die(f"{path}.itemType unsupported: {item['itemType']}")
+    if item["status"] not in VALID_STATUSES:
+        die(f"{path}.status unsupported: {item['status']}")
+    if item["status"] != "pending":
+        die(f"example queue item {item_id} must remain pending by default")
+    if item["priority"] not in VALID_PRIORITIES:
+        die(f"{path}.priority unsupported: {item['priority']}")
+
+    source = item["sourceArtifact"]
+    require_keys(source, ["system", "repo", "artifactKind", "artifactRef"], f"{path}.sourceArtifact")
+    if source["system"] not in VALID_SYSTEMS:
+        die(f"{path}.sourceArtifact.system unsupported: {source['system']}")
+    if source["artifactKind"] not in VALID_ARTIFACT_KINDS:
+        die(f"{path}.sourceArtifact.artifactKind unsupported: {source['artifactKind']}")
+
+    risk = item["risk"]
+    require_keys(risk, ["severity", "actionClass", "resource", "reason"], f"{path}.risk")
+    if risk["severity"] not in VALID_PRIORITIES:
+        die(f"{path}.risk.severity unsupported: {risk['severity']}")
+    if risk["actionClass"] not in VALID_ACTION_CLASSES:
+        die(f"{path}.risk.actionClass unsupported: {risk['actionClass']}")
+
+    review = item["review"]
+    require_keys(review, ["required", "reviewerRefs", "approvalRef", "decisionRef"], f"{path}.review")
+    if review["required"] is not True:
+        die(f"{path}.review.required must be true")
+    if review["approvalRef"] is not None:
+        die(f"{path}.review.approvalRef must be null for pending example items")
+    if review["decisionRef"] is not None:
+        die(f"{path}.review.decisionRef must be null for pending example items")
+    if not review.get("reviewerRefs"):
+        die(f"{path}.review.reviewerRefs must not be empty")
+
+    if not item.get("evidenceRefs"):
+        die(f"{path}.evidenceRefs must not be empty")
+    if not item.get("policyDecisionRefs"):
+        die(f"{path}.policyDecisionRefs must not be empty")
+
+    if item["itemType"] == "break-glass-approval":
+        if source["system"] != "policy-fabric" or source["artifactKind"] != "BreakGlassOverride":
+            die("break-glass approval items must reference PolicyFabric BreakGlassOverride artifacts")
+        if risk["severity"] not in {"high", "critical"}:
+            die("break-glass approval items must be high or critical priority")
+    if item["itemType"] == "memory-learning-review":
+        if source["system"] != "memory-mesh" or source["artifactKind"] != "AgentLearningProposal":
+            die("memory learning review items must reference MemoryMesh AgentLearningProposal artifacts")
+        if risk["actionClass"] != "memory":
+            die("memory learning review items must use actionClass=memory")
+
+
+def validate_queue(queue: dict[str, Any]) -> None:
+    require_keys(queue, ["apiVersion", "kind", "queueId", "createdAt", "owner", "sourceLane", "items"], "queue")
+    if queue["apiVersion"] != "sociosphere.governance-queue/v1":
+        die("queue apiVersion mismatch")
+    if queue["kind"] != "AgentReliabilityGovernanceQueue":
+        die("queue kind mismatch")
+    if queue["sourceLane"] != "sourceos-agent-reliability-control-plane":
+        die("queue sourceLane mismatch")
+    items = queue["items"]
+    if not isinstance(items, list) or not items:
+        die("queue.items must be a non-empty list")
+    seen: set[str] = set()
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            die(f"items[{index}] must be an object")
+        validate_item(item, seen, index)
+    types = {item["itemType"] for item in items}
+    if "break-glass-approval" not in types:
+        die("example queue must include at least one break-glass-approval item")
+    if "memory-learning-review" not in types:
+        die("example queue must include at least one memory-learning-review item")
+
+
+def main() -> int:
+    schema = load_json(SCHEMA)
+    queue = load_json(EXAMPLE)
+    validate_schema_shape(schema)
+    validate_queue(queue)
+    print("[agent-reliability-governance-queue] OK: queue schema and example validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the first SocioSphere governance queue contract for the SourceOS Agent Reliability Control Plane.

## What changed

- Added `standards/agent-reliability/governance-queue.schema.v0.1.json`
  - queue contract for review items from PolicyFabric, MemoryMesh, AgentPlane, and guardrail-fabric
  - supports break-glass approvals, memory learning reviews, stop-gate waivers, and external-action reviews
- Added `standards/agent-reliability/examples/governance-queue.example.v0.1.json`
  - includes a PolicyFabric `BreakGlassOverride` review item
  - includes a MemoryMesh `AgentLearningProposal` review item
- Added `tools/validate_agent_reliability_governance_queue.py`
  - dependency-free validator
  - checks queue shape and semantic invariants
  - enforces pending-by-default review posture
  - enforces source artifact type/system compatibility
  - enforces evidence and policy decision references
- Added `make agent-reliability-governance-queue-validate`
- Added focused workflow `.github/workflows/agent-reliability-governance-queue.yml`
- Added `standards/agent-reliability/README.md`

## Why

PolicyFabric break-glass overrides and MemoryMesh learning proposals should not remain disconnected artifact files. SocioSphere needs a typed review queue so these artifacts become visible governance work items.

## Validation

Expected validation:

```bash
make agent-reliability-governance-queue-validate
make validate
```

## Linked work

Refs SocioProphet/sociosphere#264
Refs SocioProphet/policy-fabric#54
Refs SocioProphet/memory-mesh#22
Refs SocioProphet/agentplane#92
Refs SourceOS Agent Reliability Control Plane workstream.