### PR TITLE
registry: add ProviderBinding evidence propagation rule

### DIFF
--- a/registry/broker-reasoning-propagation-rules.yaml
+++ b/registry/broker-reasoning-propagation-rules.yaml
@@ -1,8 +1,8 @@
 # Broker reasoning propagation rules
 # Companion registry for the cross-cloud services broker reasoning loop.
 
-version: "0.1.0"
-updated_at: "2026-04-26"
+version: "0.2.0"
+updated_at: "2026-05-07"
 
 rules:
   - id: broker-standard-change
@@ -51,6 +51,31 @@ rules:
       - repo: sociosphere
         action: validate_topology
         reason: broker contract changes must be checked against dependency-direction rules
+
+  - id: provider-binding-evidence-profile-change
+    trigger:
+      repo: prophet-platform
+      paths:
+        - specs/brokerage/schemas/provider-binding-evidence-profile.schema.json
+        - specs/brokerage/events/examples/provider-binding-evidence-profile.example.json
+        - docs/reference/next-gen-tom/provider-binding-evidence-refs.md
+        - tools/validate_provider_binding_evidence_profile.py
+    propagate_to:
+      - repo: policy-fabric
+        action: review_evidence_requirements
+        reason: policy decisions must enforce evidence profiles and exception posture
+      - repo: agentplane
+        action: review_execution_evidence_inputs
+        reason: execution bundles must emit evidence required by ProviderBinding profiles
+      - repo: global-devsecops-intelligence
+        action: review_evidence_graph_projection
+        reason: operational intelligence must reason over required and missing evidence refs
+      - repo: alexandrian-academy
+        action: review_training_gates
+        reason: broker training and evaluations must include evidence-profile review cases
+      - repo: sociosphere
+        action: validate_broker_evidence_propagation
+        reason: evidence-profile changes must trigger downstream review across broker reasoning repos
 
   - id: broker-reasoning-output-change
     trigger:

--- a/tools/check_broker_reasoning_propagation.py
+++ b/tools/check_broker_reasoning_propagation.py
@@ -17,6 +17,7 @@ RULES = ROOT / "registry" / "broker-reasoning-propagation-rules.yaml"
 REQUIRED_RULE_IDS = {
     "broker-standard-change",
     "provider-binding-contract-change",
+    "provider-binding-evidence-profile-change",
     "broker-reasoning-output-change",
 }
 


### PR DESCRIPTION
## Summary

Adds ProviderBinding evidence-profile propagation to SocioSphere's broker reasoning registry.

## Changes

- Updates `registry/broker-reasoning-propagation-rules.yaml` to add `provider-binding-evidence-profile-change`.
- Updates `tools/check_broker_reasoning_propagation.py` so the checker requires that new rule.

## Why

ProviderBinding evidence-profile changes affect downstream policy evaluation, AgentPlane execution bundles, operational-intelligence graph projection, Academy training/evaluation gates, and SocioSphere topology/hardening review. This makes that propagation explicit and checkable.

## Scope

Registry/checker only. No runtime broker behavior changes.
