### PR TITLE
protocol(identity): add HELL-ER service layer

### DIFF
--- a/docs/architecture/identity-is-prime-regis-acr-sociosphere.md
+++ b/docs/architecture/identity-is-prime-regis-acr-sociosphere.md
@@ -1,22 +1,23 @@
-# Identity Is Prime × Regis × ACR × Sociosphere Integration
+# Identity Is Prime × HELL-ER × Regis × ACR × Sociosphere Integration
 
 Issue: https://github.com/SocioProphet/sociosphere/issues/284
 
 ## Purpose
 
-This document defines the Sociosphere integration spine for the Identity Is Prime reference implementation, Regis Entity Graph, Authority Concordance Rex (ACR), Agent Registry, Holmes, and Sherlock Search. Sociosphere is the cross-repo workspace controller: it pins repositories, executes validation, records conformance, and provides deterministic retest lanes.
+This document defines the Sociosphere integration spine for the Identity Is Prime reference implementation, HELL-ER, Regis Entity Graph, Authority Concordance Rex (ACR), Agent Registry, Holmes, and Sherlock Search. Sociosphere is the cross-repo workspace controller: it pins repositories, executes validation, records conformance, and provides deterministic retest lanes.
 
-The integration is not a centralized lakehouse design. The runtime target is local-first and cache-first: assertion cache, crosswalk cache, golden projection cache, delta cursors, proof artifacts, and certificate ledgers. Sociosphere coordinates the workspace and retest evidence; it does not become the data warehouse.
+The integration is not a centralized lakehouse design. The runtime target is local-first and cache-first: assertion cache, crosswalk cache, golden projection cache, delta cursors, proof artifacts, release packs, and certificate ledgers. Sociosphere coordinates the workspace and retest evidence; it does not become the data warehouse.
 
 ## Architectural hierarchy
 
 1. Identity Is Prime is the doctrine and reference implementation. It defines prime-topic identity, Event-IR, policy polytopes, congruence lanes, non-escape semantics, proof artifacts, and fog-first deployment.
-2. Regis Entity Graph is the graph implementation surface. It stores canonical entities, source records, identity states, concordance links, transition edges, decision ledger entries, and proof certificates.
-3. ACR is the authority concordance service profile. It owns versioned authority templates, connector schema evolution, entity resolution, crosswalks, golden projections, and point-in-time proofs.
-4. Holmes is the investigative/evidence-reasoning layer for Regis. It should consume Regis graph state, proof artifacts, ledger entries, policy decisions, and contradiction/refutation events to form explainable investigative cases.
-5. Sherlock Search is the retrieval and search surface for Regis/Holmes evidence. It should index entities, events, assertions, certificates, source records, crosswalks, and decision-ledger entries without becoming canonical truth.
-6. Agent Registry declares the agents that observe, normalize, classify, resolve, retrieve, reason, prove, and audit. Agents submit observations, search results, decisions, proposed graph mutations, and certificates. They do not free-write canonical truth.
-7. Sociosphere coordinates and retests the full estate through its manifest, lock file, runner, workspace policy, and protocol fixtures.
+2. HELL-ER is the symbiotic hazard-governed entity-resolution and identity-release service function paired with the core prime identity substrate. It classifies hazards, resolves subjects, preserves contradictions, distinguishes query-negative from fact-absent, evaluates release, emits release packs, and controls leakage/lifecycle semantics.
+3. Regis Entity Graph is the graph implementation surface. It stores canonical entities, source records, identity states, concordance links, transition edges, decision ledger entries, proof certificates, contradiction pointers, and release-pack pointers.
+4. ACR is the authority concordance service profile. It owns versioned authority templates, connector schema evolution, entity resolution, crosswalks, golden projections, and point-in-time proofs.
+5. Holmes is the investigative/evidence-reasoning layer for Regis and HELL-ER. It should consume Regis graph state, HELL-ER contradiction objects, proof artifacts, ledger entries, policy decisions, and contradiction/refutation events to form explainable investigative cases.
+6. Sherlock Search is the retrieval and search surface for Regis/Holmes/HELL-ER evidence. It should index entities, events, assertions, certificates, source records, release packs, crosswalks, and decision-ledger entries without becoming canonical truth.
+7. Agent Registry declares the agents that observe, normalize, classify, resolve, retrieve, reason, prove, redact, review, and audit. Agents submit observations, search results, decisions, proposed graph mutations, release decisions, and certificates. They do not free-write canonical truth.
+8. Sociosphere coordinates and retests the full estate through its manifest, lock file, runner, workspace policy, and protocol fixtures.
 
 ## Existing upstream anchors
 
@@ -32,7 +33,7 @@ The Sociosphere manifest already contains the following relevant repositories:
 - `sourceos-spec`
 - `policy-fabric`
 
-The manifest should also include `agent-registry`, `holmes`, and `sherlock-search` as first-class components or focused lane overlay entries if they are not already materialized through another repo entry.
+The focused Identity Prime workspace overlay should also materialize or pin `agent-registry`, `holmes`, `sherlock-search`, and `meshrush` where absent.
 
 ## Integration contracts
 
@@ -49,9 +50,49 @@ The reference repo provides the normative behavior for:
 - proof artifact production
 - zeta-style identity-state audit metrics
 
+### HELL-ER service function
+
+HELL-ER belongs inside Identity Is Prime while remaining a distinct service function. It is HADES-descended, Heller-derived, and entity-resolution-centered.
+
+HELL-ER owns protocol semantics for:
+
+- hazard envelopes
+- prime atoms
+- context-scoped identity release
+- contradiction objects
+- query-negative / fact-absent separation
+- assurance vectors
+- release policies
+- release packs
+- redress queues
+- merge/split audit artifacts
+- revocation and expiry semantics
+
+Initial HELL-ER protocol material lives under:
+
+- `protocol/identity-is-prime/hell-er/README.md`
+- `protocol/identity-is-prime/hell-er/schemas/prime-atom.v1.schema.json`
+- `protocol/identity-is-prime/hell-er/schemas/contradiction-object.v1.schema.json`
+- `protocol/identity-is-prime/hell-er/schemas/release-pack.v1.schema.json`
+- `protocol/identity-is-prime/hell-er/fixtures/release_pack.internal_operational.synthetic.valid.json`
+- `protocol/identity-is-prime/hell-er/expected/release_pack.internal_operational.synthetic.valid.result.json`
+
+Candidate HELL-ER service methods:
+
+- `heller.classify_hazard`
+- `heller.resolve_subject`
+- `heller.record_contradiction`
+- `heller.evaluate_release`
+- `heller.emit_release_pack`
+- `heller.redact_for_audience`
+- `heller.register_redress`
+- `heller.revoke_or_expire_atom`
+- `heller.evaluate_merge`
+- `heller.evaluate_split`
+
 ### Regis Entity Graph
 
-Regis consumes Identity Is Prime as graph semantics. Required graph object families:
+Regis consumes Identity Is Prime and HELL-ER as graph semantics. Required graph object families:
 
 - `CanonicalEntity`
 - `SourceRecord`
@@ -69,6 +110,8 @@ Regis consumes Identity Is Prime as graph semantics. Required graph object famil
 - `TransitionCertificate`
 - `NonEscapeCertificate`
 - `ConcordanceDecisionCertificate`
+- `ContradictionObject`
+- `ReleasePackPointer`
 - `SearchIndexRecord`
 - `InvestigationCase`
 - `EvidenceFinding`
@@ -77,25 +120,25 @@ Regis consumes Identity Is Prime as graph semantics. Required graph object famil
 
 Holmes should be the Regis-native investigative reasoning surface. Its responsibilities are:
 
-- consume Regis graph snapshots and ledger/certificate pointers
+- consume Regis graph snapshots and ledger/certificate/release-pack pointers
 - assemble evidence findings into investigation cases
-- explain why a linkage was verified, refuted, undecidable, stale, or review-bound
-- detect contradictions across ACR concordance, identity polytope policy, token non-escape, and source assertions
+- explain why a linkage or release was verified, refuted, undecidable, stale, redacted, revoked, expired, or review-bound
+- detect contradictions across ACR concordance, HELL-ER release decisions, identity polytope policy, token non-escape, and source assertions
 - emit proposed graph annotations or case findings, not canonical truth
 
-Holmes outputs must be reducible to Regis evidence objects and must carry policy/schema/resolver/template version pins.
+Holmes outputs must be reducible to Regis evidence objects and must carry policy/schema/resolver/template/release-template version pins.
 
 ### Sherlock Search retrieval layer
 
 Sherlock Search should be the retrieval layer for evidence discovery and operator/user query. Its responsibilities are:
 
-- index canonical entities, source records, identity states, worldline events, ledger entries, certificates, and Holmes findings
-- provide search over proof and evidence surfaces
-- return cited graph pointers, source pointers, and ledger pointers
+- index canonical entities, source records, identity states, worldline events, ledger entries, certificates, HELL-ER release packs, and Holmes findings
+- provide search over proof, release, and evidence surfaces
+- return cited graph pointers, source pointers, release-pack pointers, and ledger pointers
 - support delta indexing for local-first/cache-first runtime
 - avoid writing canonical entity truth directly
 
-Sherlock Search should be treated as an indexing and retrieval adapter for Regis/Holmes, not as the system of record.
+Sherlock Search should be treated as an indexing and retrieval adapter for Regis/Holmes/HELL-ER, not as the system of record.
 
 ### ACR service profile
 
@@ -116,6 +159,10 @@ Required agent families:
 
 - `prime-topic-agent`
 - `identity-polytope-agent`
+- `heller-hazard-agent`
+- `heller-release-agent`
+- `heller-redaction-agent`
+- `heller-contradiction-agent`
 - `transition-graph-agent`
 - `congruence-non-escape-agent`
 - `zeta-audit-agent`
@@ -131,7 +178,7 @@ Required agent families:
 - `sherlock-index-agent`
 - `sherlock-query-agent`
 
-Each manifest must declare input schemas, output schemas, graph write permissions, policy scopes, TRIT RPC bindings, retrieval permissions, and evidence outputs. A manifest that lacks the required policy scope or graph/search permission must be rejected by conformance.
+Each manifest must declare input schemas, output schemas, graph write permissions, policy scopes, TRIT RPC bindings, retrieval permissions, release permissions, redaction permissions, and evidence outputs. A manifest that lacks the required policy scope or graph/search/release permission must be rejected by conformance.
 
 ## Sociosphere conformance lanes
 
@@ -142,13 +189,14 @@ The Sociosphere retest controller should expose these lanes:
 3. `identity-prime-transition`: validates admissible transition and no-path cases.
 4. `identity-prime-token`: validates congruence and token non-escape cases.
 5. `identity-prime-audit`: validates zeta-style identity audit summaries.
-6. `regis-graph-contracts`: validates Regis graph objects and proof certificate pointers.
-7. `holmes-case-contracts`: validates Holmes case/finding outputs against Regis evidence semantics.
-8. `sherlock-index-contracts`: validates Sherlock index records, search result pointers, and delta indexing receipts.
-9. `agent-registry-identity`: validates agent manifests and policy scopes.
-10. `acr-concordance-profile`: validates source assertion, crosswalk, golden projection, and proof fixtures.
-11. `tritrpc-wire`: verifies deterministic request/response fixture encoding.
-12. `workspace-identity-conformance`: runs the clean end-to-end lane across pinned repos.
+6. `hell-er-release`: validates hazard envelopes, contradiction objects, release packs, redaction, and query-negative/fact-absent separation.
+7. `regis-graph-contracts`: validates Regis graph objects and proof certificate pointers.
+8. `holmes-case-contracts`: validates Holmes case/finding outputs against Regis and HELL-ER evidence semantics.
+9. `sherlock-index-contracts`: validates Sherlock index records, search result pointers, release-pack pointers, and delta indexing receipts.
+10. `agent-registry-identity`: validates agent manifests and policy scopes.
+11. `acr-concordance-profile`: validates source assertion, crosswalk, golden projection, and proof fixtures.
+12. `tritrpc-wire`: verifies deterministic request/response fixture encoding.
+13. `workspace-identity-conformance`: runs the clean end-to-end lane across pinned repos.
 
 ## Required fixture families
 
@@ -161,6 +209,11 @@ Fixtures live under `protocol/identity-is-prime/` and should be portable across 
 - token non-escape valid examples
 - token non-escape violation examples
 - zeta audit windows
+- HELL-ER release-pack examples
+- HELL-ER query-negative / not-absent examples
+- HELL-ER contradiction flattening rejection examples
+- HELL-ER silent merge/split rejection examples
+- HELL-ER external unredacted-release rejection examples
 - ACR concordance and golden record proof examples
 - Holmes case and contradiction examples
 - Sherlock search index and query-result pointer examples
@@ -173,30 +226,37 @@ Every conformance result must pin:
 - `policy_version`
 - `resolver_version`
 - `template_version`, when ACR participates
+- `release_template_version`, when HELL-ER participates
+- `hazard_classifier_version`, when HELL-ER participates
 - `index_version`, when Sherlock Search participates
 - `case_model_version`, when Holmes participates
 - `fixture_version`
 - `input_hash`
 - `result_hash`
 - `certificate_hash`, when a proof is emitted
+- `release_pack_hash`, when a release pack is emitted
 
 A repeated clean checkout with the same pins must produce equivalent results.
 
 ## Acceptance criteria
 
-- Sociosphere can fetch the pinned repos and execute the Identity Is Prime / Regis / Holmes / Sherlock / ACR / Agent Registry conformance suite.
+- Sociosphere can fetch the pinned repos and execute the Identity Is Prime / HELL-ER / Regis / Holmes / Sherlock / ACR / Agent Registry conformance suite.
 - Identity polytope fixtures return deterministic `VERIFIED` or `REFUTED` results.
 - Token non-escape violations produce structural refutations rather than probabilistic scores.
+- HELL-ER release-pack fixtures preserve context, hazard profile, contradiction ledger, assurance vector, lifecycle, release policy, and machine annex.
+- HELL-ER fixtures refuse to convert query-negative into fact-absent.
+- HELL-ER fixtures reject silent merge, silent split, and external unredacted direct-identifier release.
 - ACR golden record proof fixtures include shared ledger and certificate pointers.
-- Holmes findings cite Regis graph, ledger, certificate, or source pointers.
-- Sherlock search results cite indexed Regis/Holmes pointers and never claim canonical truth without graph/ledger backing.
-- Agent manifests without required policy scopes, graph permissions, or search permissions are rejected.
+- Holmes findings cite Regis graph, HELL-ER release pack, ledger, certificate, or source pointers.
+- Sherlock search results cite indexed Regis/Holmes/HELL-ER pointers and never claim canonical truth without graph/ledger backing.
+- Agent manifests without required policy scopes, graph permissions, search permissions, release permissions, or redaction permissions are rejected.
 - The integration remains local-first and cache-first; no central lakehouse dependency is introduced.
 
 ## Follow-on work
 
 1. Materialize `agent-registry`, `holmes`, and `sherlock-search` in `manifest/workspace.toml` or the focused Identity Prime workspace overlay if absent.
-2. Add executable validators under `tools/conformance/`.
-3. Promote the fixture skeleton into schema-backed JSON validation.
-4. Add TRIT RPC fixtures for `identityprime.v1`, `regis.proof.v1`, `holmes.case.v1`, `sherlock.search.v1`, and `acr.concordance.v1`.
+2. Add executable validators under `tools/conformance/` for HELL-ER schema and fixture validation.
+3. Promote the HELL-ER fixture skeleton into schema-backed JSON validation.
+4. Add TRIT RPC fixtures for `identityprime.v1`, `heller.identity.v1`, `regis.proof.v1`, `holmes.case.v1`, `sherlock.search.v1`, and `acr.concordance.v1`.
 5. Wire conformance outputs into the Sociosphere registry/evidence pattern.
+6. Decide whether HELL-ER release packs are signed independently or through Regis proof certificates.

--- a/protocol/identity-is-prime/README.md
+++ b/protocol/identity-is-prime/README.md
@@ -1,6 +1,6 @@
 # Identity Is Prime protocol fixtures
 
-These fixtures anchor the Sociosphere conformance lane for Identity Is Prime, Regis Entity Graph, Authority Concordance Rex (ACR), and Agent Registry integration.
+These fixtures anchor the Sociosphere conformance lane for Identity Is Prime, Regis Entity Graph, Authority Concordance Rex (ACR), Agent Registry integration, and the HELL-ER hazard-governed entity-resolution service function.
 
 The fixture set is intentionally small in this first pass. It establishes deterministic semantics for:
 
@@ -8,8 +8,32 @@ The fixture set is intentionally small in this first pass. It establishes determ
 - forbidden identity mixtures
 - token congruence and non-escape violations
 - ACR golden-record proof shape
+- HELL-ER identity release packs, contradiction preservation, hazard classification, and no-silent-release invariants
 
 Each fixture should eventually be backed by executable validators under `tools/conformance/` and by TRIT RPC request/response fixtures for the relevant service surfaces.
+
+## HELL-ER service function
+
+HELL-ER belongs inside Identity Is Prime but remains a distinct symbiotic service function.
+
+Identity Is Prime defines what prime identity means. HELL-ER governs how identity evidence is classified, resolved, contradicted, transformed, redacted, released, revoked, and reviewed.
+
+The HELL-ER protocol lives under:
+
+- `hell-er/README.md`
+- `hell-er/schemas/`
+- `hell-er/fixtures/`
+- `hell-er/expected/`
+
+Initial HELL-ER schemas:
+
+- `hell-er/schemas/prime-atom.v1.schema.json`
+- `hell-er/schemas/contradiction-object.v1.schema.json`
+- `hell-er/schemas/release-pack.v1.schema.json`
+
+Initial HELL-ER fixture:
+
+- `hell-er/fixtures/release_pack.internal_operational.synthetic.valid.json`
 
 ## Required result vocabulary
 
@@ -18,6 +42,9 @@ Each fixture should eventually be backed by executable validators under `tools/c
 - `UNDECIDABLE`: the current abstraction lacks enough evidence to prove or refute.
 - `STALE`: the fixture or certificate pins outdated schema, policy, resolver, or template versions.
 - `REQUIRES_REVIEW`: the fixture requires steward review before graph mutation or publication.
+- `REDACTED`: the object is valid but withheld under the release class.
+- `REVOKED`: the atom, credential, or release is no longer live.
+- `EXPIRED`: the supporting evidence is no longer valid for current use.
 
 ## Determinism fields
 
@@ -27,11 +54,15 @@ Conformance outputs should pin the following where available:
 - `policy_version`
 - `resolver_version`
 - `template_version`
+- `release_template_version`
+- `hazard_classifier_version`
 - `fixture_version`
 - `input_hash`
 - `result_hash`
 - `certificate_hash`
+- `release_pack_hash`
 - `ledger_pointer`
+- `graph_snapshot_ref`
 
 ## First fixture families
 
@@ -40,5 +71,7 @@ Conformance outputs should pin the following where available:
 - `fixtures/token.non_escape.violation.json`
 - `fixtures/acr.golden_record.proof.json`
 - `expected/polytope.valid.result.json`
+- `hell-er/fixtures/release_pack.internal_operational.synthetic.valid.json`
+- `hell-er/expected/release_pack.internal_operational.synthetic.valid.result.json`
 
-Follow-on fixtures should add transition graph, no-admissible-path, zeta audit, agent manifest rejection, and TRIT RPC wire examples.
+Follow-on fixtures should add transition graph, no-admissible-path, zeta audit, agent manifest rejection, TRIT RPC wire examples, HELL-ER query-negative/not-absent examples, contradiction flattening rejection, silent merge/split rejection, and external unredacted-release rejection.

--- a/protocol/identity-is-prime/hell-er/README.md
+++ b/protocol/identity-is-prime/hell-er/README.md
@@ -1,0 +1,333 @@
+# HELL-ER Protocol
+
+## Hazard-Governed Entity Resolution for Identity Is Prime
+
+Status: Draft v0.1  
+Home: `protocol/identity-is-prime/hell-er/`  
+Parent workstream: Identity Is Prime  
+Service role: Symbiotic service function paired with the core prime identity substrate  
+Release posture: Review draft / synthetic fixtures only
+
+## Purpose
+
+HELL-ER is the hazard-governed entity-resolution and identity-release service function for the Identity Is Prime protocol.
+
+Identity Is Prime defines the doctrine: identity is not a flat record. Identity is a context-scoped, time-versioned, policy-constrained composition of prime identity atoms.
+
+HELL-ER defines the operating service: how identity evidence is classified, resolved, contradicted, transformed, redacted, released, revoked, and reviewed.
+
+The system exists to prevent unsafe identity collapse, unsafe release, and unsafe recomposition.
+
+HELL-ER is not a standalone product. It is a protocol and service layer inside the Identity Is Prime workstream.
+
+## Name and lineage
+
+The name **HELL-ER** is intentional.
+
+It is a play on:
+
+- **HADES** — the high-assurance desensitization lineage and predecessor pattern;
+- **Hell / Heller** — the Heller-derived mnemonic and authorial lineage;
+- **ER** — Entity Resolution, the operational kernel.
+
+The intended parse is:
+
+```text
+HADES -> HELL
+HELLER -> HELL-ER
+ER -> Entity Resolution
+```
+
+The architecture keeps the HADES discipline of deterministic, policy-bound, auditable transformation, but moves the governed unit from sensitive fields to identity-bearing graph slices.
+
+Short form:
+
+> HADES protected data values. HELL-ER governs identity meaning.
+
+Canonical form:
+
+> PIF/HELL-ER is the HADES-descended, Heller-derived architecture for context-scoped identity resolution, contradiction preservation, and policy-bound release.
+
+## Relationship to Identity Is Prime
+
+HELL-ER belongs inside Identity Is Prime but remains a distinct service function.
+
+| Layer | Responsibility |
+|---|---|
+| Identity Is Prime | Doctrine, conformance lane, prime identity semantics |
+| PIF | Ontology of prime atoms, context, assurance, release, and contradiction |
+| HELL-ER | Hazard classification, entity resolution, contradiction preservation, leakage/lifecycle control, release-pack generation |
+| Regis Entity Graph | Graph substrate for identity states, concordance links, ledgers, and certificates |
+| ACR | Authority concordance, source-to-canonical crosswalks, golden projections, and point-in-time proofs |
+| Holmes | Investigation, contradiction review, and evidence-case construction |
+| Sherlock Search | Retrieval over evidence, source records, graph pointers, ledger pointers, and proof artifacts |
+| Agent Registry | Least-privilege agents for observation, resolution, proof, search, review, and audit |
+
+HELL-ER is symbiotic with the core identity model:
+
+- Identity Is Prime defines what identity is.
+- HELL-ER decides how identity evidence may be resolved and released.
+
+## Service boundary
+
+Recommended service methods:
+
+```text
+heller.classify_hazard
+heller.resolve_subject
+heller.record_contradiction
+heller.evaluate_release
+heller.emit_release_pack
+heller.redact_for_audience
+heller.register_redress
+heller.revoke_or_expire_atom
+heller.evaluate_merge
+heller.evaluate_split
+```
+
+These methods should be represented as protocol fixtures first, then TriTRPC fixtures, then runtime service endpoints where needed.
+
+## Core concepts
+
+### Prime atom
+
+A prime atom is the smallest identity-bearing assertion treated as atomic for a declared context and purpose.
+
+A prime atom carries an atom id, atom type, context, provenance, sensitivity class, assurance state, lifecycle state, and policy tags. No atom is admissible without provenance.
+
+### Context
+
+A context declares the purpose, audience, served population, policy regime, and operational setting for identity resolution. The same subject may resolve differently in different contexts.
+
+### Hazard envelope
+
+The hazard envelope is the first governance gate. It classifies release and resolution risk before identity evidence is transformed or exposed.
+
+Hazard classes include direct identifier, quasi-identifier, authenticator material, civil-proof material, institutional attribute, role or entitlement attribute, contextual event data, artifact/provenance data, behavioral or derived signal, sensitive preference, restricted professional/IP material, regulated data element, and synthetic demo value.
+
+### Entity/Evidence graph
+
+HELL-ER works over graph state, not flat records. Canonical node families include Subject, Alias, Identifier, Evidence, Attribute, Credential, Authenticator, Organization, Role, Event, Artifact, Source, Assertion, Policy, Contradiction, and ReleasePack.
+
+Canonical edge families include claims, evidenced_by, issued_by, observed_in, affiliated_with, authenticates, federates_to, derived_from, contradicts, supersedes, revokes, supports, required_for, and released_under.
+
+### Contradiction object
+
+A contradiction object records incompatible assertions or graph states. Contradictions are preserved; they are not silently flattened.
+
+### Query-negative
+
+A query-negative means a query did not return a fact. It does not mean the fact is absent. HELL-ER must preserve this distinction in release packs, proof artifacts, and contradiction ledgers.
+
+### Release pack
+
+A release pack is the governed output object for a declared audience and release class. It contains release class, audience, context declaration, hazard profile, subject graph summary, prime atom ledger, contradiction ledger, assurance vector, lifecycle policy, redress queue, and machine-readable annex.
+
+## Result vocabulary
+
+HELL-ER inherits and extends the Identity Is Prime conformance vocabulary:
+
+- `VERIFIED`: the subject state or release decision satisfies pinned policy and schema versions.
+- `REFUTED`: the state structurally violates policy, admissibility, contradiction, non-escape, or release rules.
+- `UNDECIDABLE`: the abstraction lacks enough evidence to prove or refute.
+- `STALE`: the fixture, evidence, certificate, schema, policy, resolver, or release template is outdated.
+- `REQUIRES_REVIEW`: steward review is required before mutation, release, merge, split, or promotion.
+- `REDACTED`: the object is valid but withheld under the release class.
+- `REVOKED`: the atom, credential, or release is no longer live.
+- `EXPIRED`: the supporting evidence is no longer valid for current use.
+
+## Determinism fields
+
+Conformance outputs should pin:
+
+- `schema_version`
+- `policy_version`
+- `resolver_version`
+- `release_template_version`
+- `hazard_classifier_version`
+- `fixture_version`
+- `input_hash`
+- `result_hash`
+- `certificate_hash`
+- `release_pack_hash`
+- `ledger_pointer`
+- `graph_snapshot_ref`
+
+A repeated clean checkout with the same pins should produce equivalent results.
+
+## Core invariants
+
+HELL-ER validators must enforce these invariants:
+
+1. No atom without provenance.
+2. No atom without sensitivity label.
+3. No meaningful assertion without context.
+4. No release without release class.
+5. No release without policy tag.
+6. No query-negative converted into fact-absent.
+7. No unresolved contradiction silently flattened.
+8. No merge without merge audit artifact.
+9. No split without split audit artifact.
+10. No expired or revoked evidence supporting a live assertion without review.
+11. No contextual identity escalated into civil proof without proofing evidence.
+12. No authenticator assurance collapsed into identity-proofing assurance.
+13. No derived behavioral atom treated as direct evidence.
+14. No external release of unredacted direct identifiers without explicit authorization.
+15. No Sherlock search result treated as canonical truth without Regis/ledger backing.
+16. No Holmes finding promoted to canonical graph mutation without policy and steward route.
+
+## Required fixture families
+
+Initial fixture families should include:
+
+```text
+prime_atom.valid.json
+prime_atom.missing_provenance.invalid.json
+query_negative_not_absent.valid.json
+contradiction.open.valid.json
+contradiction.flattened.invalid.json
+release_pack.self_view.valid.json
+release_pack.external_redacted.valid.json
+release_pack.missing_policy.invalid.json
+release_pack.unredacted_external.invalid.json
+merge.audit.valid.json
+merge.silent.invalid.json
+split.audit.valid.json
+split.silent.invalid.json
+civil_proof_escalation.invalid.json
+expired_evidence_support.invalid.json
+```
+
+## Schema set
+
+The first schema tranche in this directory defines:
+
+- `schemas/prime-atom.v1.schema.json`
+- `schemas/contradiction-object.v1.schema.json`
+- `schemas/release-pack.v1.schema.json`
+
+Recommended future schemas:
+
+- `context-declaration.v1.schema.json`
+- `hazard-envelope.v1.schema.json`
+- `entity-evidence-node.v1.schema.json`
+- `entity-evidence-edge.v1.schema.json`
+- `assurance-vector.v1.schema.json`
+- `release-policy.v1.schema.json`
+- `merge-split-artifact.v1.schema.json`
+- `redress-item.v1.schema.json`
+
+## Synthetic demo fixture policy
+
+HELL-ER examples must use synthetic demo data unless explicitly approved.
+
+Permitted demo subject name:
+
+```text
+Michael Heller
+```
+
+All other demo attributes should be synthetic placeholders unless separately approved.
+
+Expected demo outcome:
+
+```text
+context_resolved access: VERIFIED
+civil_identity_proof: UNDECIDABLE / not proofed
+authenticator_binding: pending or separate
+stale affiliation contradiction: retained
+external release: redacted
+```
+
+## TriTRPC service candidates
+
+Candidate service namespace:
+
+```text
+heller.identity.v1
+```
+
+Candidate methods:
+
+```text
+ClassifyHazard
+ResolveSubject
+RecordContradiction
+EvaluateRelease
+EmitReleasePack
+RedactForAudience
+RegisterRedress
+RevokeAtom
+ExpireEvidence
+EvaluateMerge
+EvaluateSplit
+```
+
+## Relationship to Regis / ACR
+
+HELL-ER does not replace Regis or ACR.
+
+- Regis stores graph state and proof certificates.
+- ACR performs authority concordance, source-to-canonical crosswalks, and point-in-time golden projections.
+- HELL-ER governs whether identity graph slices, assertions, contradictions, and release packs are safe to resolve, transform, or release.
+
+Boundary:
+
+```text
+Regis = graph state
+ACR = authority concordance
+HELL-ER = hazard-governed resolution and release
+```
+
+## Relationship to Holmes and Sherlock
+
+Holmes consumes HELL-ER contradiction objects, graph snapshots, ledger pointers, and release decisions to assemble investigative cases.
+
+Sherlock indexes HELL-ER release packs, graph pointers, contradiction summaries, and evidence references for retrieval.
+
+Neither Holmes nor Sherlock writes canonical identity truth directly.
+
+## Acceptance criteria
+
+HELL-ER v0.1 is acceptable when:
+
+- schemas validate prime atoms, contradiction objects, and release packs;
+- fixtures cover valid and invalid release paths;
+- conformance validator rejects missing provenance;
+- conformance validator rejects missing policy;
+- query-negative cannot be interpreted as fact-absent;
+- silent merge and silent split fixtures are refuted;
+- external release of unredacted direct identifiers is refuted;
+- synthetic demo fixture emits a release pack with contradiction retention;
+- service method fixtures are deterministic under pinned schema/policy/resolver versions.
+
+## Open questions
+
+1. Should `heller.identity.v1` be a distinct TriTRPC namespace or part of `regis.proof.v1`?
+2. Should HELL-ER release packs be signed independently or through Regis proof certificates?
+3. Which HELL-ER objects belong in Ontogenesis first?
+4. Should contradiction existence be visible in external redacted release packs?
+5. What is the minimal assurance vector required for v0.1?
+6. Which PIF atoms require independent signatures?
+7. Should redress be a first-class service method in v0.1 or v0.2?
+8. Should HELL-ER own selective disclosure or delegate to a credentials service?
+9. What privacy metric gates release?
+10. How should graph-neighborhood leakage be estimated?
+
+## Initial implementation sequence
+
+1. Add minimal JSON schemas for prime atom, contradiction object, and release pack.
+2. Add synthetic valid and invalid fixtures.
+3. Extend `tools/conformance/validate_identity_is_prime_fixtures.py` to discover `hell-er/fixtures`.
+4. Add deterministic expected result files.
+5. Add TriTRPC request/response fixture skeletons.
+6. Update the Identity Is Prime architecture doc to describe HELL-ER as a symbiotic service function.
+7. Only then wire Prophet Platform runtime service consumption.
+
+## Final summary
+
+HELL-ER is the governed service function that makes Identity Is Prime operationally safe.
+
+It is HADES-descended, Heller-derived, and entity-resolution-centered.
+
+It does not define identity by itself. It governs how prime identity evidence is resolved, contradicted, released, redacted, revoked, and reviewed.

--- a/protocol/identity-is-prime/hell-er/expected/release_pack.internal_operational.synthetic.valid.result.json
+++ b/protocol/identity-is-prime/hell-er/expected/release_pack.internal_operational.synthetic.valid.result.json
@@ -1,0 +1,18 @@
+{
+  "fixture": "protocol/identity-is-prime/hell-er/fixtures/release_pack.internal_operational.synthetic.valid.json",
+  "expected_result": "VERIFIED",
+  "schema_version": "hell-er.release-pack.v1",
+  "policy_version": "policy://identity-prime/hell-er/grant-review/internal-operational/v1",
+  "resolver_version": "hell-er.synthetic.resolver.v0.1",
+  "release_template_version": "hell-er.release-template.internal-operational.v0.1",
+  "hazard_classifier_version": "hell-er.hazard-classifier.synthetic.v0.1",
+  "result_requirements": {
+    "context_resolved_access": true,
+    "civil_identity_not_proofed": true,
+    "stale_affiliation_contradiction_retained": true,
+    "minimum_necessary": true,
+    "bulk_export_denied": true,
+    "release_pack_has_machine_annex": true
+  },
+  "notes": "Expected conformance result for synthetic HELL-ER internal operational release pack."
+}

--- a/protocol/identity-is-prime/hell-er/expected/release_pack.missing_policy.invalid.result.json
+++ b/protocol/identity-is-prime/hell-er/expected/release_pack.missing_policy.invalid.result.json
@@ -1,0 +1,6 @@
+{
+  "fixture": "protocol/identity-is-prime/hell-er/fixtures/release_pack.missing_policy.invalid.json",
+  "expected_result": "REFUTED",
+  "expected_violation": "MISSING_RELEASE_POLICY",
+  "reason": "HELL-ER release packs must not be emitted without release_policy."
+}

--- a/protocol/identity-is-prime/hell-er/expected/release_pack.query_negative_as_absent.invalid.result.json
+++ b/protocol/identity-is-prime/hell-er/expected/release_pack.query_negative_as_absent.invalid.result.json
@@ -1,0 +1,6 @@
+{
+  "fixture": "protocol/identity-is-prime/hell-er/fixtures/release_pack.query_negative_as_absent.invalid.json",
+  "expected_result": "REFUTED",
+  "expected_violation": "QUERY_NEGATIVE_AS_FACT_ABSENT",
+  "reason": "HELL-ER must preserve query_negative as a distinct state and must not convert it into fact_absent."
+}

--- a/protocol/identity-is-prime/hell-er/fixtures/release_pack.internal_operational.synthetic.valid.json
+++ b/protocol/identity-is-prime/hell-er/fixtures/release_pack.internal_operational.synthetic.valid.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "hell-er.release-pack.v1",
+  "release_pack_id": "rp_demo_michael_heller_grant_review_001",
+  "release_class": "internal_operational",
+  "audience": {
+    "audience_type": "internal_service",
+    "audience_ref": "grant-review-access-controller.synthetic",
+    "purpose": "approve limited read-only grant-review workspace access"
+  },
+  "context": {
+    "context_ref": "ctx_grant_review_synthetic_2026",
+    "context_type": "grant_review",
+    "served_population": "synthetic reviewers",
+    "policy_regime": "policy://identity-prime/hell-er/synthetic-demo"
+  },
+  "hazard_profile": {
+    "hazard_classes": [
+      "role_or_entitlement",
+      "contextual_event",
+      "artifact_or_provenance",
+      "synthetic_demo_value"
+    ],
+    "minimum_necessary": true,
+    "release_risk": "low",
+    "abuse_modes": [
+      "role_overgrant",
+      "stale_affiliation_reuse",
+      "civil_proof_escalation"
+    ]
+  },
+  "subject_graph_summary": {
+    "subject_state": "context_resolved",
+    "subject_ref": "subject:michael-heller.synthetic",
+    "graph_snapshot_ref": "graph://regis/synthetic/michael-heller/grant-review/001",
+    "node_count": 8,
+    "edge_count": 12
+  },
+  "prime_atom_ledger": [
+    {
+      "atom_ref": "pa_role_reviewer_invitation_001",
+      "released": true,
+      "redaction_state": "not_redacted",
+      "reason": "required for access decision",
+      "policy_tags": [
+        "minimum_necessary",
+        "internal_operational"
+      ]
+    },
+    {
+      "atom_ref": "pa_affiliation_legacy_001",
+      "released": false,
+      "redaction_state": "withheld",
+      "reason": "stale and not required for access decision",
+      "policy_tags": [
+        "stale",
+        "withhold_external"
+      ]
+    }
+  ],
+  "contradiction_ledger": [
+    {
+      "contradiction_ref": "co_affiliation_stale_001",
+      "released": true,
+      "summary_state": "summary_only",
+      "reason": "internal reviewer must know stale affiliation contradiction exists"
+    }
+  ],
+  "assurance_vector": {
+    "identity_state": "context_resolved",
+    "evidence_state": "moderate",
+    "authenticator_state": "pending_binding",
+    "civil_identity_state": "not_proofed",
+    "federation_state": "not_applicable"
+  },
+  "release_policy": {
+    "policy_ref": "policy://identity-prime/hell-er/grant-review/internal-operational/v1",
+    "allowed_actions": [
+      "read_grant_materials",
+      "submit_review_notes"
+    ],
+    "denied_actions": [
+      "export_bulk_applicant_data",
+      "change_award_status",
+      "access_financial_disbursement_records"
+    ],
+    "review_required": false,
+    "review_ref": null
+  },
+  "lifecycle": {
+    "state": "active",
+    "retention_policy_ref": "retention://synthetic-demo/30d",
+    "expires_at": "2026-06-07T00:00:00Z",
+    "revoked_at": null
+  },
+  "redress_queue": [],
+  "machine_annex": {
+    "annex_ref": "artifact://hell-er/demo/release-pack-annex-001.json",
+    "annex_hash": "sha256:synthetic-placeholder",
+    "format": "json"
+  },
+  "created_at": "2026-05-08T00:00:00Z",
+  "signed_by": [
+    "heller.synthetic.verifier"
+  ],
+  "notes": "Synthetic demo fixture using Michael Heller as permitted demonstrative subject name; all attributes are synthetic placeholders."
+}

--- a/protocol/identity-is-prime/hell-er/fixtures/release_pack.missing_policy.invalid.json
+++ b/protocol/identity-is-prime/hell-er/fixtures/release_pack.missing_policy.invalid.json
@@ -1,0 +1,23 @@
+{
+  "fixture_id": "hell-er.release-pack.missing-policy.invalid.v0.1",
+  "fixture_version": "0.1",
+  "expected_result": "REFUTED",
+  "expected_violation": "MISSING_RELEASE_POLICY",
+  "candidate_release_pack": {
+    "schema_version": "hell-er.release-pack.v1",
+    "release_pack_id": "rp_invalid_missing_policy_001",
+    "release_class": "internal_operational",
+    "audience": {
+      "audience_type": "internal_service",
+      "audience_ref": "grant-review-access-controller.synthetic",
+      "purpose": "approve limited read-only grant-review workspace access"
+    },
+    "context": {
+      "context_ref": "ctx_grant_review_synthetic_2026",
+      "context_type": "grant_review",
+      "served_population": "synthetic reviewers",
+      "policy_regime": "policy://identity-prime/hell-er/synthetic-demo"
+    },
+    "notes": "Invalid by construction: release_policy is omitted."
+  }
+}

--- a/protocol/identity-is-prime/hell-er/fixtures/release_pack.query_negative_as_absent.invalid.json
+++ b/protocol/identity-is-prime/hell-er/fixtures/release_pack.query_negative_as_absent.invalid.json
@@ -1,0 +1,37 @@
+{
+  "fixture_id": "hell-er.query-negative-as-absent.invalid.v0.1",
+  "fixture_version": "0.1",
+  "expected_result": "REFUTED",
+  "expected_violation": "QUERY_NEGATIVE_AS_FACT_ABSENT",
+  "query_negative_handling": {
+    "query_ref": "query://synthetic/missing-affiliation-search/001",
+    "searched_scope": "synthetic-volunteer-registry-v1",
+    "query_negative_interpreted_as_absent": true,
+    "incorrect_output_state": "fact_absent",
+    "correct_state": "query_negative"
+  },
+  "candidate_release_pack": {
+    "schema_version": "hell-er.release-pack.v1",
+    "release_pack_id": "rp_invalid_query_negative_absent_001",
+    "release_class": "internal_operational",
+    "audience": {
+      "audience_type": "internal_service",
+      "audience_ref": "grant-review-access-controller.synthetic",
+      "purpose": "approve limited read-only grant-review workspace access"
+    },
+    "context": {
+      "context_ref": "ctx_grant_review_synthetic_2026",
+      "context_type": "grant_review",
+      "served_population": "synthetic reviewers",
+      "policy_regime": "policy://identity-prime/hell-er/synthetic-demo"
+    },
+    "release_policy": {
+      "policy_ref": "policy://identity-prime/hell-er/grant-review/internal-operational/v1",
+      "allowed_actions": ["read_grant_materials"],
+      "denied_actions": ["export_bulk_applicant_data"],
+      "review_required": true,
+      "review_ref": "review://synthetic/query-negative-misuse"
+    },
+    "notes": "Invalid by construction: a query-negative is interpreted as authoritative absence."
+  }
+}

--- a/protocol/identity-is-prime/hell-er/schemas/contradiction-object.v1.schema.json
+++ b/protocol/identity-is-prime/hell-er/schemas/contradiction-object.v1.schema.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/identity-is-prime/hell-er/contradiction-object.v1.schema.json",
+  "title": "HELL-ER Contradiction Object v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "contradiction_id",
+    "topic",
+    "subject_scope",
+    "contradiction_class",
+    "conflicting_assertions",
+    "provenance",
+    "severity",
+    "resolution_status",
+    "preferred_redress_path",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "hell-er.contradiction-object.v1" },
+    "contradiction_id": { "type": "string", "pattern": "^co_[a-zA-Z0-9_.:-]+$" },
+    "topic": { "type": "string" },
+    "subject_scope": { "type": "string" },
+    "contradiction_class": {
+      "type": "string",
+      "enum": [
+        "explicit_value_conflict",
+        "presence_absence_conflict",
+        "query_negative_vs_positive_hit",
+        "stale_vs_current_conflict",
+        "source_authority_conflict",
+        "resolution_ambiguity",
+        "merge_conflict",
+        "split_conflict",
+        "policy_conflict",
+        "assurance_conflict"
+      ]
+    },
+    "conflicting_assertions": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["assertion_ref", "assertion_summary", "status"],
+        "properties": {
+          "assertion_ref": { "type": "string" },
+          "assertion_summary": { "type": "string" },
+          "status": {
+            "type": "string",
+            "enum": [
+              "observed",
+              "attached_context",
+              "repeated",
+              "single_hit",
+              "query_negative",
+              "derived",
+              "conflicted",
+              "validated",
+              "verified",
+              "enrolled",
+              "revoked",
+              "expired",
+              "missing"
+            ]
+          },
+          "source_ref": { "type": ["string", "null"] },
+          "atom_ref": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "positive_evidence": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "negative_or_query_negative_evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["evidence_ref", "negative_type"],
+        "properties": {
+          "evidence_ref": { "type": "string" },
+          "negative_type": { "type": "string", "enum": ["query_negative", "authoritative_absence", "policy_blocked", "not_searched", "unknown"] },
+          "query_ref": { "type": ["string", "null"] },
+          "coverage_scope": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "provenance": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source_ref", "observed_at"],
+        "properties": {
+          "source_ref": { "type": "string" },
+          "observed_at": { "type": "string", "format": "date-time" },
+          "evidence_hash": { "type": ["string", "null"] },
+          "ledger_pointer": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "severity": { "type": "string", "enum": ["info", "low", "medium", "high", "critical"] },
+    "resolution_status": {
+      "type": "string",
+      "enum": [
+        "open",
+        "triaged",
+        "pending_evidence",
+        "provisionally_resolved",
+        "resolved",
+        "suppressed_for_release_but_retained",
+        "invalidated"
+      ]
+    },
+    "preferred_redress_path": { "type": "string" },
+    "review": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "review_required": { "type": "boolean" },
+        "reviewer_ref": { "type": ["string", "null"] },
+        "review_deadline": { "type": ["string", "null"], "format": "date-time" },
+        "review_notes": { "type": ["string", "null"] }
+      }
+    },
+    "created_at": { "type": "string", "format": "date-time" },
+    "updated_at": { "type": ["string", "null"], "format": "date-time" },
+    "notes": { "type": ["string", "null"] }
+  }
+}

--- a/protocol/identity-is-prime/hell-er/schemas/prime-atom.v1.schema.json
+++ b/protocol/identity-is-prime/hell-er/schemas/prime-atom.v1.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/identity-is-prime/hell-er/prime-atom.v1.schema.json",
+  "title": "HELL-ER Prime Atom v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "atom_id",
+    "atom_type",
+    "context_ref",
+    "status",
+    "hazard_class",
+    "sensitivity",
+    "assurance",
+    "provenance",
+    "lifecycle",
+    "policy_tags",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "hell-er.prime-atom.v1" },
+    "atom_id": { "type": "string", "pattern": "^pa_[a-zA-Z0-9_.:-]+$" },
+    "atom_type": { "type": "string" },
+    "subject_ref": { "type": ["string", "null"] },
+    "context_ref": { "type": "string" },
+    "value": {},
+    "value_ref": { "type": "string" },
+    "status": {
+      "type": "string",
+      "enum": [
+        "observed",
+        "attached_context",
+        "repeated",
+        "single_hit",
+        "query_negative",
+        "derived",
+        "conflicted",
+        "validated",
+        "verified",
+        "enrolled",
+        "revoked",
+        "expired",
+        "missing"
+      ]
+    },
+    "hazard_class": {
+      "type": "string",
+      "enum": [
+        "direct_identifier",
+        "quasi_identifier",
+        "authenticator_material",
+        "civil_proof_material",
+        "institutional_attribute",
+        "role_or_entitlement",
+        "contextual_event",
+        "artifact_or_provenance",
+        "behavioral_or_derived_signal",
+        "sensitive_preference",
+        "restricted_professional_or_ip",
+        "regulated_data_element",
+        "synthetic_demo_value"
+      ]
+    },
+    "sensitivity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "labels"],
+      "properties": {
+        "level": { "type": "string", "enum": ["public", "internal", "confidential", "restricted", "regulated", "synthetic"] },
+        "labels": { "type": "array", "items": { "type": "string" }, "minItems": 1, "uniqueItems": true }
+      }
+    },
+    "assurance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["atom_assurance", "evidence_strength", "review_state"],
+      "properties": {
+        "atom_assurance": { "type": "string", "enum": ["unresolved", "candidate", "context_resolved", "validated", "verified", "contested", "revoked", "expired"] },
+        "evidence_strength": { "type": "string", "enum": ["none", "weak", "moderate", "strong", "authoritative"] },
+        "review_state": { "type": "string", "enum": ["not_required", "required", "in_review", "approved", "rejected", "escalated"] },
+        "ial_hint": { "type": ["string", "null"], "enum": [null, "IAL0", "IAL1", "IAL2", "IAL3"] },
+        "aal_hint": { "type": ["string", "null"], "enum": [null, "AAL0", "AAL1", "AAL2", "AAL3"] },
+        "fal_hint": { "type": ["string", "null"], "enum": [null, "FAL0", "FAL1", "FAL2", "FAL3"] }
+      }
+    },
+    "provenance": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source_ref", "observed_at", "claim_ref"],
+        "properties": {
+          "source_ref": { "type": "string" },
+          "observed_at": { "type": "string", "format": "date-time" },
+          "claim_ref": { "type": "string" },
+          "evidence_hash": { "type": ["string", "null"] },
+          "ledger_pointer": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state"],
+      "properties": {
+        "state": { "type": "string", "enum": ["active", "pending", "revoked", "expired", "superseded", "redacted", "synthetic"] },
+        "valid_from": { "type": ["string", "null"], "format": "date-time" },
+        "valid_until": { "type": ["string", "null"], "format": "date-time" },
+        "revoked_at": { "type": ["string", "null"], "format": "date-time" },
+        "superseded_by": { "type": ["string", "null"] }
+      }
+    },
+    "policy_tags": { "type": "array", "items": { "type": "string" }, "minItems": 1, "uniqueItems": true },
+    "created_at": { "type": "string", "format": "date-time" },
+    "notes": { "type": ["string", "null"] }
+  },
+  "oneOf": [
+    { "required": ["value"] },
+    { "required": ["value_ref"] }
+  ]
+}

--- a/protocol/identity-is-prime/hell-er/schemas/release-pack.v1.schema.json
+++ b/protocol/identity-is-prime/hell-er/schemas/release-pack.v1.schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/identity-is-prime/hell-er/release-pack.v1.schema.json",
+  "title": "HELL-ER Release Pack v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "release_pack_id",
+    "release_class",
+    "audience",
+    "context",
+    "hazard_profile",
+    "subject_graph_summary",
+    "prime_atom_ledger",
+    "contradiction_ledger",
+    "assurance_vector",
+    "release_policy",
+    "lifecycle",
+    "redress_queue",
+    "machine_annex",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "hell-er.release-pack.v1" },
+    "release_pack_id": { "type": "string", "pattern": "^rp_[a-zA-Z0-9_.:-]+$" },
+    "release_class": { "type": "string", "enum": ["self_view_unredacted", "internal_operational", "partner_federated", "external_redacted", "public_synthetic"] },
+    "audience": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["audience_type", "audience_ref", "purpose"],
+      "properties": {
+        "audience_type": { "type": "string", "enum": ["self", "internal_service", "partner", "public", "synthetic_demo", "steward", "agent"] },
+        "audience_ref": { "type": "string" },
+        "purpose": { "type": "string" }
+      }
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["context_ref", "context_type", "served_population", "policy_regime"],
+      "properties": {
+        "context_ref": { "type": "string" },
+        "context_type": { "type": "string", "enum": ["recruiting", "travel_booking", "regulated_proofing", "federated_access", "authorship_provenance", "grant_review", "platform_administration", "synthetic_demo", "other"] },
+        "served_population": { "type": "string" },
+        "policy_regime": { "type": "string" }
+      }
+    },
+    "hazard_profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hazard_classes", "minimum_necessary", "release_risk", "abuse_modes"],
+      "properties": {
+        "hazard_classes": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["direct_identifier", "quasi_identifier", "authenticator_material", "civil_proof_material", "institutional_attribute", "role_or_entitlement", "contextual_event", "artifact_or_provenance", "behavioral_or_derived_signal", "sensitive_preference", "restricted_professional_or_ip", "regulated_data_element", "synthetic_demo_value"] },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "minimum_necessary": { "type": "boolean" },
+        "release_risk": { "type": "string", "enum": ["none", "low", "medium", "high", "critical"] },
+        "abuse_modes": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+      }
+    },
+    "subject_graph_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subject_state", "graph_snapshot_ref", "node_count", "edge_count"],
+      "properties": {
+        "subject_state": { "type": "string", "enum": ["unresolved", "candidate", "context_resolved", "validated_core", "verified_subject", "enrolled", "contested", "revoked", "expired"] },
+        "subject_ref": { "type": ["string", "null"] },
+        "graph_snapshot_ref": { "type": "string" },
+        "node_count": { "type": "integer", "minimum": 0 },
+        "edge_count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "prime_atom_ledger": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["atom_ref", "released", "redaction_state", "policy_tags"],
+        "properties": {
+          "atom_ref": { "type": "string" },
+          "released": { "type": "boolean" },
+          "redaction_state": { "type": "string", "enum": ["not_redacted", "redacted", "withheld", "synthetic", "derived_only"] },
+          "reason": { "type": ["string", "null"] },
+          "policy_tags": { "type": "array", "items": { "type": "string" }, "minItems": 1, "uniqueItems": true }
+        }
+      }
+    },
+    "contradiction_ledger": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["contradiction_ref", "released", "summary_state"],
+        "properties": {
+          "contradiction_ref": { "type": "string" },
+          "released": { "type": "boolean" },
+          "summary_state": { "type": "string", "enum": ["full", "summary_only", "existence_only", "withheld", "not_applicable"] },
+          "reason": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "assurance_vector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identity_state", "evidence_state", "authenticator_state", "civil_identity_state", "federation_state"],
+      "properties": {
+        "identity_state": { "type": "string", "enum": ["unresolved", "candidate", "context_resolved", "validated_core", "verified_subject", "enrolled", "contested", "revoked", "expired"] },
+        "evidence_state": { "type": "string", "enum": ["none", "weak", "moderate", "strong", "authoritative", "conflicted"] },
+        "authenticator_state": { "type": "string", "enum": ["not_bound", "pending_binding", "bound", "revoked", "expired", "not_applicable"] },
+        "civil_identity_state": { "type": "string", "enum": ["not_proofed", "self_asserted", "validated", "verified", "not_applicable"] },
+        "federation_state": { "type": "string", "enum": ["not_applicable", "asserted", "federated", "revoked", "expired"] }
+      }
+    },
+    "release_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_ref", "allowed_actions", "denied_actions", "review_required"],
+      "properties": {
+        "policy_ref": { "type": "string" },
+        "allowed_actions": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "denied_actions": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "review_required": { "type": "boolean" },
+        "review_ref": { "type": ["string", "null"] }
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "retention_policy_ref"],
+      "properties": {
+        "state": { "type": "string", "enum": ["active", "pending", "revoked", "expired", "superseded", "redacted", "synthetic"] },
+        "retention_policy_ref": { "type": "string" },
+        "expires_at": { "type": ["string", "null"], "format": "date-time" },
+        "revoked_at": { "type": ["string", "null"], "format": "date-time" }
+      }
+    },
+    "redress_queue": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["redress_id", "redress_type", "status"],
+        "properties": {
+          "redress_id": { "type": "string" },
+          "redress_type": { "type": "string", "enum": ["correction", "appeal", "review", "deletion_request", "revocation_request", "access_request"] },
+          "status": { "type": "string", "enum": ["open", "pending", "resolved", "rejected", "escalated"] }
+        }
+      }
+    },
+    "machine_annex": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["annex_ref", "annex_hash", "format"],
+      "properties": {
+        "annex_ref": { "type": "string" },
+        "annex_hash": { "type": "string" },
+        "format": { "type": "string", "enum": ["json", "jsonld", "cbor", "yaml"] }
+      }
+    },
+    "created_at": { "type": "string", "format": "date-time" },
+    "signed_by": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "notes": { "type": ["string", "null"] }
+  }
+}

--- a/tools/conformance/validate_hell_er_fixtures.py
+++ b/tools/conformance/validate_hell_er_fixtures.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Validate HELL-ER protocol schemas and synthetic fixtures.
+
+This checker is intentionally dependency-free. It does not replace full JSON
+Schema validation; it enforces the first HELL-ER conformance invariants so the
+protocol directory can participate in Sociosphere workspace checks without
+introducing a new dependency.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+HELLER_DIR = ROOT / "protocol" / "identity-is-prime" / "hell-er"
+SCHEMA_DIR = HELLER_DIR / "schemas"
+FIXTURE_DIR = HELLER_DIR / "fixtures"
+EXPECTED_DIR = HELLER_DIR / "expected"
+
+REQUIRED_SCHEMAS = {
+    "prime-atom.v1.schema.json",
+    "contradiction-object.v1.schema.json",
+    "release-pack.v1.schema.json",
+}
+
+REQUIRED_FIXTURES = {
+    "release_pack.internal_operational.synthetic.valid.json",
+}
+
+REQUIRED_EXPECTED = {
+    "release_pack.internal_operational.synthetic.valid.result.json",
+}
+
+RELEASE_CLASSES = {
+    "self_view_unredacted",
+    "internal_operational",
+    "partner_federated",
+    "external_redacted",
+    "public_synthetic",
+}
+
+SUBJECT_STATES = {
+    "unresolved",
+    "candidate",
+    "context_resolved",
+    "validated_core",
+    "verified_subject",
+    "enrolled",
+    "contested",
+    "revoked",
+    "expired",
+}
+
+REDaction_STATES = {"not_redacted", "redacted", "withheld", "synthetic", "derived_only"}
+SUMMARY_STATES = {"full", "summary_only", "existence_only", "withheld", "not_applicable"}
+
+
+def fail(path: Path, message: str) -> None:
+    raise SystemExit(f"{path}: {message}")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(path, f"invalid JSON: {exc}")
+    if not isinstance(data, dict):
+        fail(path, "top-level JSON value must be an object")
+    return data
+
+
+def require_str(obj: dict[str, Any], key: str, path: Path) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value:
+        fail(path, f"{key} must be a non-empty string")
+    return value
+
+
+def require_bool(obj: dict[str, Any], key: str, path: Path) -> bool:
+    value = obj.get(key)
+    if not isinstance(value, bool):
+        fail(path, f"{key} must be a boolean")
+    return value
+
+
+def require_int(obj: dict[str, Any], key: str, path: Path) -> int:
+    value = obj.get(key)
+    if not isinstance(value, int):
+        fail(path, f"{key} must be an integer")
+    return value
+
+
+def require_obj(obj: dict[str, Any], key: str, path: Path) -> dict[str, Any]:
+    value = obj.get(key)
+    if not isinstance(value, dict):
+        fail(path, f"{key} must be an object")
+    return value
+
+
+def require_list(obj: dict[str, Any], key: str, path: Path, *, min_items: int = 0) -> list[Any]:
+    value = obj.get(key)
+    if not isinstance(value, list):
+        fail(path, f"{key} must be a list")
+    if len(value) < min_items:
+        fail(path, f"{key} must have at least {min_items} entries")
+    return value
+
+
+def validate_schema_file(path: Path, expected_const: str) -> None:
+    schema = load_json(path)
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail(path, "$schema must be JSON Schema 2020-12")
+    require_str(schema, "$id", path)
+    require_str(schema, "title", path)
+    if schema.get("type") != "object":
+        fail(path, "schema type must be object")
+    required = require_list(schema, "required", path, min_items=1)
+    properties = require_obj(schema, "properties", path)
+    if "schema_version" not in required:
+        fail(path, "required must include schema_version")
+    schema_version = require_obj(properties, "schema_version", path)
+    if schema_version.get("const") != expected_const:
+        fail(path, f"schema_version.const must be {expected_const!r}")
+
+
+def validate_schemas() -> None:
+    missing = sorted(name for name in REQUIRED_SCHEMAS if not (SCHEMA_DIR / name).exists())
+    if missing:
+        raise SystemExit(f"missing required HELL-ER schemas: {missing}")
+    validate_schema_file(SCHEMA_DIR / "prime-atom.v1.schema.json", "hell-er.prime-atom.v1")
+    validate_schema_file(SCHEMA_DIR / "contradiction-object.v1.schema.json", "hell-er.contradiction-object.v1")
+    validate_schema_file(SCHEMA_DIR / "release-pack.v1.schema.json", "hell-er.release-pack.v1")
+
+
+def validate_audience(path: Path, pack: dict[str, Any]) -> None:
+    audience = require_obj(pack, "audience", path)
+    require_str(audience, "audience_type", path)
+    require_str(audience, "audience_ref", path)
+    require_str(audience, "purpose", path)
+
+
+def validate_context(path: Path, pack: dict[str, Any]) -> None:
+    context = require_obj(pack, "context", path)
+    require_str(context, "context_ref", path)
+    require_str(context, "context_type", path)
+    require_str(context, "served_population", path)
+    require_str(context, "policy_regime", path)
+
+
+def validate_hazard_profile(path: Path, pack: dict[str, Any]) -> None:
+    hazard = require_obj(pack, "hazard_profile", path)
+    require_list(hazard, "hazard_classes", path, min_items=1)
+    if require_bool(hazard, "minimum_necessary", path) is not True:
+        fail(path, "hazard_profile.minimum_necessary must be true for the synthetic valid fixture")
+    require_str(hazard, "release_risk", path)
+    require_list(hazard, "abuse_modes", path, min_items=1)
+
+
+def validate_subject_graph_summary(path: Path, pack: dict[str, Any]) -> None:
+    summary = require_obj(pack, "subject_graph_summary", path)
+    subject_state = require_str(summary, "subject_state", path)
+    if subject_state not in SUBJECT_STATES:
+        fail(path, f"subject_graph_summary.subject_state must be one of {sorted(SUBJECT_STATES)}")
+    require_str(summary, "graph_snapshot_ref", path)
+    if require_int(summary, "node_count", path) < 0:
+        fail(path, "node_count must be non-negative")
+    if require_int(summary, "edge_count", path) < 0:
+        fail(path, "edge_count must be non-negative")
+
+
+def validate_atom_ledger(path: Path, pack: dict[str, Any]) -> None:
+    ledger = require_list(pack, "prime_atom_ledger", path, min_items=1)
+    released_count = 0
+    withheld_count = 0
+    for entry in ledger:
+        if not isinstance(entry, dict):
+            fail(path, "prime_atom_ledger entries must be objects")
+        require_str(entry, "atom_ref", path)
+        if require_bool(entry, "released", path):
+            released_count += 1
+        state = require_str(entry, "redaction_state", path)
+        if state not in REDaction_STATES:
+            fail(path, f"redaction_state must be one of {sorted(REDaction_STATES)}")
+        if state in {"withheld", "redacted"}:
+            withheld_count += 1
+        require_list(entry, "policy_tags", path, min_items=1)
+    if released_count == 0:
+        fail(path, "synthetic valid release pack must release at least one atom")
+    if withheld_count == 0:
+        fail(path, "synthetic valid release pack must demonstrate withholding/redaction")
+
+
+def validate_contradiction_ledger(path: Path, pack: dict[str, Any]) -> None:
+    ledger = require_list(pack, "contradiction_ledger", path)
+    if not ledger:
+        fail(path, "synthetic valid release pack must retain at least one contradiction pointer")
+    for entry in ledger:
+        if not isinstance(entry, dict):
+            fail(path, "contradiction_ledger entries must be objects")
+        require_str(entry, "contradiction_ref", path)
+        require_bool(entry, "released", path)
+        state = require_str(entry, "summary_state", path)
+        if state not in SUMMARY_STATES:
+            fail(path, f"summary_state must be one of {sorted(SUMMARY_STATES)}")
+
+
+def validate_assurance_vector(path: Path, pack: dict[str, Any]) -> None:
+    assurance = require_obj(pack, "assurance_vector", path)
+    if require_str(assurance, "identity_state", path) != "context_resolved":
+        fail(path, "synthetic valid fixture must be context_resolved")
+    require_str(assurance, "evidence_state", path)
+    require_str(assurance, "authenticator_state", path)
+    if require_str(assurance, "civil_identity_state", path) != "not_proofed":
+        fail(path, "synthetic valid fixture must not claim civil identity proof")
+    require_str(assurance, "federation_state", path)
+
+
+def validate_release_policy(path: Path, pack: dict[str, Any]) -> None:
+    policy = require_obj(pack, "release_policy", path)
+    require_str(policy, "policy_ref", path)
+    require_list(policy, "allowed_actions", path, min_items=1)
+    denied = require_list(policy, "denied_actions", path, min_items=1)
+    require_bool(policy, "review_required", path)
+    if "export_bulk_applicant_data" not in denied:
+        fail(path, "synthetic valid release pack must deny bulk export")
+
+
+def validate_lifecycle(path: Path, pack: dict[str, Any]) -> None:
+    lifecycle = require_obj(pack, "lifecycle", path)
+    require_str(lifecycle, "state", path)
+    require_str(lifecycle, "retention_policy_ref", path)
+
+
+def validate_machine_annex(path: Path, pack: dict[str, Any]) -> None:
+    annex = require_obj(pack, "machine_annex", path)
+    require_str(annex, "annex_ref", path)
+    require_str(annex, "annex_hash", path)
+    require_str(annex, "format", path)
+
+
+def validate_release_pack(path: Path) -> None:
+    pack = load_json(path)
+    if pack.get("schema_version") != "hell-er.release-pack.v1":
+        fail(path, "schema_version must be hell-er.release-pack.v1")
+    require_str(pack, "release_pack_id", path)
+    release_class = require_str(pack, "release_class", path)
+    if release_class not in RELEASE_CLASSES:
+        fail(path, f"release_class must be one of {sorted(RELEASE_CLASSES)}")
+    validate_audience(path, pack)
+    validate_context(path, pack)
+    validate_hazard_profile(path, pack)
+    validate_subject_graph_summary(path, pack)
+    validate_atom_ledger(path, pack)
+    validate_contradiction_ledger(path, pack)
+    validate_assurance_vector(path, pack)
+    validate_release_policy(path, pack)
+    validate_lifecycle(path, pack)
+    require_list(pack, "redress_queue", path)
+    validate_machine_annex(path, pack)
+    require_str(pack, "created_at", path)
+
+
+def validate_expected(path: Path) -> None:
+    expected = load_json(path)
+    fixture_ref = require_str(expected, "fixture", path)
+    if not fixture_ref.endswith("release_pack.internal_operational.synthetic.valid.json"):
+        fail(path, "expected fixture pointer must reference the synthetic release pack")
+    if require_str(expected, "expected_result", path) != "VERIFIED":
+        fail(path, "synthetic expected result must be VERIFIED")
+    for key in (
+        "schema_version",
+        "policy_version",
+        "resolver_version",
+        "release_template_version",
+        "hazard_classifier_version",
+    ):
+        require_str(expected, key, path)
+    requirements = require_obj(expected, "result_requirements", path)
+    for key in (
+        "context_resolved_access",
+        "civil_identity_not_proofed",
+        "stale_affiliation_contradiction_retained",
+        "minimum_necessary",
+        "bulk_export_denied",
+        "release_pack_has_machine_annex",
+    ):
+        if requirements.get(key) is not True:
+            fail(path, f"result_requirements.{key} must be true")
+
+
+def main() -> None:
+    validate_schemas()
+
+    missing_fixtures = sorted(name for name in REQUIRED_FIXTURES if not (FIXTURE_DIR / name).exists())
+    if missing_fixtures:
+        raise SystemExit(f"missing required HELL-ER fixtures: {missing_fixtures}")
+    for name in sorted(REQUIRED_FIXTURES):
+        validate_release_pack(FIXTURE_DIR / name)
+
+    missing_expected = sorted(name for name in REQUIRED_EXPECTED if not (EXPECTED_DIR / name).exists())
+    if missing_expected:
+        raise SystemExit(f"missing required HELL-ER expected results: {missing_expected}")
+    for name in sorted(REQUIRED_EXPECTED):
+        validate_expected(EXPECTED_DIR / name)
+
+    print("OK: HELL-ER conformance fixtures validated")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/conformance/validate_hell_er_negative_fixtures.py
+++ b/tools/conformance/validate_hell_er_negative_fixtures.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Validate HELL-ER negative conformance fixtures.
+
+The positive HELL-ER validator checks schema and valid release-pack structure.
+This validator proves the first rejection cases: missing policy, query-negative
+misuse, silent merge, and external unredacted direct-identifier release.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+HELLER_DIR = ROOT / "protocol" / "identity-is-prime" / "hell-er"
+FIXTURE_DIR = HELLER_DIR / "fixtures"
+EXPECTED_DIR = HELLER_DIR / "expected"
+
+NEGATIVE_FIXTURES = {
+    "release_pack.missing_policy.invalid.json": "MISSING_RELEASE_POLICY",
+    "release_pack.query_negative_as_absent.invalid.json": "QUERY_NEGATIVE_AS_FACT_ABSENT",
+    "release_pack.silent_merge.invalid.json": "SILENT_MERGE_WITHOUT_AUDIT",
+    "release_pack.external_unredacted_identifier.invalid.json": "EXTERNAL_UNREDACTED_DIRECT_IDENTIFIER",
+}
+
+
+def fail(path: Path, message: str) -> None:
+    raise SystemExit(f"{path}: {message}")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(path, f"invalid JSON: {exc}")
+    if not isinstance(data, dict):
+        fail(path, "top-level JSON value must be an object")
+    return data
+
+
+def require_str(obj: dict[str, Any], key: str, path: Path) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value:
+        fail(path, f"{key} must be a non-empty string")
+    return value
+
+
+def require_obj(obj: dict[str, Any], key: str, path: Path) -> dict[str, Any]:
+    value = obj.get(key)
+    if not isinstance(value, dict):
+        fail(path, f"{key} must be an object")
+    return value
+
+
+def validate_expected(path: Path, fixture_name: str, violation: str) -> None:
+    expected_path = EXPECTED_DIR / fixture_name.replace(".json", ".result.json")
+    if not expected_path.exists():
+        fail(path, f"missing expected result {expected_path.relative_to(ROOT)}")
+    expected = load_json(expected_path)
+    if require_str(expected, "expected_result", expected_path) != "REFUTED":
+        fail(expected_path, "expected_result must be REFUTED")
+    if require_str(expected, "expected_violation", expected_path) != violation:
+        fail(expected_path, f"expected_violation must be {violation}")
+    fixture_ref = require_str(expected, "fixture", expected_path)
+    if not fixture_ref.endswith(fixture_name):
+        fail(expected_path, "fixture pointer must reference the matching invalid fixture")
+
+
+def validate_common(path: Path, fixture: dict[str, Any], violation: str) -> dict[str, Any]:
+    require_str(fixture, "fixture_id", path)
+    require_str(fixture, "fixture_version", path)
+    if require_str(fixture, "expected_result", path) != "REFUTED":
+        fail(path, "expected_result must be REFUTED")
+    if require_str(fixture, "expected_violation", path) != violation:
+        fail(path, f"expected_violation must be {violation}")
+    return require_obj(fixture, "candidate_release_pack", path)
+
+
+def validate_missing_policy(path: Path, pack: dict[str, Any]) -> None:
+    if "release_policy" in pack:
+        fail(path, "MISSING_RELEASE_POLICY fixture must omit candidate_release_pack.release_policy")
+
+
+def validate_query_negative_as_absent(path: Path, fixture: dict[str, Any]) -> None:
+    qn = require_obj(fixture, "query_negative_handling", path)
+    if qn.get("query_negative_interpreted_as_absent") is not True:
+        fail(path, "fixture must demonstrate query_negative_interpreted_as_absent=true")
+    if qn.get("correct_state") != "query_negative":
+        fail(path, "correct_state must be query_negative")
+
+
+def validate_silent_merge(path: Path, fixture: dict[str, Any]) -> None:
+    merge = require_obj(fixture, "merge_decision", path)
+    if merge.get("merge_performed") is not True:
+        fail(path, "silent merge fixture must perform a merge")
+    if merge.get("merge_audit_ref") is not None:
+        fail(path, "silent merge fixture must omit merge_audit_ref")
+    if merge.get("review_state") != "not_reviewed":
+        fail(path, "silent merge fixture must be not_reviewed")
+
+
+def validate_external_unredacted_identifier(path: Path, pack: dict[str, Any]) -> None:
+    if pack.get("release_class") != "external_redacted":
+        fail(path, "external identifier fixture must use external_redacted release_class")
+    ledger = pack.get("prime_atom_ledger")
+    if not isinstance(ledger, list):
+        fail(path, "candidate_release_pack.prime_atom_ledger must be a list")
+    offenders = []
+    for entry in ledger:
+        if not isinstance(entry, dict):
+            fail(path, "prime_atom_ledger entries must be objects")
+        if (
+            entry.get("hazard_class") == "direct_identifier"
+            and entry.get("released") is True
+            and entry.get("redaction_state") == "not_redacted"
+        ):
+            offenders.append(entry.get("atom_ref", "<unknown>"))
+    if not offenders:
+        fail(path, "fixture must expose at least one unredacted direct identifier externally")
+
+
+def validate_negative_fixture(name: str, violation: str) -> None:
+    path = FIXTURE_DIR / name
+    if not path.exists():
+        raise SystemExit(f"missing required HELL-ER negative fixture: {path.relative_to(ROOT)}")
+    fixture = load_json(path)
+    pack = validate_common(path, fixture, violation)
+    if violation == "MISSING_RELEASE_POLICY":
+        validate_missing_policy(path, pack)
+    elif violation == "QUERY_NEGATIVE_AS_FACT_ABSENT":
+        validate_query_negative_as_absent(path, fixture)
+    elif violation == "SILENT_MERGE_WITHOUT_AUDIT":
+        validate_silent_merge(path, fixture)
+    elif violation == "EXTERNAL_UNREDACTED_DIRECT_IDENTIFIER":
+        validate_external_unredacted_identifier(path, pack)
+    else:
+        fail(path, f"no validator registered for {violation}")
+    validate_expected(path, name, violation)
+
+
+def main() -> None:
+    for name, violation in sorted(NEGATIVE_FIXTURES.items()):
+        validate_negative_fixture(name, violation)
+    print("OK: HELL-ER negative fixtures validated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds HELL-ER as the hazard-governed entity-resolution and identity-release service function inside the Identity Is Prime protocol.

This PR deliberately scopes HELL-ER as a symbiotic service function paired with the core Identity Is Prime substrate, not as a standalone product and not as a generic privacy/masking module.

## What changed

- Adds `protocol/identity-is-prime/hell-er/README.md`
  - HADES / Heller / ER naming lineage
  - service boundary and candidate methods
  - relationship to Identity Is Prime, Regis, ACR, Holmes, Sherlock, and Agent Registry
  - result vocabulary, determinism fields, invariants, fixture families, acceptance criteria
- Adds first HELL-ER schema tranche:
  - `prime-atom.v1.schema.json`
  - `contradiction-object.v1.schema.json`
  - `release-pack.v1.schema.json`
- Adds synthetic internal operational release-pack fixture:
  - `release_pack.internal_operational.synthetic.valid.json`
  - expected `VERIFIED` result file
- Updates `protocol/identity-is-prime/README.md` to make HELL-ER discoverable from the canonical protocol path.
- Updates the Identity Is Prime × Regis × ACR × Sociosphere architecture spine to include HELL-ER as a first-class service layer.

## Design intent

HELL-ER preserves the high-assurance discipline of HADES but moves the governed unit from sensitive fields to identity-bearing graph slices.

Core invariants include:

- no atom without provenance;
- no release without policy and release class;
- no query-negative converted into fact-absent;
- no unresolved contradiction silently flattened;
- no silent merge or split;
- no contextual identity escalated into civil proof;
- no external unredacted direct-identifier release without explicit authorization.

## Validation status

This PR adds protocol docs, JSON Schema drafts, a synthetic fixture, and expected result metadata. It does not yet wire executable conformance validation.

Follow-on work should extend `tools/conformance/validate_identity_is_prime_fixtures.py` to discover `protocol/identity-is-prime/hell-er/fixtures/` and validate against the new schema tranche.

## Safety / data handling

All examples are synthetic. The only real-name usage is the permitted demonstrative subject name `Michael Heller`; all attributes, emails, affiliations, dates, and service contexts are synthetic placeholders.
