### PR TITLE
Document governed intelligence rollout architecture

### DIFF
--- a/docs/architecture/governed-intelligence-reference-architecture.md
+++ b/docs/architecture/governed-intelligence-reference-architecture.md
@@ -1,0 +1,172 @@
+# Governed Intelligence Reference Architecture
+
+Status: draft
+Owner repo: `SocioProphet/sociosphere`
+Parent issue: `SocioProphet/sociosphere#310`
+
+## Purpose
+
+This document defines the SocioProphet governed-intelligence reference architecture. It converts the program synthesis across typed proof systems, hyperknowledge graphs, neuro-symbolic reasoning, explainable text models, and vector-symbolic architectures into a single operational contract for the estate.
+
+The architecture is not a model feature and not a search feature. It is the shared control loop for turning observations into governed claims and governed actions.
+
+## Canonical loop
+
+```text
+Observe -> Anchor -> Normalize -> Propose -> Explain -> Verify -> Govern -> Act -> Receipt -> Learn
+```
+
+Every participating repo should preserve this sequence and declare which segment it owns.
+
+| Step | Meaning | Primary owner |
+| --- | --- | --- |
+| Observe | Ingest raw state, text, code, map, model, event, or runtime signal. | GAIA, Sherlock, Agentplane, Model Governance Ledger |
+| Anchor | Bind the observation to a source span, geometry, code range, table cell, log range, or media region. | Sherlock, GAIA, Ontogenesis |
+| Normalize | Convert raw inputs into typed entities, evidence, observations, or candidate objects. | Ontogenesis, Regis, Sherlock, GAIA |
+| Propose | Emit a candidate claim, action, model output, or vector candidate. | Holmes, Sherlock, GAIA, Agentplane, Model Governance Ledger |
+| Explain | Attach rule traces, evidence paths, model scores, phrase evidence, graph paths, or fusion chains. | Holmes, Model Governance Ledger, GAIA, Sherlock |
+| Verify | Type-check, validate, reason over contradiction, and confirm required evidence is present. | Holmes, Ontogenesis |
+| Govern | Admit, deny, require review, or mark provisional. | Guardrail Fabric, Policy Fabric |
+| Act | Execute only after admission when the operation is effectful. | Agentplane |
+| Receipt | Emit runtime, artifact, workflow, or learning receipts. | Agentplane, Model Governance Ledger, Sociosphere |
+| Learn | Register evaluation, drift, calibration, rollout, and adoption events. | Model Governance Ledger, Sociosphere |
+
+## Architecture invariant
+
+No model, graph, vector index, parser, agent, or runtime is authoritative by itself.
+
+```text
+Candidate + Evidence + Explanation + Verification + PolicyDecision => AdmittedClaim or AdmittedAction
+```
+
+Corollaries:
+
+- Raw model output is a proposal, not admitted truth.
+- Raw graph candidates are proposals, not admitted truth.
+- Raw vector candidates remain `candidate_only`.
+- Holmes verifies and explains claims but does not admit them.
+- Policy/Guardrail Fabric admits, denies, requires review, or marks provisional.
+- Agentplane performs effectful work only after admission and must emit receipts.
+
+## Canonical objects
+
+| Object | Definition | Source-of-truth responsibility | Initial consumers |
+| --- | --- | --- | --- |
+| `Entity` | Canonical actor, repo, concept, region, model, artifact, or domain object. | Ontogenesis / Regis | Sherlock, Holmes, GAIA, Sociosphere |
+| `Anchor` | Pointer into a source artifact such as a text span, image region, geospatial selector, H3 cell, code range, log range, table cell, or media segment. | Ontogenesis | Sherlock, GAIA, Model Governance Ledger |
+| `Evidence` | Source-backed support or opposition for a claim or action. | Ontogenesis | Sherlock, Holmes, Policy Fabric, GAIA |
+| `Claim` | Typed assertion over a subject, predicate, object, context, evidence, uncertainty, and lifecycle state. | Ontogenesis / Holmes | Sherlock, GAIA, Sociosphere, Policy Fabric |
+| `ProofCertificate` | Machine-checkable or structured reasoning artifact for a claim. | Holmes | Policy Fabric, Sociosphere |
+| `ExplanationTrace` | Human/operator-readable reasoning, rule, model, graph, phrase, or fusion trace. | Holmes / Model Governance Ledger / GAIA | Sherlock, Policy Fabric, Sociosphere |
+| `VectorCandidate` | Candidate retrieved through vector-symbolic or embedding-based recall. It is never authoritative. | Ontogenesis / Sherlock / Holmes | Sherlock, Holmes, GAIA, Agentplane |
+| `PolicyDecision` | `allow`, `deny`, `require_review`, or `provisional` decision for a claim, action, model, artifact, or workflow. | Guardrail Fabric / Policy Fabric | Holmes, Sherlock, GAIA, Agentplane, Sociosphere |
+| `ActionProposal` | Structured request to perform effectful work with intent, scope, expected effects, required capabilities, and evidence. | Agentplane | Policy Fabric, Sociosphere |
+| `ActionAdmission` | Policy-bound decision to allow or deny an action proposal or require review. | Guardrail Fabric / Agentplane | Agentplane, Sociosphere |
+| `RuntimeReceipt` | Execution record containing agent/runtime identity, policy reference, inputs/outputs, hashes, logs, and status. | Agentplane | Sociosphere, Model Governance Ledger |
+| `LearningEvent` | Evaluation, drift, calibration, adoption, rollout, or feedback event. | Model Governance Ledger / Sociosphere | Holmes, Sherlock, Policy Fabric |
+| `Revocation` | Lifecycle event that withdraws or supersedes a claim, policy decision, artifact, action, or receipt. | Policy Fabric / Sociosphere | All consumers |
+| `SlashTopicProfile` | Governance membrane for allowed objects, evidence requirements, policy profile, and query/display behavior. | Sociosphere | Sherlock, Holmes, GAIA, Agentplane |
+
+## Slash-topic membranes
+
+The first rollout registers these membranes:
+
+- `/architecture/governed-intelligence`
+- `/sherlock/evidence-answers`
+- `/holmes/proof-claims`
+- `/gaia/world-claims`
+- `/agents/action-admission`
+- `/policy/claim-action-admission`
+- `/ontogenesis/schema-contracts`
+- `/models/governance-ledger`
+
+A slash-topic is not a tag. It is a governance membrane defining allowed object types, evidence requirements, policy profile, query behavior, display behavior, and lifecycle expectations.
+
+## Repo responsibilities
+
+| Repo | Responsibility in this architecture | Issue |
+| --- | --- | --- |
+| `SocioProphet/sociosphere` | Rollout registry, slash-topic membranes, adoption status, workspace/mesh projection. | `#310` |
+| `SocioProphet/ontogenesis` | Canonical schema, ontology, SHACL, JSON-LD, and vector encoding manifests. | `#77` |
+| `SocioProphet/holmes` | Proof-claim, contradiction, truth-bound, explanation, and neuro-symbolic reasoning contracts. | `#7` |
+| `SocioProphet/sherlock-search` | Evidence-answer contract, anchors, proposed claims, vector candidates, answer display handoff. | `#51` |
+| `SocioProphet/gaia-world-model` | Governed world claims, geospatial anchors, fusion evidence, uncertainty, `/map` evidence contract. | `#25` |
+| `SocioProphet/guardrail-fabric` | Claim/action admission policy, decision states, evidence sufficiency, review gates, revocation. | `#23` |
+| `SocioProphet/agentplane` | Action proposals, action admission handoff, runtime boundary records, receipts. | `#152` |
+| `SocioProphet/model-governance-ledger` | Model lineage, inference traces, evaluation reports, drift events, learning events. | `#16` |
+
+## Minimum vertical slice
+
+The first complete implementation slice is:
+
+```text
+Sherlock query -> Anchor -> Evidence -> ProposedClaim -> Holmes ExplanationTrace -> PolicyDecision -> Answer display
+```
+
+Acceptance for this slice:
+
+1. Sherlock emits a structured answer candidate with `Anchor`, `Evidence`, and `Claim`.
+2. Holmes emits an `ExplanationTrace` and, where applicable, `ProofCertificate`, `ContradictionReport`, and `TruthBounds`.
+3. Guardrail/Policy Fabric emits `PolicyDecision`.
+4. Sociosphere projects adoption status under `/architecture/governed-intelligence`.
+5. Vector candidates, if present, remain `candidate_only`.
+
+## GAIA vertical slice
+
+The GAIA slice is:
+
+```text
+Bounded source evidence -> GeoAnchor -> WorldClaim -> FusionExplanation -> Uncertainty -> PolicyDecision -> /map evidence display
+```
+
+Acceptance for this slice:
+
+1. GAIA emits geospatial anchors for source evidence.
+2. GAIA emits proposed world claims with valid time and uncertainty.
+3. Holmes or GAIA emits the fusion/explanation trace.
+4. Policy Fabric emits admitted, denied, review, or provisional status.
+5. `/map` displays source attribution, evidence chain, uncertainty, and policy status.
+
+## Agentplane vertical slice
+
+The Agentplane slice is:
+
+```text
+AgentIntent -> ActionProposal -> PolicyDecision/ActionAdmission -> RuntimeBoundary -> RuntimeReceipt -> Sociosphere/LearningEvent
+```
+
+Acceptance for this slice:
+
+1. Agentplane emits `ActionProposal` before effectful runtime work.
+2. Policy Fabric emits an action decision.
+3. Agentplane records runtime identity, sandbox/runtime profile, input/output hashes, logs ref, policy ref, start/end time, and status.
+4. Sociosphere projects the receipt into workspace/mesh status.
+
+## Adoption states
+
+Sociosphere tracks rollout using these states:
+
+- `not_started`
+- `schema_stubbed`
+- `adapter_in_progress`
+- `contract_tests_present`
+- `vertical_slice_ready`
+
+## Non-goals
+
+- Sociosphere does not own every canonical schema.
+- Vector candidates do not become truth.
+- Holmes does not admit claims.
+- Policy Fabric does not perform runtime work.
+- Agentplane does not decide policy.
+- Model outputs do not become claims without downstream evidence, explanation, validation, and policy status.
+
+## Definition of done
+
+This architecture is minimally real when the estate can produce one full evidence-governed answer and one action receipt:
+
+1. A Sherlock technical question produces a typed, cited, policy-statused claim.
+2. A GAIA observation produces an admitted, provisional, review-required, or denied world claim.
+3. An agent action executes only after action admission and emits a runtime receipt.
+4. Model outputs remain proposals with lineage, evaluation, and inference trace references.
+5. Sociosphere can report adoption status across the participating repos.

--- a/registry/governed-intelligence-rollout.yaml
+++ b/registry/governed-intelligence-rollout.yaml
@@ -1,0 +1,149 @@
+version: 0.1.0
+updated_at: '2026-05-09'
+status: draft
+parent_issue: SocioProphet/sociosphere#310
+canonical_loop:
+  - observe
+  - anchor
+  - normalize
+  - propose
+  - explain
+  - verify
+  - govern
+  - act
+  - receipt
+  - learn
+invariants:
+  - raw_model_output_is_proposal_not_truth
+  - graph_candidates_are_proposals_not_truth
+  - vector_candidates_remain_candidate_only
+  - holmes_verifies_and_explains_but_does_not_admit
+  - policy_fabric_decides_allow_deny_review_or_provisional
+  - agentplane_acts_only_after_admission_and_emits_receipts
+slash_topic_membranes:
+  - id: /architecture/governed-intelligence
+    owner_repo: SocioProphet/sociosphere
+    purpose: Reference architecture rollout and adoption state.
+  - id: /sherlock/evidence-answers
+    owner_repo: SocioProphet/sherlock-search
+    purpose: Evidence-bearing answer candidates, anchors, proposed claims, and display handoff.
+  - id: /holmes/proof-claims
+    owner_repo: SocioProphet/holmes
+    purpose: Proof claims, reasoning traces, contradiction reports, and explanation contracts.
+  - id: /gaia/world-claims
+    owner_repo: SocioProphet/gaia-world-model
+    purpose: Spatial-temporal world claims, geospatial anchors, fusion evidence, uncertainty, and map display.
+  - id: /agents/action-admission
+    owner_repo: SocioProphet/agentplane
+    purpose: Action proposals, admission handoff, runtime boundary records, and receipts.
+  - id: /policy/claim-action-admission
+    owner_repo: SocioProphet/guardrail-fabric
+    purpose: Claim/action admission policy, evidence sufficiency, review gates, and revocation.
+  - id: /ontogenesis/schema-contracts
+    owner_repo: SocioProphet/ontogenesis
+    purpose: Canonical schemas, ontology, SHACL, JSON-LD, and vector encoding manifests.
+  - id: /models/governance-ledger
+    owner_repo: SocioProphet/model-governance-ledger
+    purpose: Model lineage, inference traces, evaluation reports, drift events, and learning events.
+canonical_objects:
+  - name: Entity
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/regis-entity-graph
+    consumers: [SocioProphet/sherlock-search, SocioProphet/holmes, SocioProphet/gaia-world-model, SocioProphet/sociosphere]
+  - name: Anchor
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/sherlock-search
+    consumers: [SocioProphet/gaia-world-model, SocioProphet/model-governance-ledger, SocioProphet/holmes]
+  - name: Evidence
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/sherlock-search
+    consumers: [SocioProphet/holmes, SocioProphet/guardrail-fabric, SocioProphet/gaia-world-model]
+  - name: Claim
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/holmes
+    consumers: [SocioProphet/sherlock-search, SocioProphet/gaia-world-model, SocioProphet/guardrail-fabric, SocioProphet/sociosphere]
+  - name: ProofCertificate
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/holmes
+    consumers: [SocioProphet/guardrail-fabric, SocioProphet/sociosphere]
+  - name: ExplanationTrace
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/holmes
+    consumers: [SocioProphet/sherlock-search, SocioProphet/guardrail-fabric, SocioProphet/gaia-world-model, SocioProphet/model-governance-ledger]
+  - name: VectorCandidate
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/sherlock-search
+    required_status: candidate_only
+    consumers: [SocioProphet/holmes, SocioProphet/gaia-world-model, SocioProphet/agentplane]
+  - name: PolicyDecision
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/guardrail-fabric
+    allowed_states: [allow, deny, require_review, provisional]
+    consumers: [SocioProphet/holmes, SocioProphet/sherlock-search, SocioProphet/gaia-world-model, SocioProphet/agentplane, SocioProphet/sociosphere]
+  - name: ActionProposal
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/agentplane
+    consumers: [SocioProphet/guardrail-fabric, SocioProphet/sociosphere]
+  - name: ActionAdmission
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/guardrail-fabric
+    consumers: [SocioProphet/agentplane, SocioProphet/sociosphere]
+  - name: RuntimeReceipt
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/agentplane
+    consumers: [SocioProphet/sociosphere, SocioProphet/model-governance-ledger]
+  - name: LearningEvent
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/model-governance-ledger
+    consumers: [SocioProphet/sociosphere, SocioProphet/holmes, SocioProphet/guardrail-fabric]
+  - name: Revocation
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/guardrail-fabric
+    consumers: [SocioProphet/sociosphere, SocioProphet/holmes, SocioProphet/sherlock-search, SocioProphet/gaia-world-model, SocioProphet/agentplane]
+  - name: SlashTopicProfile
+    schema_owner: SocioProphet/ontogenesis
+    primary_runtime_owner: SocioProphet/sociosphere
+    consumers: [SocioProphet/sherlock-search, SocioProphet/holmes, SocioProphet/gaia-world-model, SocioProphet/agentplane]
+repo_adoption:
+  - repo: SocioProphet/sociosphere
+    issue: 310
+    role: rollout_registry_and_slash_topic_projection
+    adoption_state: schema_stubbed
+  - repo: SocioProphet/ontogenesis
+    issue: 77
+    role: canonical_schema_generation
+    adoption_state: not_started
+  - repo: SocioProphet/holmes
+    issue: 7
+    role: proof_claim_and_reasoning_contracts
+    adoption_state: not_started
+  - repo: SocioProphet/sherlock-search
+    issue: 51
+    role: evidence_answer_contracts
+    adoption_state: not_started
+  - repo: SocioProphet/gaia-world-model
+    issue: 25
+    role: governed_world_claim_contracts
+    adoption_state: not_started
+  - repo: SocioProphet/guardrail-fabric
+    issue: 23
+    role: claim_action_admission_policy
+    adoption_state: not_started
+  - repo: SocioProphet/agentplane
+    issue: 152
+    role: action_proposal_admission_and_runtime_receipts
+    adoption_state: not_started
+  - repo: SocioProphet/model-governance-ledger
+    issue: 16
+    role: model_lineage_inference_trace_and_learning_events
+    adoption_state: not_started
+vertical_slices:
+  - id: sherlock_holmes_policy_answer
+    status: planned
+    flow: Sherlock query -> Anchor -> Evidence -> ProposedClaim -> Holmes ExplanationTrace -> PolicyDecision -> Answer display
+  - id: gaia_world_claim
+    status: planned
+    flow: Bounded source evidence -> GeoAnchor -> WorldClaim -> FusionExplanation -> Uncertainty -> PolicyDecision -> /map evidence display
+  - id: agentplane_action_receipt
+    status: planned
+    flow: AgentIntent -> ActionProposal -> PolicyDecision/ActionAdmission -> RuntimeBoundary -> RuntimeReceipt -> Sociosphere/LearningEvent


### PR DESCRIPTION
## Summary

Adds the initial SocioProphet governed-intelligence reference architecture and a machine-readable rollout registry.

This PR operationalizes the parent rollout issue:

- Closes/advances: SocioProphet/sociosphere#310
- Links child issues:
  - SocioProphet/ontogenesis#77
  - SocioProphet/holmes#7
  - SocioProphet/sherlock-search#51
  - SocioProphet/gaia-world-model#25
  - SocioProphet/guardrail-fabric#23
  - SocioProphet/agentplane#152
  - SocioProphet/model-governance-ledger#16

## Changes

- Adds `docs/architecture/governed-intelligence-reference-architecture.md`
- Adds `registry/governed-intelligence-rollout.yaml`

## Architectural invariant

`Observe -> Anchor -> Normalize -> Propose -> Explain -> Verify -> Govern -> Act -> Receipt -> Learn`

The PR documents the non-negotiable boundaries:

- Raw model output is a proposal, not admitted truth.
- Raw graph/vector candidates remain candidates.
- Holmes verifies and explains but does not admit.
- Policy/Guardrail Fabric decides `allow`, `deny`, `require_review`, or `provisional`.
- Agentplane acts only after admission and emits receipts.
- Sociosphere tracks rollout/adoption state and slash-topic governance membranes.

## Validation

Documentation/registry-only change. Manual validation performed by checking object ownership, repo issue references, and adoption-state vocabulary against the rollout issue acceptance criteria.

## Non-goals

- Does not implement repo-local schemas.
- Does not implement runtime adapters.
- Does not mark vector candidates as authoritative.
- Does not replace Ontogenesis as schema-generation owner.