### PR TITLE
Add Boundary Atlas v0.1 bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ Platform meta-workspace controller for the SocioProphet ecosystem.
 
 Sociosphere owns the canonical workspace manifest + lock, runner semantics,
 protocol fixtures, deterministic multi-repo materialization, source-exposure
-governance, adversarial hardening critique, and validation lanes for platform
-build and release readiness.
+governance, adversarial hardening critique, validation lanes for platform
+build and release readiness, and the estate Boundary Atlas for typed repo
+jurisdictions and evidence contracts.
 
 ## Governance references
 
 - [Repository topology and dependency rules](docs/TOPOLOGY.md) — canonical source for repo roles, directionality, and the submodule update playbook.
 - [Naming and versioning policy](docs/NAMING_VERSIONING.md) — single source of truth for repo naming, SemVer discipline, and submodule pin-bump rules.
+- [Boundary Atlas v0.1](docs/boundary-atlas-v0.1.md) — typed repo jurisdiction map, claim modes, evidence contracts, sufficiency labels, and boundary maturity.
+- [Boundary Coverage Report](docs/boundary-coverage-report.md) — bootstrap report of boundary-governed repo coverage and hardening gaps.
 - [Angel of the Lord Hardening Regime](standards/angel-of-the-lord/README.md) — adversarial CI and workspace critique regime for repository, boundary, release, and evidence hardening.
 - [Source Exposure Governance Standard](standards/source-exposure/README.md) — publication-safety rules for public source, public release mirrors, inner-source development, and restricted security/operations material.
 
@@ -23,6 +26,7 @@ Sociosphere is responsible for:
 - Materializing and validating the workspace with `tools/runner/runner.py`.
 - Enforcing topology and dependency-direction policies via `tools/check_topology.py`.
 - Maintaining cross-repo governance and registry metadata in `registry/` + `governance/`.
+- Maintaining the Boundary Atlas in `catalog/` + `docs/boundary-atlas-v0.1.md`.
 - Owning the Angel of the Lord adversarial hardening regime across workspace CI lanes.
 - Validating source-exposure publication safety with `tools/check_source_exposure.py`.
 
@@ -36,11 +40,22 @@ component repositories.
 - Upstream bindings (edge capabilities): `docs/architecture/upstream-bindings-edge-capabilities.md`
 - Scope/current state/backlog: `docs/SCOPE_PURPOSE_STATUS_BACKLOG.md`
 - Integration ledger: `docs/INTEGRATION_STATUS.md`
+- Boundary Atlas: `docs/boundary-atlas-v0.1.md`
+- Repo jurisdiction model: `docs/repo-jurisdiction-model.md`
+- Boundary coverage report: `docs/boundary-coverage-report.md`
 - Namespace ownership map: `governance/CANONICAL_SOURCES.yaml`
 - Angel of the Lord hardening regime: `standards/angel-of-the-lord/README.md`
 - Source exposure standard: `standards/source-exposure/README.md`
 
 ## Repository intelligence assets
+
+### Boundary catalog layer
+
+| File | Description |
+|---|---|
+| `catalog/boundaries.yaml` | Estate typed boundary atlas: repo jurisdictions, maturity, claim modes, sufficiency labels, trust roots, and next hardening steps |
+| `catalog/claim-modes.yaml` | Claim-mode registry and evidence requirements |
+| `catalog/evidence-contracts.yaml` | Evidence contract catalog for proof artifacts, boundary records, governance evidence packets, boot trust, and local state integrity |
 
 ### Registry layer
 

--- a/catalog/boundaries.yaml
+++ b/catalog/boundaries.yaml
@@ -1,0 +1,294 @@
+schema_version: "0.1"
+standard_ref:
+  repo: SocioProphet/prophet-platform-standards
+  issue: 15
+  pull_request: 16
+  schema: schemas/boundary.schema.json
+atlas:
+  purpose: Estate-level typed boundary map for repo jurisdictions, evidence contracts, sufficiency labels, and permitted crossings.
+  owner: SocioProphet/sociosphere
+  claim_mode: formal_construction
+  sufficiency_type: governance_sufficient
+entries:
+  - repo: SocioProphet/prophet-platform-standards
+    boundary_class: standards
+    jurisdiction: Normative typed-boundary standard, claim modes, sufficiency taxonomy, and evidence artifact schemas.
+    owned_artifacts:
+      - docs/typed-boundary-standard.md
+      - schemas/boundary.schema.json
+      - schemas/claim-mode.schema.json
+      - schemas/evidence-artifact.schema.json
+      - templates/BOUNDARY.md
+    claim_modes:
+      - formal_construction
+      - illustrative_schema
+    sufficiency_types:
+      - governance_sufficient
+      - audit_sufficient
+    trust_roots:
+      - schema version pinning
+      - standards review
+    maturity: L2
+    current_status: PR open for typed-boundary standard v0.1.
+    next_step: Merge standard and consume schemas in Sociosphere validator.
+
+  - repo: SocioProphet/sociosphere
+    boundary_class: estate_registry
+    jurisdiction: Boundary atlas, repo jurisdiction registry, transition reporting, and boundary coverage status.
+    owned_artifacts:
+      - catalog/boundaries.yaml
+      - catalog/claim-modes.yaml
+      - catalog/evidence-contracts.yaml
+      - docs/boundary-atlas-v0.1.md
+      - docs/boundary-coverage-report.md
+    claim_modes:
+      - formal_construction
+      - illustrative_schema
+      - fixture_validated
+    sufficiency_types:
+      - governance_sufficient
+      - audit_sufficient
+    trust_roots:
+      - boundary schema version
+      - source repo commit hash
+      - policy-fabric admissibility decisions
+    maturity: L2
+    current_status: Atlas bootstrap.
+    next_step: Add ingestion/validation tool and coverage report automation.
+
+  - repo: SocioProphet/prophet-platform
+    boundary_class: runtime_verifier
+    jurisdiction: Platform runtime verification, Event-IR, proof artifacts, run bundles, and checker contract.
+    owned_artifacts:
+      - schemas/event-ir.schema.json
+      - schemas/proof-artifact.schema.json
+      - docs/checker-contract.md
+      - examples/kms-key-usage-*.json
+    claim_modes:
+      - formal_construction
+      - illustrative_schema
+      - fixture_validated
+      - experimental_run
+    sufficiency_types:
+      - reconstruction_sufficient
+      - governance_sufficient
+      - audit_sufficient
+    trust_roots:
+      - inputs hash
+      - policy bundle hash
+      - checker version
+    maturity: L1
+    current_status: Implementation issue open for Trust-First proof artifact/checker contract.
+    next_step: Add proof artifact and Event-IR schemas.
+
+  - repo: SocioProphet/policy-fabric
+    boundary_class: admissibility_policy
+    jurisdiction: Claim-mode promotion, proof-artifact verdict interpretation, and boundary-crossing admissibility.
+    owned_artifacts:
+      - docs/boundary-admissibility.md
+      - policies/boundary/claim_mode_promotion.rego
+      - policies/boundary/proof_artifact_verdicts.rego
+    claim_modes:
+      - formal_construction
+      - illustrative_schema
+      - fixture_validated
+    sufficiency_types:
+      - governance_sufficient
+      - audit_sufficient
+    trust_roots:
+      - signed policy bundle
+      - approved schema versions
+    maturity: L1
+    current_status: Implementation issue open for boundary admissibility gates.
+    next_step: Add policy skeletons and fixture tests.
+
+  - repo: SocioProphet/ontogenesis
+    boundary_class: law_compiler
+    jurisdiction: Schema, ontology, SHACL, CRD, and constraint compilation into executable law surfaces.
+    owned_artifacts:
+      - ontology-to-schema pipelines
+      - SHACL or validation contracts
+      - generated law/constraint artifacts
+    claim_modes:
+      - formal_construction
+      - illustrative_schema
+      - fixture_validated
+    sufficiency_types:
+      - reconstruction_sufficient
+      - governance_sufficient
+    trust_roots:
+      - ontology source hashes
+      - schema compiler version
+    maturity: L0
+    current_status: Boundary record not yet native in repo.
+    next_step: Add BOUNDARY.md and boundary.yaml mapping schema-to-law obligations.
+
+  - repo: SocioProphet/model-governance-ledger
+    boundary_class: governance_evidence
+    jurisdiction: Model and service documentation evidence packets, sufficiency rubrics, adjudication worksheets, and governance scoring.
+    owned_artifacts:
+      - schemas/evidence-packet.schema.json
+      - schemas/adjudication.schema.json
+      - examples/frozen-evidence-packets
+      - tools/sufficiency scoring
+    claim_modes:
+      - formal_construction
+      - illustrative_schema
+      - fixture_validated
+      - independently_reproduced
+    sufficiency_types:
+      - semantic_sufficient
+      - task_sufficient
+      - governance_sufficient
+      - audit_sufficient
+    trust_roots:
+      - frozen packet hash
+      - codebook version
+      - rater/adjudication identity
+    maturity: L1
+    current_status: Implementation issue open for evidence-packet and sufficiency-rubric tooling.
+    next_step: Add packet schema, examples, and deterministic scorer.
+
+  - repo: SocioProphet/sherlock-search
+    boundary_class: evidentiary_retrieval
+    jurisdiction: Search, source attribution, evidence retrieval, query surfaces, and claim-support traces.
+    owned_artifacts:
+      - indexed evidence surfaces
+      - search result traces
+      - source attribution bundles
+    claim_modes:
+      - formal_construction
+      - illustrative_schema
+      - experimental_run
+    sufficiency_types:
+      - semantic_sufficient
+      - task_sufficient
+      - governance_sufficient
+    trust_roots:
+      - index build manifests
+      - source hashes
+      - retrieval logs
+    maturity: L0
+    current_status: Boundary record not yet native in repo.
+    next_step: Define evidentiary retrieval boundary and source-trace artifacts.
+
+  - repo: SocioProphet/gaia-world-model
+    boundary_class: world_model_trace
+    jurisdiction: Geospatial/world-model traces, layer provenance, reconstruction-limited access, and uncertainty evidence.
+    owned_artifacts:
+      - feature manifests
+      - tile/layer manifests
+      - observation evidence
+      - provenance chains
+    claim_modes:
+      - formal_construction
+      - illustrative_schema
+      - fixture_validated
+      - experimental_run
+    sufficiency_types:
+      - reconstruction_sufficient
+      - semantic_sufficient
+      - task_sufficient
+      - governance_sufficient
+    trust_roots:
+      - source receipts
+      - geometry validation
+      - provenance hashes
+    maturity: L0
+    current_status: Boundary record not yet native in repo.
+    next_step: Define GAIA trace/provenance boundary.
+
+  - repo: SocioProphet/agentplane
+    boundary_class: agent_runtime
+    jurisdiction: Agent execution boundary, lifecycle, sandboxing, resource limits, and output attestation.
+    owned_artifacts:
+      - runtime contracts
+      - sandbox policy
+      - agent output attestations
+    claim_modes:
+      - formal_construction
+      - illustrative_schema
+      - fixture_validated
+      - experimental_run
+    sufficiency_types:
+      - task_sufficient
+      - governance_sufficient
+      - audit_sufficient
+    trust_roots:
+      - runtime attestation
+      - sandbox logs
+      - output artifact hashes
+    maturity: L0
+    current_status: Boundary record not yet native in repo.
+    next_step: Define agent runtime boundary and proof-carrying output contract.
+
+  - repo: SocioProphet/agent-registry
+    boundary_class: agent_identity_capability
+    jurisdiction: Agent identity, capability manifests, versioned admission, and revocation records.
+    owned_artifacts:
+      - agent manifests
+      - capability records
+      - revocation events
+    claim_modes:
+      - formal_construction
+      - illustrative_schema
+      - fixture_validated
+    sufficiency_types:
+      - governance_sufficient
+      - audit_sufficient
+    trust_roots:
+      - manifest signatures
+      - registry version pinning
+      - revocation logs
+    maturity: L0
+    current_status: Boundary record not yet native in repo.
+    next_step: Define identity/capability boundary.
+
+  - repo: SourceOS-Linux/sourceos-boot
+    boundary_class: boot_trust
+    jurisdiction: BootReleaseSet, boot attestation, TPM/PCR evidence, rollback, and host trust anchor boundary.
+    owned_artifacts:
+      - boot manifests
+      - attestation evidence
+      - rollback records
+      - boot trust reports
+    claim_modes:
+      - formal_construction
+      - fixture_validated
+      - experimental_run
+      - audited_run
+    sufficiency_types:
+      - reconstruction_sufficient
+      - governance_sufficient
+      - audit_sufficient
+    trust_roots:
+      - TPM PCR measurements
+      - signed BootReleaseSet
+      - build provenance
+    maturity: L0
+    current_status: Boundary record not yet native in repo.
+    next_step: Add SourceOS boot trust boundary declaration.
+
+  - repo: SourceOS-Linux/sourceos-syncd
+    boundary_class: local_state_integrity
+    jurisdiction: Local-first state replication, repair, provenance-preserving sync, and reconciliation boundary.
+    owned_artifacts:
+      - replication manifests
+      - repair receipts
+      - provenance chains
+      - sync integrity reports
+    claim_modes:
+      - formal_construction
+      - fixture_validated
+      - experimental_run
+    sufficiency_types:
+      - reconstruction_sufficient
+      - governance_sufficient
+      - audit_sufficient
+    trust_roots:
+      - local state hashes
+      - signed repair receipts
+      - policy-governed replication logs
+    maturity: L0
+    current_status: Boundary record not yet native in repo.
+    next_step: Add local-first state integrity boundary declaration.

--- a/catalog/claim-modes.yaml
+++ b/catalog/claim-modes.yaml
@@ -1,0 +1,57 @@
+schema_version: "0.1"
+standard_ref:
+  repo: SocioProphet/prophet-platform-standards
+  docs:
+    - docs/claim-modes.md
+modes:
+  formal_construction:
+    rank: 1
+    description: Definition, schema, theorem statement, proof sketch, or architecture doctrine. No executed run implied.
+    minimum_evidence:
+      - versioned document or schema
+      - explicit assumptions
+      - explicit non-claims
+  illustrative_schema:
+    rank: 2
+    description: Example packet, artifact, or config illustrating expected shape. Not executed evidence.
+    minimum_evidence:
+      - example artifact
+      - statement that values are illustrative
+      - schema validation when applicable
+  fixture_validated:
+    rank: 3
+    description: Deterministic fixture or toy run was executed and replayed.
+    minimum_evidence:
+      - fixture input artifact
+      - expected result
+      - verification output
+      - pinned tool and schema versions
+  experimental_run:
+    rank: 4
+    description: Real or realistic run executed under declared assumptions.
+    minimum_evidence:
+      - input hashes
+      - environment or runtime metadata
+      - result artifact
+      - assumptions and coverage contract
+      - failure or uncertainty handling
+  independently_reproduced:
+    rank: 5
+    description: Second rater, implementation, environment, or verifier reproduced the result.
+    minimum_evidence:
+      - independent run artifact
+      - comparison report
+      - disagreement or adjudication notes
+  audited_run:
+    rank: 6
+    description: Internal or external reviewer accepted the evidence bundle under an audit protocol.
+    minimum_evidence:
+      - evidence bundle manifest
+      - audit or review record
+      - scope of acceptance
+      - unresolved findings if any
+promotion_rules:
+  - A claim cannot be presented at a stronger mode than its evidence supports.
+  - INCONCLUSIVE blocks claim promotion but may support investigation.
+  - VIOLATION blocks promotion and routes a counterexample.
+  - PROVED only supports the mode matched by its evidence context; a PROVED fixture is not an audited run.

--- a/catalog/evidence-contracts.yaml
+++ b/catalog/evidence-contracts.yaml
@@ -1,0 +1,113 @@
+schema_version: "0.1"
+standard_ref:
+  repo: SocioProphet/prophet-platform-standards
+  schemas:
+    - schemas/evidence-artifact.schema.json
+    - schemas/claim-mode.schema.json
+contracts:
+  proof_artifact:
+    owner: SocioProphet/prophet-platform
+    purpose: Replayable proof/checker result for runtime, security, or platform claims.
+    required_fields:
+      - schema_version
+      - artifact_id
+      - producer_boundary
+      - claim
+      - assumptions
+      - inputs_hash
+      - result
+      - sufficiency_type
+    verdicts:
+      PROVED: Claim holds for all traces consistent with observed window and assumptions.
+      VIOLATION: Counterexample or witness slice demonstrates forbidden state or transition.
+      INCONCLUSIVE: Required evidence, trust roots, precision, or budget are insufficient.
+    required_trust_roots:
+      - input hash canonicalization
+      - policy bundle hash/signature
+      - checker version pinning
+    downgrade_rules:
+      - Missing required coverage family -> INCONCLUSIVE
+      - Input hash mismatch -> reject artifact
+      - Unknown schema version -> reject artifact
+
+  boundary_record:
+    owner: SocioProphet/prophet-platform-standards
+    purpose: Machine-readable repo jurisdiction and evidence contract declaration.
+    required_fields:
+      - schema_version
+      - repo
+      - jurisdiction
+      - owned_artifacts
+      - non_goals
+      - upstream_inputs
+      - downstream_outputs
+      - claim_modes
+      - sufficiency_types
+      - trust_roots
+      - evidence_required
+      - allowed_crossings
+      - forbidden_crossings
+      - promotion_gates
+      - maturity
+    required_trust_roots:
+      - schema version pinning
+      - source repo commit hash
+    downgrade_rules:
+      - Missing boundary record -> boundary coverage gap
+      - Invalid boundary schema -> INCONCLUSIVE for atlas ingestion
+
+  governance_evidence_packet:
+    owner: SocioProphet/model-governance-ledger
+    purpose: Frozen evidence packet and adjudication material for model/service documentation sufficiency claims.
+    required_fields:
+      - artifact identifier
+      - surface type
+      - vector family
+      - field index
+      - raw tri-state code
+      - conservative collapsed code
+      - source URL or artifact hash
+      - evidence note
+      - scope note
+    required_trust_roots:
+      - frozen packet hash
+      - codebook version
+      - rater/adjudication identity for stronger modes
+    downgrade_rules:
+      - Raw U on required field collapses to 0
+      - Single-team packet cannot claim independently_reproduced
+      - Missing source evidence blocks governance-ready classification
+
+  boot_trust_evidence:
+    owner: SourceOS-Linux/sourceos-boot
+    purpose: BootReleaseSet and attestation evidence for substrate trust claims.
+    required_fields:
+      - release set hash
+      - boot measurement evidence
+      - policy version
+      - rollback status
+      - verifier result
+    required_trust_roots:
+      - TPM/PCR measurement
+      - signed BootReleaseSet
+      - build provenance
+    downgrade_rules:
+      - Missing attestation -> INCONCLUSIVE
+      - Unsigned release set -> reject as trust root failure
+
+  local_state_integrity_evidence:
+    owner: SourceOS-Linux/sourceos-syncd
+    purpose: Local-first state sync, repair, replication, and provenance evidence.
+    required_fields:
+      - state object hash
+      - actor or node identity
+      - replication event
+      - repair receipt if applicable
+      - policy gate result
+    required_trust_roots:
+      - local state hash chain
+      - signed repair receipt
+      - policy-governed replication log
+    downgrade_rules:
+      - Missing repair receipt for repair claim -> INCONCLUSIVE
+      - Unsigned state mutation -> violation or trust-root failure depending on context

--- a/docs/boundary-atlas-v0.1.md
+++ b/docs/boundary-atlas-v0.1.md
@@ -1,0 +1,114 @@
+# SocioProphet Boundary Atlas v0.1
+
+Status: bootstrap draft.  
+Owner: `SocioProphet/sociosphere`.  
+Standard source: `SocioProphet/prophet-platform-standards` typed boundary standard.
+
+## Purpose
+
+The Boundary Atlas maps repositories to typed jurisdictions, evidence contracts, claim modes, sufficiency labels, trust roots, and permitted boundary crossings.
+
+This turns the typed-boundary doctrine into estate operations:
+
+- repos are jurisdictions;
+- APIs, schemas, proof artifacts, model cards, system cards, boot attestations, and agent traces are typed boundary surfaces;
+- issues and PRs are proposed transitions;
+- CI, checkers, and validators are local proof mechanisms;
+- Policy Fabric decides admissibility;
+- Sociosphere records coverage, gaps, and transition status.
+
+## Core model
+
+```text
+latent state -> typed trace -> semantic/policy lift -> claim -> evidence artifact -> checker verdict -> admissibility gate -> atlas record
+```
+
+The atlas does not make a claim true. It records which repo is allowed to make which claim, under which evidence contract, and what downstream consumers may rely on.
+
+## Initial boundary entries
+
+The initial catalog is `catalog/boundaries.yaml`. It covers:
+
+| Repo | Boundary class | Jurisdiction | Maturity |
+| --- | --- | --- | --- |
+| `SocioProphet/prophet-platform-standards` | standards | Typed-boundary standard, claim modes, sufficiency taxonomy, evidence schemas | L2 |
+| `SocioProphet/sociosphere` | estate_registry | Boundary atlas, repo jurisdiction registry, transition reporting | L2 |
+| `SocioProphet/prophet-platform` | runtime_verifier | Event-IR, proof artifacts, run bundles, checker contract | L1 |
+| `SocioProphet/policy-fabric` | admissibility_policy | Claim-mode promotion and proof-artifact admissibility | L1 |
+| `SocioProphet/ontogenesis` | law_compiler | Schema/ontology-to-law compilation | L0 |
+| `SocioProphet/model-governance-ledger` | governance_evidence | Documentation evidence packets, sufficiency rubrics, adjudication | L1 |
+| `SocioProphet/sherlock-search` | evidentiary_retrieval | Search, source attribution, claim-support traces | L0 |
+| `SocioProphet/gaia-world-model` | world_model_trace | World-model traces, provenance, uncertainty evidence | L0 |
+| `SocioProphet/agentplane` | agent_runtime | Agent execution boundary, sandboxing, output attestation | L0 |
+| `SocioProphet/agent-registry` | agent_identity_capability | Agent identity, capability manifests, revocation | L0 |
+| `SourceOS-Linux/sourceos-boot` | boot_trust | BootReleaseSet, TPM/PCR evidence, rollback, host trust | L0 |
+| `SourceOS-Linux/sourceos-syncd` | local_state_integrity | Local-first sync, repair, replication, provenance | L0 |
+
+## Claim mode registry
+
+Claim modes are defined in `catalog/claim-modes.yaml`:
+
+1. `formal_construction`
+2. `illustrative_schema`
+3. `fixture_validated`
+4. `experimental_run`
+5. `independently_reproduced`
+6. `audited_run`
+
+The atlas must not upgrade a claim beyond its evidence mode.
+
+## Evidence contracts
+
+Evidence contracts are defined in `catalog/evidence-contracts.yaml`. Initial contracts:
+
+- `proof_artifact`
+- `boundary_record`
+- `governance_evidence_packet`
+- `boot_trust_evidence`
+- `local_state_integrity_evidence`
+
+Each contract declares required fields, trust roots, and downgrade rules.
+
+## Verdict semantics
+
+The atlas records proof/checker verdicts but does not reinterpret them:
+
+- `PROVED`: the claim holds for all traces consistent with the observation window and assumptions.
+- `VIOLATION`: a forbidden state or transition has a witness/counterexample.
+- `INCONCLUSIVE`: evidence, trust root, precision, or budget is insufficient.
+
+`INCONCLUSIVE` is not failure. It is honest uncertainty and should create a backlog item or investigation path.
+
+## Boundary maturity
+
+- `L0`: repo exists; boundary informal.
+- `L1`: human boundary declaration exists or implementation issue open.
+- `L2`: machine-readable boundary record exists.
+- `L3`: schema validation exists.
+- `L4`: claim-mode/evidence gates exist in CI or policy.
+- `L5`: Sociosphere ingests boundary metadata automatically.
+- `L6`: cross-repo boundary checks run on PRs or release.
+- `L7`: release artifacts carry evidence bundles and sufficiency labels.
+- `L8`: independent replay or audit exists.
+
+## Current interpretation
+
+The estate has strong conceptual alignment but limited operational enforcement. The current atlas is an explicit bootstrap: it creates a shared map and identifies the first hardening queue.
+
+Priority order:
+
+1. Merge the typed-boundary standard.
+2. Add native `BOUNDARY.md` / `.socioprophet/boundary.yaml` to the six canonical repos.
+3. Implement schema validation and coverage report generation in Sociosphere.
+4. Connect Prophet Platform proof artifacts to Policy Fabric admissibility gates.
+5. Promote only fixture-validated evidence after deterministic examples exist.
+
+## Non-goals
+
+The atlas does not:
+
+- implement downstream repo features;
+- replace Policy Fabric admissibility decisions;
+- certify runtime claims without evidence artifacts;
+- treat logs, dashboards, or comments as proof by themselves;
+- assert production readiness for repos that lack boundary declarations.

--- a/docs/boundary-coverage-report.md
+++ b/docs/boundary-coverage-report.md
@@ -1,0 +1,60 @@
+# Boundary Coverage Report v0.1
+
+Status: bootstrap report.  
+Owner: `SocioProphet/sociosphere`.
+
+## Summary
+
+The Boundary Atlas v0.1 makes repo boundary maturity visible across the initial estate spine.
+
+Current high-level status:
+
+| Maturity | Count | Meaning |
+| --- | ---: | --- |
+| L2 | 2 | Machine-readable example or catalog record exists |
+| L1 | 3 | Implementation issue or human boundary path exists |
+| L0 | 7 | Boundary still informal / native file missing |
+
+Total initial entries: 12.
+
+## Coverage by repo
+
+| Repo | Boundary class | Maturity | Immediate gap |
+| --- | --- | --- | --- |
+| `SocioProphet/prophet-platform-standards` | standards | L2 | Merge typed-boundary standard and publish schemas |
+| `SocioProphet/sociosphere` | estate_registry | L2 | Add validator / ingestion tool |
+| `SocioProphet/prophet-platform` | runtime_verifier | L1 | Add native proof-artifact and Event-IR schemas |
+| `SocioProphet/policy-fabric` | admissibility_policy | L1 | Add claim-mode and proof-verdict gates |
+| `SocioProphet/model-governance-ledger` | governance_evidence | L1 | Add evidence-packet schema and scorer |
+| `SocioProphet/ontogenesis` | law_compiler | L0 | Add boundary declaration for schema-to-law compiler role |
+| `SocioProphet/sherlock-search` | evidentiary_retrieval | L0 | Add evidence retrieval/source trace boundary |
+| `SocioProphet/gaia-world-model` | world_model_trace | L0 | Add world-model provenance/trace boundary |
+| `SocioProphet/agentplane` | agent_runtime | L0 | Add runtime sandbox/output-attestation boundary |
+| `SocioProphet/agent-registry` | agent_identity_capability | L0 | Add identity/capability/revocation boundary |
+| `SourceOS-Linux/sourceos-boot` | boot_trust | L0 | Add BootReleaseSet/TPM/PCR trust boundary |
+| `SourceOS-Linux/sourceos-syncd` | local_state_integrity | L0 | Add local-first state integrity boundary |
+
+## First hardening queue
+
+1. Merge `prophet-platform-standards` typed-boundary standard.
+2. Add native boundary files to `prophet-platform`, `policy-fabric`, and `model-governance-ledger`.
+3. Add Sociosphere validator for `catalog/boundaries.yaml` and repo-local `.socioprophet/boundary.yaml` files.
+4. Add Policy Fabric admissibility gates for claim-mode promotion.
+5. Add Prophet Platform proof-artifact schema and KMS fixtures.
+
+## Risk notes
+
+- Current catalog entries are bootstrap declarations, not proof of implementation.
+- L0 repos should not be presented as boundary-governed until native declarations land.
+- `PROVED`, `VIOLATION`, and `INCONCLUSIVE` semantics require downstream checker and policy integration before they can govern releases.
+- The atlas records evidence contracts; it does not replace the evidence itself.
+
+## v0.2 target
+
+Boundary Atlas v0.2 should add:
+
+- schema validation command;
+- generated coverage report from catalog files;
+- PR check for missing/invalid boundary metadata;
+- links to native repo `BOUNDARY.md` files;
+- transition status imported from Policy Fabric once available.

--- a/docs/repo-jurisdiction-model.md
+++ b/docs/repo-jurisdiction-model.md
@@ -1,0 +1,76 @@
+# Repo Jurisdiction Model
+
+Status: Boundary Atlas v0.1 companion.
+
+## Principle
+
+A repository is a jurisdiction when it is the authoritative producer of one or more typed artifacts and the declared owner of the evidence contract attached to those artifacts.
+
+Jurisdiction is not the same as ownership in GitHub. A repo may contain code without being authoritative for a claim. A repo becomes authoritative only when its boundary declaration names the artifact, claim mode, sufficiency type, trust roots, and downstream consumers.
+
+## Jurisdiction record
+
+Each jurisdiction records:
+
+- `boundary_class`: the role this repo plays in the estate.
+- `jurisdiction`: the concise responsibility statement.
+- `owned_artifacts`: authoritative outputs.
+- `claim_modes`: strongest claim types the repo may publish.
+- `sufficiency_types`: what its outputs are sufficient for.
+- `trust_roots`: assumptions required for downstream reliance.
+- `maturity`: current boundary hardening level.
+- `next_step`: immediate work needed to advance maturity.
+
+## Boundary classes
+
+Initial classes:
+
+- `standards`: normative schemas, templates, and doctrine.
+- `estate_registry`: estate-wide catalog, topology, coverage, and transition reporting.
+- `runtime_verifier`: Event-IR, proof artifacts, run bundles, checker contracts.
+- `admissibility_policy`: policy gates for claim promotion and boundary crossings.
+- `law_compiler`: ontology/schema-to-law compilation.
+- `governance_evidence`: evidence packets, scoring, adjudication, and model/service governance.
+- `evidentiary_retrieval`: search surfaces, source attribution, and evidence retrieval traces.
+- `world_model_trace`: geospatial/world-model traces, provenance, and uncertainty.
+- `agent_runtime`: agent execution boundary, sandboxing, lifecycle, and output attestation.
+- `agent_identity_capability`: agent identity, capability manifests, and revocation.
+- `boot_trust`: boot, TPM/PCR, release set, and rollback trust boundary.
+- `local_state_integrity`: local-first sync, repair, replication, and provenance integrity.
+
+## Crossing rule
+
+A boundary crossing is admissible only when all of the following are true:
+
+1. the producer declares the emitted artifact;
+2. the consumer declares the required input;
+3. the artifact has an allowed claim mode;
+4. the artifact has the required sufficiency type;
+5. evidence required by the producer and consumer is present;
+6. Policy Fabric admits the transition;
+7. Sociosphere records the crossing.
+
+## Example
+
+`SocioProphet/prophet-platform` may emit a `proof_artifact` for a KMS key usage claim. `SocioProphet/policy-fabric` may consume that artifact to decide whether a claim-mode promotion is admissible. `SocioProphet/sociosphere` records the resulting transition status in the Boundary Atlas.
+
+If the proof artifact is `INCONCLUSIVE`, Policy Fabric blocks promotion and Sociosphere records the missing evidence family. If the artifact is `VIOLATION`, Policy Fabric blocks promotion and routes the counterexample. If the artifact is `PROVED` under approved assumptions, Policy Fabric may allow promotion to the matching evidence mode.
+
+## Anti-patterns
+
+- Treating a repo as authoritative because it contains related docs.
+- Treating a README claim as fixture validation.
+- Treating logs or dashboards as proof artifacts.
+- Consuming an artifact without a declared upstream boundary.
+- Emitting public claims without claim-mode labels.
+- Treating semantic sufficiency as microstate sufficiency.
+
+## v0.1 target
+
+The first target is not full automation. It is explicitness:
+
+- boundary catalog exists;
+- evidence contracts exist;
+- maturity gaps are visible;
+- first downstream repos know what boundary files to add;
+- claim promotion cannot be discussed without evidence mode vocabulary.


### PR DESCRIPTION
## Summary
Adds the first Sociosphere Boundary Atlas v0.1 bootstrap catalog and documentation.

This turns the typed-boundary doctrine into estate-level registry material:
- repo jurisdictions and boundary classes;
- claim modes and evidence mode ranking;
- evidence contracts and downgrade rules;
- boundary coverage/maturity report;
- README links for discoverability.

## Added
- `catalog/boundaries.yaml`
- `catalog/claim-modes.yaml`
- `catalog/evidence-contracts.yaml`
- `docs/boundary-atlas-v0.1.md`
- `docs/repo-jurisdiction-model.md`
- `docs/boundary-coverage-report.md`
- README updates for Boundary Atlas entry points

## Initial entries
The atlas initially covers 12 boundary-relevant repos:
- `SocioProphet/prophet-platform-standards`
- `SocioProphet/sociosphere`
- `SocioProphet/prophet-platform`
- `SocioProphet/policy-fabric`
- `SocioProphet/ontogenesis`
- `SocioProphet/model-governance-ledger`
- `SocioProphet/sherlock-search`
- `SocioProphet/gaia-world-model`
- `SocioProphet/agentplane`
- `SocioProphet/agent-registry`
- `SourceOS-Linux/sourceos-boot`
- `SourceOS-Linux/sourceos-syncd`

## Validation
- Manual catalog/document consistency review.
- No automated schema validation yet; this is explicitly marked as a v0.2 target.

## Follow-up
- Add validator for `catalog/boundaries.yaml` and repo-local `.socioprophet/boundary.yaml`.
- Add generated boundary coverage reporting.
- Consume `prophet-platform-standards` boundary schema after PR #16 lands.

Refs #313.