### PR TITLE
Add Epistemic Governance standard and estate ownership map

### DIFF
--- a/docs/INTEGRATION_STATUS.md
+++ b/docs/INTEGRATION_STATUS.md
@@ -5,6 +5,23 @@ facts that were previously repeated in multiple places.
 
 ## Current state
 
+### Epistemic Governance
+- Canonical standard anchor: `standards/epistemic-governance/`
+- Protocol surface: `protocol/epistemic-governance/v1/`
+- Estate ownership map: `registry/epistemic-governance.yaml`
+- Reference application lineage: Debater 2.0 / Argument Hygiene / Ruleset v1.3.0
+- Status: proposed cross-repo standard and protocol surface
+- Current scope: documentation, lifecycle law, promotion law, detector/counter-test bindings, topic catalog, run spec, migration ledger, and estate ownership map
+- Non-scope in SocioSphere: downstream detector implementation, UI implementation, policy compiler implementation, SourceOS event-store implementation, HolographMe projection runtime, and DeliveryExcellence dashboards
+- Downstream targets:
+  - `SocioProphet/ProCybernetica` for epistemic control doctrine and discursive control node law
+  - `SocioProphet/policy-fabric` for epistemic intervention, profile projection, retention, drift, and promotion policy as code
+  - `SocioProphet/agentplane` for executable detector, counter-test, replay, fixture evaluation, and policy-backtest bundles
+  - `SourceOS-Linux/sourceos-syncd` for local-first discourse events, SourceOS lane mapping, tombstones, repair events, and replayable state integrity
+  - `SocioProphet/HolographMe` and/or `human-digital-twin` for consent-scoped Reasoning Calibration Projections
+  - `SocioProphet/delivery-excellence` for evidence coverage, repair success, false-positive appeal rate, contradiction half-life, review fatigue, and release-readiness metrics
+  - `SocioProphet/ontogenesis` for claim ontology, evidence classes, detector vocabulary, counter-test vocabulary, contradiction semantics, and repair-action semantics
+
 ### TritRPC
 - Canonical upstream: `SocioProphet/TriTRPC`
 - Workspace declaration: `manifest/workspace.toml` repo `tritrpc`
@@ -44,3 +61,8 @@ treat that content as historical context. Current behavior is defined by
 For edge-capability upstreams, treat the registry file plus drift-check tool as
 the operational baseline, and treat the narrative binding doc as the policy /
 disposition explanation.
+
+For Epistemic Governance, treat `standards/epistemic-governance/` plus
+`registry/epistemic-governance.yaml` as the SocioSphere standard/ownership
+baseline. Downstream repos own implementation according to their canonical
+namespace responsibilities.

--- a/governance/CANONICAL_SOURCES.yaml
+++ b/governance/CANONICAL_SOURCES.yaml
@@ -29,12 +29,24 @@ namespaces:
   standards/market-data: { canonical_repo: prophet-platform-standards, upstream_standard: socioprophet-standards-storage, note: "runtime market-data profile authority; storage semantics remain upstream" }
   standards/knowledge: { canonical_repo: socioprophet-standards-knowledge }
   standards/sourceos-spec: { canonical_repo: sourceos-spec, note: "Typed contracts spec (SourceOS-Linux/sourceos-spec)" }
+  standards/epistemic-governance: { canonical_repo: sociosphere, note: "Claim, evidence, critique, repair, promotion, decision/action, appeal, and replay governance standard" }
 
   # Transport & protocol
   protocol/tritrpc: { canonical_repo: TriTRPC }
   protocol/execution: { canonical_repo: agentplane }
   protocol/serdes: { canonical_repo: semantic-serdes }
   protocol/replay: { canonical_repo: cairnpath-mesh }
+  protocol/epistemic-governance/v1: { canonical_repo: sociosphere, note: "Epistemic Governance topic catalog, run spec, fixture contracts, and compatibility expectations" }
+
+  # Epistemic Governance implementation ownership
+  policy/epistemic-intervention: { canonical_repo: policy-fabric, note: "Severity, thresholds, promotion gates, profile projection, retention, drift, and appeal policy as code" }
+  execution/epistemic-detectors: { canonical_repo: agentplane, note: "Detector, counter-test, replay, fixture evaluation, and policy backtest bundles" }
+  sourceos/discourse-events: { canonical_repo: sourceos-syncd, note: "Local-first discourse events, SourceOS lane mapping, tombstones, repair events, and replayable state integrity" }
+  identity/reasoning-calibration: { canonical_repo: HolographMe, upstream_standard: human-digital-twin, note: "Self-owned consent-scoped Reasoning Calibration Projection surface" }
+  delivery/epistemic-metrics: { canonical_repo: delivery-excellence, note: "Evidence coverage, repair success, false-positive appeal rate, contradiction half-life, review fatigue, and release-readiness metrics" }
+  ontology/epistemic-governance: { canonical_repo: ontogenesis, note: "Claim ontology, evidence classes, detector vocabulary, counter-test vocabulary, contradiction semantics, and repair actions" }
+  ui/epistemic-governance: { canonical_repo: socioprophet, note: "Reference UI surfaces for graph views, hygiene flags, repair suggestions, and audit/replay views" }
+  trust/epistemic-authority: { canonical_repo: mcp-a2a-zero-trust, note: "Authority grants, reviewer permissions, tenant boundaries, and policy-scoped tool/action authority" }
 
   # Human Digital Twin
   hdt/core: { canonical_repo: human-digital-twin }

--- a/protocol/epistemic-governance/v1/runspec.v1.yaml
+++ b/protocol/epistemic-governance/v1/runspec.v1.yaml
@@ -1,0 +1,123 @@
+schema_version: 0.1.0
+standard: epistemic-governance
+protocol_version: v1
+status: draft
+owner: sociosphere
+
+purpose: >-
+  Run declaration for deterministic epistemic-governance evaluations,
+  detector runs, counter-tests, policy backtests, replay bundles, and MVS-1
+  smoke runs.
+
+required_fields:
+  - runspec_id
+  - run_kind
+  - standard_version
+  - tenant
+  - inputs
+  - ruleset
+  - policy
+  - outputs
+  - replay
+
+run_kinds:
+  - hygiene_detector
+  - counter_test
+  - fixture_evaluation
+  - policy_backtest
+  - replay
+  - mvs1_smoke
+
+standard_version: epistemic-governance.v0.2.1
+
+tenant_fields:
+  tenant_id: required
+  workspace_id: optional
+  data_residency_region: optional
+  cross_tenant_export_allowed: false_by_default
+
+input_fields:
+  events:
+    required: true
+    item_fields:
+      topic: required
+      ref: required
+      sha256: required
+      privacy_tier: required
+  fixtures:
+    required: false
+
+ruleset_fields:
+  ruleset_semver: required
+  ruleset_hash: required
+  domain_pack: optional
+
+policy_fields:
+  policy_version: required
+  policy_hash: required
+  mode:
+    allowed:
+      - silent_audit
+      - coach
+      - debate
+      - forensic
+      - incident_response
+      - fast_take
+      - refine
+      - teaching
+      - governance_board
+
+authority_fields:
+  requested_by: optional
+  authority_scope: optional
+  quorum_rule: optional
+
+output_fields:
+  required_topics: required
+  artifact_dir: optional
+  sourceos_lane: optional
+  agentplane_bundle: optional
+
+replay_fields:
+  replay_mode:
+    required: true
+    allowed:
+      - original_replay
+      - current_replay
+      - diff_replay
+      - migration_replay
+  deterministic: required
+  expected_output_hashes: optional
+
+mvs1_example:
+  runspec_id: runspec_mvs1_strawman_smoke
+  run_kind: mvs1_smoke
+  tenant:
+    tenant_id: tenant_local_dev
+    cross_tenant_export_allowed: false
+  inputs:
+    events:
+      - topic: ingress.discourse.v1
+        ref: examples/mvs1/strawman.input.json
+        sha256: sha256:<placeholder>
+        privacy_tier: internal
+  ruleset:
+    ruleset_semver: 1.3.0
+    ruleset_hash: sha256:<placeholder>
+    domain_pack: domain.policy.ruleset.yaml
+  policy:
+    policy_version: epigov.policy.0.1
+    policy_hash: sha256:<placeholder>
+    mode: refine
+  outputs:
+    required_topics:
+      - claim.parsed.v1
+      - hygiene.detect.v1
+      - hygiene.ctest.v1
+      - claim.repair.v1
+      - audit.append.v1
+    sourceos_lane: repair
+    agentplane_bundle: epigov-hygiene-detector-smoke
+  replay:
+    replay_mode: original_replay
+    deterministic: true

--- a/protocol/epistemic-governance/v1/topic-catalog.v1.yaml
+++ b/protocol/epistemic-governance/v1/topic-catalog.v1.yaml
@@ -1,0 +1,195 @@
+schema_version: 0.1.0
+standard: epistemic-governance
+protocol_version: v1
+status: draft
+owner: sociosphere
+compatibility_policy: semver
+
+description: >-
+  Topic catalog for Epistemic Governance event streams. The catalog follows
+  the QES pattern: versioned topics, deterministic replay inputs, and evidence
+  events with provenance. Full CloudEvents schemas are deferred to the schema
+  pack; this file establishes topic identity and compatibility expectations.
+
+envelope:
+  expected_shape: cloudevents_1_0_compatible
+  required_fields:
+    - id
+    - source
+    - specversion
+    - type
+    - subject
+    - time
+    - datacontenttype
+    - data
+  required_trace_fields:
+    - trace_id
+    - span_id
+    - schema_version
+    - privacy_tier
+    - tenant_id
+
+topics:
+  - name: ingress.discourse.v1
+    owner: reference_app_or_connector
+    purpose: raw or redacted discourse event ingress
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: claim.parsed.v1
+    owner: argument_mining_service
+    purpose: parsed claim, warrant, evidence, qualifier, and counterexample candidates
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: claim.classified.v1
+    owner: argument_mining_service
+    purpose: claim type, domain, language, register, modality, and speaker/agent context
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: moderation.decision.v1
+    owner: moderation_policy_service
+    purpose: safety, abuse, PII, prompt-injection, and manipulation decisions
+    compatibility: additive_optional_fields_only
+    privacy_default: sensitive
+
+  - name: hygiene.detect.v1
+    owner: hygiene_profiler
+    purpose: detector finding hypothesis with score, span, rationale, and required counter-test
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: hygiene.ctest.v1
+    owner: counter_test_runner
+    purpose: counter-test result with measurement quality and policy effect
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: evidence.authority.v1
+    owner: evidence_authority_service
+    purpose: evidence source class, provenance, hash, jurisdiction, freshness, and authority metadata
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: verification.result.v1
+    owner: verifier_service
+    purpose: entailment, contradiction, quote-exactness, numeric, date, actor, and source checks
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: claim.repair.v1
+    owner: repair_engine
+    purpose: repair suggestions, accepted repairs, rejected repairs, and retest status
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: claim.promotion.v1
+    owner: promotion_authority
+    purpose: claim lifecycle promotion, canonization, and accepted-for-context movement
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: claim.reversal.v1
+    owner: reversal_authority
+    purpose: deprecation, reversal, failed replay, successful appeal, or contradiction-driven demotion
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: contradiction.record.v1
+    owner: contradiction_ledger
+    purpose: scoped conflicts between claims, resolution status, synthesis attempts, and uncertainty
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: decision.record.v1
+    owner: decision_authority
+    purpose: governance decision that cites claims, values, policy, jurisdiction, uncertainty, and appeal path
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: action.record.v1
+    owner: action_authority
+    purpose: authorized action, execution state, verification, rollback, and remediation status
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: appeal.case.v1
+    owner: review_queue
+    purpose: appeal, dispute, correction, reviewer assignment, decision, and downstream correction path
+    compatibility: additive_optional_fields_only
+    privacy_default: sensitive
+
+  - name: reasoning.calibration.projection.v1
+    owner: holographme_or_human_digital_twin
+    purpose: consent-scoped reasoning calibration projection with MQI and profile safety limits
+    compatibility: additive_optional_fields_only
+    privacy_default: sensitive
+
+  - name: drift.alert.v1
+    owner: drift_monitor
+    purpose: detector, policy, threshold, false-positive, false-negative, or calibration drift alert
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: governance.policy-update.v1
+    owner: policy_authority
+    purpose: signed policy/ruleset threshold update with backtest and approval metadata
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: audit.append.v1
+    owner: audit_ledger
+    purpose: append-only audit event for material governance, detector, policy, claim, decision, action, appeal, and profile events
+    compatibility: additive_optional_fields_only
+    privacy_default: internal
+
+  - name: export.manifest.v1
+    owner: export_service
+    purpose: export bundle manifest with redactions, hash commitments, evidence references, replay inputs, and permissions
+    compatibility: additive_optional_fields_only
+    privacy_default: sensitive
+
+  - name: threat.detected.v1
+    owner: abuse_or_threat_monitor
+    purpose: Goodharting, citation stuffing, source laundering, brigading, label poisoning, policy capture, and detector evasion events
+    compatibility: additive_optional_fields_only
+    privacy_default: sensitive
+
+sourceos_lane_mapping:
+  normal:
+    - claim.parsed.v1
+    - claim.classified.v1
+  audit:
+    - audit.append.v1
+  policy:
+    - moderation.decision.v1
+    - governance.policy-update.v1
+  repair:
+    - claim.repair.v1
+    - appeal.case.v1
+  memory:
+    - claim.promotion.v1
+    - decision.record.v1
+  tombstone:
+    - claim.reversal.v1
+  archive:
+    - export.manifest.v1
+  secure:
+    - reasoning.calibration.projection.v1
+    - threat.detected.v1
+
+compatibility_rules:
+  patch:
+    - wording changes
+    - examples
+    - non-breaking metadata
+  minor:
+    - new optional field
+    - new topic
+    - new detector binding
+  major:
+    - required field change
+    - topic semantic change
+    - lifecycle transition change
+    - detector threshold semantics change

--- a/registry/epistemic-governance.yaml
+++ b/registry/epistemic-governance.yaml
@@ -1,0 +1,130 @@
+schema_version: 0.1.0
+standard: epistemic-governance
+status: draft
+owner: sociosphere
+
+purpose: >-
+  Estate ownership map for Epistemic Governance. SocioSphere owns the canonical
+  standard, protocol, migration ledger, and cross-repo orchestration map. Downstream
+  repositories own their implementation surfaces.
+
+canonical_namespaces:
+  standards/epistemic-governance:
+    canonical_repo: sociosphere
+    responsibility: standard text, lifecycle model, promotion law, detector map, migration ledger
+
+  protocol/epistemic-governance/v1:
+    canonical_repo: sociosphere
+    responsibility: topic catalog, run spec, fixture contract, compatibility expectations
+
+  policy/epistemic-intervention:
+    canonical_repo: policy-fabric
+    responsibility: severity mapping, detector thresholds, generation gates, promotion gates, appeal policy, drift freeze policy
+
+  execution/epistemic-detectors:
+    canonical_repo: agentplane
+    responsibility: detector bundles, counter-test bundles, replay bundles, policy backtests, fixture evaluation runs
+
+  sourceos/discourse-events:
+    canonical_repo: sourceos-syncd
+    responsibility: local-first event integrity, SourceOS lane mapping, tombstones, repair events, replayable state
+
+  identity/reasoning-calibration:
+    canonical_repo: HolographMe
+    upstream_related_repo: human-digital-twin
+    responsibility: self-owned reasoning calibration projections, consent scope, profile transition receipts
+
+  delivery/epistemic-metrics:
+    canonical_repo: delivery-excellence
+    responsibility: evidence coverage, repair success, false-positive appeal rate, contradiction half-life, review fatigue, release-readiness metrics
+
+  ontology/epistemic-governance:
+    canonical_repo: ontogenesis
+    responsibility: claim ontology, evidence classes, detector vocabulary, counter-test vocabulary, contradiction semantics
+
+  ui/epistemic-governance:
+    canonical_repo: socioprophet
+    responsibility: reference UI surfaces, graph views, hygiene flags, repair suggestions, audit/replay views
+
+  trust/epistemic-authority:
+    canonical_repo: mcp-a2a-zero-trust
+    responsibility: authority grants, reviewer permissions, tenant boundaries, policy-scoped tool/action authority
+
+repo_alignment:
+  sociosphere:
+    layer: control-plane
+    role: standard-owner
+    files:
+      - standards/epistemic-governance/
+      - protocol/epistemic-governance/v1/
+      - registry/epistemic-governance.yaml
+
+  ProCybernetica:
+    layer: doctrine
+    role: cybernetic-control-law-owner
+    planned_files:
+      - docs/doctrine/epistemic-control-law.md
+      - docs/doctrine/discursive-control-node.md
+      - docs/doctrine/claim-promotion-and-reversal-law.md
+
+  policy-fabric:
+    layer: governance
+    role: policy-as-code-owner
+    planned_files:
+      - contracts/epistemic-intervention-policy.schema.json
+      - contracts/epistemic-profile-projection-policy.schema.json
+      - contracts/epistemic-retention-policy.schema.json
+      - examples/epistemic/
+
+  agentplane:
+    layer: execution-plane
+    role: executable-evidence-owner
+    planned_files:
+      - bundles/epigov-hygiene-detector-smoke/
+      - bundles/epigov-countertest-smoke/
+      - schemas/hygiene-run-artifact.schema.json
+      - schemas/countertest-run-artifact.schema.json
+
+  sourceos-syncd:
+    layer: sourceos-control-plane
+    role: local-first-event-integrity-owner
+    planned_files:
+      - schemas/sourceos.discourse-event.v0.1.schema.json
+      - examples/events/discourse/
+
+  HolographMe:
+    layer: human-digital-twin
+    role: reasoning-calibration-projection-owner
+    planned_files:
+      - schemas/reasoning-calibration-projection.schema.json
+      - examples/reasoning-calibration/
+
+  delivery-excellence:
+    layer: governance-metrics
+    role: metrics-and-release-readiness-owner
+    planned_files:
+      - metrics/epistemic-governance-signals.yaml
+      - docs/epistemic-delivery-metrics.md
+
+mvs1:
+  title: MVS-1 strawman detector smoke path
+  owner: sociosphere for contract; agentplane/sourceos/policy-fabric for execution follow-up
+  steps:
+    - claim ingress
+    - claim parser
+    - LOGFALL.STRAWMAN.V2 deterministic detector
+    - CTEST.STEELMAN.CONFIRM.V2 stub
+    - repair suggestion
+    - audit append
+    - JSON Schema validation
+    - one AgentPlane replay bundle
+    - one SourceOS event-store write
+
+release_gates:
+  - standard anchor exists
+  - topic catalog exists
+  - run spec exists
+  - detector map exists
+  - migration ledger exists
+  - estate ownership map exists
+  - follow-up issues created for downstream repos

--- a/standards/epistemic-governance/README.md
+++ b/standards/epistemic-governance/README.md
@@ -1,0 +1,157 @@
+# Epistemic Governance Standard
+
+Status: draft v0.2.1 anchor  
+Owner: SocioSphere  
+Scope: cross-repo reasoning, claim, evidence, critique, repair, promotion, replay, and governance contracts  
+Non-scope: downstream product implementation, model-specific detector internals, private tenant data, hidden model reasoning traces
+
+## Purpose
+
+Epistemic Governance is the SocioSphere standard for turning claims, evidence, critiques, decisions, actions, and repairs into governed, replayable, auditable objects.
+
+The first reference application is Debater 2.0, but the standard is broader than debate. It applies to GitHub review, governance boards, agent planning, policy review, proof-program critique, SourceOS incident narratives, DeliveryExcellence retrospectives, HolographMe interviews, and institutional decision systems.
+
+The operating doctrine is:
+
+```text
+Claims are state.
+Reasoning is telemetry.
+Critique is a control loop.
+Evidence is the promotion substrate.
+Repair is the product.
+```
+
+## Why SocioSphere owns the standard
+
+SocioSphere is the workspace controller and standards surface for the estate. It owns workspace manifests, lock discipline, topology rules, registry metadata, shared protocol fixtures, standards validation, and cross-repo orchestration. Epistemic Governance is therefore registered here as a standard and protocol surface.
+
+Downstream repositories remain responsible for implementation:
+
+- ProCybernetica owns doctrine and cybernetic control law.
+- Policy Fabric owns intervention, profile-projection, retention, drift, and promotion policy as code.
+- AgentPlane owns executable detector, counter-test, replay, and backtest bundles.
+- SourceOS owns local-first discourse event integrity, privacy lanes, repair/tombstone behavior, and replayable state.
+- HolographMe / Human Digital Twin owns consent-scoped reasoning-calibration projections.
+- DeliveryExcellence owns metrics, dashboards, and release-readiness signals.
+- Ontogenesis owns semantic ontology, claim types, reasoning-defect vocabulary, and counter-test bindings.
+
+## Relationship to existing SocioSphere standards
+
+Epistemic Governance composes existing standards rather than replacing them.
+
+- The Proof Apparatus standard supplies claim, gate, evidence, obstruction, promotion, and non-claim discipline.
+- QES supplies event, topic, run, evidence, deterministic replay, and compatibility discipline.
+- Source Exposure Governance supplies publication-safety and disclosure discipline.
+- Angel of the Lord supplies adversarial critique posture.
+- Workspace manifest and topology checks supply cross-repo determinism.
+
+## Core objects
+
+```text
+Claim
+Evidence
+Warrant
+Backing
+Rebuttal
+Qualifier
+Counterexample
+DetectorFinding
+CounterTestResult
+RepairAction
+DecisionRecord
+ActionRecord
+AppealCase
+ContradictionRecord
+PromotionRecord
+ReversalRecord
+AuditRecord
+ReplayManifest
+ReasoningCalibrationProjection
+```
+
+## Claim, decision, and action separation
+
+This standard distinguishes epistemic claims from governance decisions and operational actions.
+
+```text
+Claim: a statement that can be parsed, tested, grounded, accepted, canonized, deprecated, or reversed.
+Decision: an authority-scoped governance choice made using one or more claims plus values, policy, risk, jurisdiction, and mission context.
+Action: a world-changing or repository-changing operation taken after a decision.
+```
+
+A true claim does not automatically authorize an action. A valid action must cite the decision record that authorized it, and the decision must cite its supporting claims and policies.
+
+## Detector fallibility rule
+
+LOGFALL, COGBIAS, TECHCLAIM, and related detector outputs are hypotheses, not final accusations.
+
+Required framing:
+
+```text
+possible reasoning defect
+confidence score
+span or artifact region
+signal stack
+required counter-test
+status: raised | counter_test_pending | confirmed | cleared | appealed | reversed | archived
+```
+
+User-facing surfaces must not label people as biased or defective. They must show the finding, uncertainty, repair path, and appeal path.
+
+## Human dignity rule
+
+The user-facing profile artifact is named Reasoning Calibration Projection, not Bias Passport.
+
+The system must not create public bias leaderboards, use calibration scores as sole employment criteria, expose low-N scores outside self-private diagnostic mode, compare people across domains without MQI, mutate human profiles without audit, or treat contextual calibration telemetry as permanent identity.
+
+## Conformance surface
+
+A conforming implementation must support:
+
+1. typed discourse ingress;
+2. claim lifecycle records;
+3. detector findings as hypotheses;
+4. paired counter-tests for warn/block findings;
+5. claim repair events;
+6. evidence authority metadata;
+7. claim / decision / action separation;
+8. promotion and reversal law;
+9. appeal and dispute records;
+10. privacy tiers and tombstones;
+11. replay manifests;
+12. deterministic validation of schemas and examples;
+13. SourceOS lane mapping where local-first state applies;
+14. AgentPlane replay where executable detector/counter-test runs apply;
+15. DeliveryExcellence metrics for drift, appeal, repair, evidence, and review load.
+
+## Minimal viable slice
+
+MVS-1 is intentionally small:
+
+```text
+claim ingress
+claim parser
+LOGFALL.STRAWMAN.V2 deterministic detector
+CTEST.STEELMAN.CONFIRM.V2 stub
+repair suggestion
+audit append
+JSON Schema validation
+one AgentPlane replay bundle
+one SourceOS event-store write
+```
+
+MVS-1 proves that the standard is executable without requiring the full Debater 2.0 application.
+
+## Files in this standard
+
+| File | Purpose |
+|---|---|
+| `README.md` | Standard anchor and estate placement |
+| `claim-lifecycle.md` | Claim, decision, action, contradiction, appeal, and repair lifecycle model |
+| `promotion-law.md` | Promotion, canonization, reversal, decision, action, and authority rules |
+| `detector-countertest-map.yaml` | Initial detector/counter-test/severity/repair bindings |
+| `migration-ledger.md` | v0.1 Debater → v0.2/v0.2.1 migration map |
+
+Protocol files live under `protocol/epistemic-governance/v1/`.
+
+Registry and estate ownership live under `registry/epistemic-governance.yaml`.

--- a/standards/epistemic-governance/claim-lifecycle.md
+++ b/standards/epistemic-governance/claim-lifecycle.md
@@ -1,0 +1,224 @@
+# Epistemic claim lifecycle
+
+Status: draft v0.2.1  
+Owner: SocioSphere  
+Scope: claim, decision, action, appeal, contradiction, repair, and profile-state lifecycle semantics
+
+## 1. Claim lifecycle
+
+A claim moves through explicit states:
+
+```text
+raw
+→ parsed
+→ classified
+→ challenged
+→ tested
+→ grounded
+→ verified
+→ repaired | revised | rejected
+→ accepted_for_context
+→ canonized
+→ deprecated | reversed
+```
+
+## 2. State definitions
+
+| State | Meaning |
+|---|---|
+| `raw` | Unprocessed text, speech, artifact, code, log, or visual input. |
+| `parsed` | Segmented into possible claims, warrants, evidence, and rhetorical structure. |
+| `classified` | Assigned claim type, domain, language, register, speaker/agent context, and modality. |
+| `challenged` | A detector, human, agent, policy, or conflicting claim raised a challenge. |
+| `tested` | One or more required counter-tests executed or were explicitly waived under policy. |
+| `grounded` | Candidate evidence is attached with authority and provenance metadata. |
+| `verified` | Verification gates passed for the claim type and domain. |
+| `repaired` | Claim was improved by clarification, steelman, evidence, narrowing, or qualification. |
+| `revised` | Speaker or authorized agent materially changed the claim. |
+| `rejected` | Required gates failed or policy prohibits promotion. |
+| `accepted_for_context` | Locally usable under explicit scope and confidence, but not canonical truth. |
+| `canonized` | Promoted into a stable institutional record under promotion law. |
+| `deprecated` | No longer active, stale, superseded, or demoted by later policy/evidence. |
+| `reversed` | Materially contradicted, invalidated, or successfully appealed. |
+
+## 3. Claim types
+
+Initial claim types:
+
+```text
+empirical
+causal
+probabilistic
+normative
+legal_policy
+mathematical_formal
+operational
+identity
+authority
+preference
+forecast
+risk_threat
+promise_commitment
+interpretive
+rhetorical_metaphorical
+technical_engineering
+```
+
+Different claim types require different gates. A causal claim requires counterfactual or causal-structure evidence. A mathematical claim requires proof or computational gate discipline. An operational claim requires runtime, repository, replay, or run-artifact evidence. A normative claim requires value-premise extraction.
+
+## 4. Claim, decision, and action separation
+
+Claims, decisions, and actions are separate state machines.
+
+```text
+Claim     = what is asserted.
+Decision  = what an authority chooses, based on claims plus values, policy, risk, jurisdiction, and context.
+Action    = what is done in the world, repository, platform, policy, or runtime.
+```
+
+A claim can be true while a decision remains invalid, disproportionate, unauthorized, or jurisdictionally wrong. An action can be technically successful while the decision authorizing it is invalid.
+
+## 5. Decision lifecycle
+
+```text
+proposed
+→ supported
+→ contested
+→ reviewed
+→ approved | denied | deferred
+→ action_authorized | no_action
+→ appealed | closed
+```
+
+A `decision.record.v1` must cite:
+
+- decision authority;
+- supporting claim IDs;
+- rejected or contested claim IDs;
+- value premises;
+- policy refs;
+- jurisdiction or scope;
+- risk posture;
+- appeal path;
+- audit ID.
+
+## 6. Action lifecycle
+
+```text
+proposed
+→ authorized
+→ scheduled
+→ executed
+→ verified
+→ remediated | rolled_back | closed
+```
+
+An action must cite a decision record. Repository-changing, policy-changing, profile-changing, publication-changing, or world-changing actions must be replayable or explain why replay is impossible.
+
+## 7. Contradiction lifecycle
+
+Contradictions are not silently erased. They are governed objects.
+
+```text
+detected
+→ scoped
+→ reviewed
+→ resolved | bounded_uncertainty | escalated
+→ archived
+```
+
+A contradiction record must include:
+
+- contradiction ID;
+- claim A;
+- claim B;
+- scope of conflict;
+- conflict type;
+- current resolution status;
+- synthesis attempt, if any;
+- remaining uncertainty;
+- review authority;
+- audit ID.
+
+## 8. Appeal lifecycle
+
+```text
+submitted
+→ accepted_for_review | rejected_as_invalid
+→ assigned
+→ evidence_reviewed
+→ decision_rendered
+→ corrections_applied | no_change
+→ closed
+```
+
+Appealable objects include detector findings, counter-test results, evidence authority classifications, policy interventions, generation blocks, claim rejection, claim promotion, claim reversal, reasoning-calibration profile updates, decisions, actions, and retention/redaction decisions.
+
+## 9. Repair lifecycle
+
+```text
+suggested
+→ accepted | rejected | modified
+→ applied
+→ retested
+→ resolved | still_blocked
+```
+
+Initial repair actions:
+
+```text
+steelman_rewrite
+evidence_request
+term_lock
+claim_split
+causal_dag_request
+confidence_widening
+source_content_separation
+burden_reassignment
+baseline_request
+counterexample_request
+scope_narrowing
+value_premise_extraction
+citation_replacement
+temporal_qualification
+```
+
+## 10. Detector finding lifecycle
+
+Detector findings are hypotheses, not verdicts.
+
+```text
+raised
+→ counter_test_pending
+→ confirmed | cleared
+→ appealed
+→ upheld | reversed
+→ archived
+```
+
+Required display posture:
+
+```text
+Possible reasoning defect detected.
+Confidence: <score>
+Span/artifact region: <location>
+Counter-test: <test id>
+Repair path: <repair id or recommendation>
+Appeal path: <appeal case link>
+```
+
+## 11. Privacy and storage tier
+
+Every lifecycle event must declare a privacy/storage tier:
+
+```text
+public
+internal
+sensitive
+local_only
+hash_commitment_only
+redacted
+sealed
+```
+
+Raw text should not be retained when a derived claim object, redacted span, and hash commitment are sufficient.

--- a/standards/epistemic-governance/detector-countertest-map.yaml
+++ b/standards/epistemic-governance/detector-countertest-map.yaml
@@ -1,0 +1,226 @@
+schema_version: 0.1.0
+standard: epistemic-governance
+ruleset_semver: 1.3.0
+status: draft
+owner: sociosphere
+
+principles:
+  detector_findings_are_hypotheses: true
+  repair_before_punishment: true
+  counter_tests_required_for_warn_or_block: true
+  small_n_discipline_required: true
+  user_facing_profile_name: Reasoning Calibration Projection
+
+severity_tiers:
+  info:
+    meaning: log or gently surface; no interruption by default
+  warn:
+    meaning: surface span, rationale, counter-test, and repair path
+  block:
+    meaning: halt generation, promotion, publication, or action until resolved or waived under policy
+
+namespaces:
+  logical_fallacies: LOGFALL
+  cognitive_biases: COGBIAS
+  technical_claims: TECHCLAIM
+  counter_tests: CTEST
+  technical_tests: TTEST
+
+detectors:
+  - rule_id: LOGFALL.STRAWMAN.V2
+    default_severity: warn
+    primary_signals:
+      - nli_contradiction_or_neutrality
+      - proposition_drift
+      - quantifier_flip
+      - hyperbole_tokens
+    required_counter_tests:
+      - CTEST.STEELMAN.CONFIRM.V2
+    default_repairs:
+      - steelman_rewrite
+      - scope_narrowing
+    promotion_effect: cannot_use_rebuttal_as_grounded_until_counter_test_clears_or_repair_applied
+
+  - rule_id: LOGFALL.ADHOM.V2
+    default_severity: block
+    primary_signals:
+      - person_targeting_predicate
+      - interlocutor_subject
+      - proposition_absent_or_secondary
+    required_counter_tests:
+      - CTEST.REFOCUS.PROPOSITION.V1
+    default_repairs:
+      - refocus_on_claim
+      - remove_person_attack
+    promotion_effect: publication_block_until_repaired_or_moderator_override
+
+  - rule_id: LOGFALL.EMOTION.V2
+    default_severity: warn
+    primary_signals:
+      - high_arousal_sentiment
+      - evidence_scarcity_index_below_domain_threshold
+    required_counter_tests:
+      - CTEST.BASELINE.DATA.V1
+    default_repairs:
+      - evidence_request
+      - baseline_request
+    promotion_effect: requires_evidence_or_qualifier_before_claim_promotion
+
+  - rule_id: LOGFALL.FALSECAUSE.V2
+    default_severity: warn
+    primary_signals:
+      - causal_verbs
+      - temporal_sequence_without_counterfactual_warrant
+      - missing_confounder_handling
+    required_counter_tests:
+      - CTEST.CAUSAL.DO/COUNTERFACTUAL.V1
+    default_repairs:
+      - causal_dag_request
+      - confidence_widening
+      - temporal_qualification
+    promotion_effect: causal_claim_cannot_be_verified_without_causal_gate
+
+  - rule_id: LOGFALL.GISH.V1
+    default_severity: warn
+    primary_signals:
+      - claims_per_100w_above_domain_threshold
+      - rebuttal_bandwidth_shortage
+      - dependency_order_missing
+    required_counter_tests:
+      - CTEST.ACYCLIC.PROOF.V1
+    default_repairs:
+      - claim_split
+      - batch_rebuttal_allocation
+      - priority_ordering
+    promotion_effect: batch_claims_must_be_split_before_individual_promotion
+
+  - rule_id: LOGFALL.SHARPSHOOT.V2
+    default_severity: warn
+    primary_signals:
+      - post_hoc_cluster_selection
+      - missing_preregistration
+      - multiverse_selection_risk
+    required_counter_tests:
+      - CTEST.PREREG/MTP.V2
+    default_repairs:
+      - criteria_pre_registration
+      - multiple_testing_disclosure
+    promotion_effect: statistical_claim_requires_mtp_or_exploratory_label
+
+  - rule_id: LOGFALL.LOADED.V1
+    default_severity: block
+    primary_signals:
+      - wh_question_with_unproven_presupposition
+    required_counter_tests:
+      - CTEST.PRESUP.EXPOSE.V1
+    default_repairs:
+      - presupposition_extraction
+      - neutral_question_rewrite
+    promotion_effect: loaded_question_cannot_be_used_as_evidence_or_challenge_until_rewritten
+
+  - rule_id: LOGFALL.BURDEN.V1
+    default_severity: block
+    primary_signals:
+      - prove_me_wrong_pattern
+      - claim_without_initial_evidence
+    required_counter_tests:
+      - CTEST.BURDEN.REASSIGN.V1
+    default_repairs:
+      - burden_reassignment
+      - backing_required
+    promotion_effect: claimant_must_supply_minimum_backing
+
+  - rule_id: LOGFALL.EQUIV.V1
+    default_severity: warn
+    primary_signals:
+      - lexical_sense_switch
+      - term_scope_shift
+    required_counter_tests:
+      - CTEST.TERMS.LOCK.V1
+    default_repairs:
+      - term_lock
+      - definition_table
+    promotion_effect: ambiguous_term_must_be_locked_for_formal_decision_use
+
+  - rule_id: LOGFALL.MOTTEBAILEY.V1
+    default_severity: warn
+    primary_signals:
+      - pressure_dependent_claim_switching
+      - weak_truism_to_strong_claim_alternation
+    required_counter_tests:
+      - CTEST.CRITERIA.PRE-REGISTER.V1
+    default_repairs:
+      - claim_split
+      - criteria_pre_registration
+    promotion_effect: defended_claim_must_be_frozen_before_rebuttal_or_promotion
+
+  - rule_id: COGBIAS.ANCHORING.V2
+    default_severity: info
+    primary_signals:
+      - low_estimate_elasticity_to_counter_anchor
+    required_counter_tests:
+      - CTEST.COUNTER-ANCHOR.V1
+    default_repairs:
+      - counter_anchor_prompt
+      - confidence_widening
+    projection_policy: self_private_by_default
+
+  - rule_id: COGBIAS.CONFIRM.V1
+    default_severity: warn
+    primary_signals:
+      - support_to_disconfirm_ratio_above_threshold
+      - disconfirming_evidence_ignored
+    required_counter_tests:
+      - CTEST.DEVIL-S.LIST.V1
+    default_repairs:
+      - counterexample_request
+      - disconfirming_source_request
+    projection_policy: self_private_by_default
+
+  - rule_id: COGBIAS.OVERCONF.V1
+    default_severity: info
+    primary_signals:
+      - narrow_ci
+      - calibration_miss
+      - overprecise_language
+    required_counter_tests:
+      - CTEST.CALIBRATION-20Q.V1
+    default_repairs:
+      - confidence_widening
+      - calibration_prompt
+    projection_policy: self_private_by_default
+
+  - rule_id: COGBIAS.REACTDEV.V1
+    default_severity: warn
+    primary_signals:
+      - source_label_devaluation
+      - attribution_sensitive_judgment_shift
+    required_counter_tests:
+      - CTEST.ATTRIBUTION-BLIND.A/B.V1
+    default_repairs:
+      - source_content_separation
+      - attribution_blind_review
+    projection_policy: self_private_by_default
+
+technical_claim_detectors:
+  - rule_id: TECHCLAIM.UNREPRODUCIBLE.V1
+    default_severity: warn
+    required_counter_tests: [TTEST.REPRODUCE.RUN.V1]
+    default_repairs: [replay_artifact_request]
+  - rule_id: TECHCLAIM.BENCH_CHERRYPICK.V1
+    default_severity: warn
+    required_counter_tests: [TTEST.BENCH.BASELINE.V1]
+    default_repairs: [baseline_request, workload_specification]
+  - rule_id: TECHCLAIM.NO_FAILING_TEST.V1
+    default_severity: warn
+    required_counter_tests: [TTEST.FAILING.TEST.REQUIRED.V1]
+    default_repairs: [failing_test_request]
+  - rule_id: TECHCLAIM.NO_THREAT_MODEL.V1
+    default_severity: warn
+    required_counter_tests: [TTEST.THREAT.MODEL.MINIMUM.V1]
+    default_repairs: [threat_model_request]
+
+small_n_policy:
+  n_ge_30: central_metrics_allowed_with_ci
+  n_gt_10_lt_30: limited_evidence_partial_pooling_required
+  n_lte_10: enumerate_examples_no_generalization

--- a/standards/epistemic-governance/migration-ledger.md
+++ b/standards/epistemic-governance/migration-ledger.md
@@ -1,0 +1,95 @@
+# Epistemic Governance migration and provenance ledger
+
+Status: draft v0.2.1  
+Owner: SocioSphere  
+Scope: lineage from Debater 2.0 / Argument Hygiene artifacts into Epistemic Governance Standard
+
+## Purpose
+
+This ledger prevents artifact drift. It records how the prior Debater 2.0 design, argument-hygiene layer, Ruleset v1.3.0 material, and v0.2/v0.2.1 synthesis map into the SocioSphere estate.
+
+The governing migration rule is:
+
+```text
+Debater 2.0 is the reference application.
+Epistemic Governance is the cross-platform standard.
+```
+
+## Source artifacts
+
+| Source | Status | Role |
+|---|---|---|
+| Debater 2.0 - Evidence-Grounded Debate and Argument Hygiene Specification | prior canonical artifact | reference application and first full architecture snapshot |
+| Debater_2_0_Argument_Hygiene_Specification.pdf | immutable snapshot | portable review artifact |
+| Ruleset v1.3.0 argument hygiene material | upgrade ledger | detector/counter-test/measurement layer |
+| Epistemic Governance Standard v0.2 synthesis | scope promotion | elevates the work from Debater app to estate standard |
+| Epistemic Governance Standard v0.2.1 addendum | implementation hardening | adds authority, tenancy, promotion, appeal, privacy, package, and MVS controls |
+
+## Migration table
+
+| Source concept | v0.2.1 destination | Status | Notes |
+|---|---|---|---|
+| DebaterBot critique | Reference application rationale | kept | Historical negative-control case |
+| Event-driven Debater 2.0 pipeline | Protocol topic catalog + MVS reference flow | kept and generalized | No longer debate-only |
+| Ingress and consent gateway | Identity/consent requirements | kept | Must support tenant and profile projection boundaries |
+| Moderation and safety | Policy intervention surface | expanded | Split from epistemic detector findings |
+| Argument mining | Claim lifecycle and claim event model | expanded | Adds decision/action separation |
+| Discourse graph | Claim/contradiction/repair graph | expanded | Adds contradiction ledger and repair states |
+| Evidence retrieval | Evidence authority policy | expanded | Adds source class, jurisdiction, freshness, quote exactness |
+| Verification | Promotion gates | expanded | Verification is necessary but not sufficient for canonization |
+| Counterargument generation | Reference application generation | narrowed | Generation is downstream of governance gates |
+| Rationale explainer | User-visible explanation and repair path | expanded | Must avoid hidden chain-of-thought logging |
+| Audit ledger | Audit append + replay manifest | kept | Requires canonical hashing/signature rules in later schema pack |
+| LOGFALL detector library | Detector map | kept | Detector outputs are hypotheses, not accusations |
+| COGBIAS profiler library | Reasoning Calibration Projection | renamed | Bias Passport demoted from user-facing term |
+| CTEST counter-tests | Counter-test catalog | kept | Required for warn/block findings unless waived under policy |
+| Bias Passport | Reasoning Calibration Projection | renamed and constrained | Self-owned, consent-scoped, low-N guarded |
+| MQI | Measurement quality gate | kept | Required for metrics and profiles |
+| Drift monitor | Drift and policy-freeze topic | kept | Threshold changes require signed update and backtest |
+| Small-N discipline | Small-N policy | kept | N<=10 enumerates examples and forbids generalization |
+| Debater UI frames | Reference app UI frames | moved | Not owned by SocioSphere implementation |
+| JSON Schemas | Future schema pack | pending | To be created in next implementation turn |
+| AsyncAPI/OpenAPI | Protocol and API specs | pending | Topic catalog seeded here; full specs later |
+| Agent execution | AgentPlane bundle ownership | expanded | Detector/counter-test runs must be replayable bundles |
+| Local-first state | SourceOS lane mapping | expanded | Discourse events map to SourceOS lanes |
+| Delivery metrics | DeliveryExcellence metrics | expanded | KPIs and dashboards external to SocioSphere |
+
+## Version policy
+
+The migration policy is conservative:
+
+- `v0.1` remains the reference application snapshot.
+- `v0.2` defines the cross-platform standard shape.
+- `v0.2.1` defines implementation-hardening requirements.
+- Future `v0.3` should not remove `v0.1` lineage; it should add schema compatibility and replay guidance.
+
+## Required future migration fields
+
+Machine-readable migration rows should eventually include:
+
+```yaml
+source_section: string
+source_version: string
+source_artifact: string
+destination_section: string
+destination_repo: string
+status: kept | renamed | expanded | superseded | moved | deleted
+rationale: string
+implementation_priority: P0 | P1 | P2 | P3
+```
+
+## Chain-of-custody requirements
+
+Every future revision should preserve:
+
+- source artifact ID or link;
+- revision date;
+- author or acting agent;
+- section-level migration status;
+- compatibility impact;
+- affected repos;
+- audit or PR reference.
+
+## Immediate estate target
+
+This ledger is registered in SocioSphere because SocioSphere owns cross-repo standards and canonical ownership maps. Downstream implementation PRs must cite this ledger when creating Policy Fabric contracts, AgentPlane bundles, SourceOS event schemas, HolographMe projection schemas, or DeliveryExcellence metrics.

--- a/standards/epistemic-governance/promotion-law.md
+++ b/standards/epistemic-governance/promotion-law.md
@@ -1,0 +1,213 @@
+# Epistemic promotion, reversal, decision, and authority law
+
+Status: draft v0.2.1  
+Owner: SocioSphere  
+Scope: cross-repo claim promotion, reversal, decision authorization, action authorization, authority, and appeal requirements
+
+## 1. Promotion principle
+
+No epistemic claim may be promoted by prose alone.
+
+Promotion requires:
+
+- stable claim ID;
+- prior lifecycle state;
+- target lifecycle state;
+- claim type;
+- claim boundary and non-claims;
+- required gates;
+- passed gate records;
+- evidence IDs and artifact digests;
+- policy version;
+- promotion authority;
+- audit record;
+- replay manifest where executable evidence exists.
+
+This mirrors SocioSphere proof-apparatus discipline for discourse, governance, policy, operational, and institutional claims.
+
+## 2. Promotion record
+
+A promotion record must include:
+
+```json
+{
+  "promotion_id": "prom_<ULID>",
+  "claim_id": "clm_<ULID>",
+  "claim_type": "operational",
+  "from_state": "accepted_for_context",
+  "to_state": "canonized",
+  "promotion_authority": "authority:<id>",
+  "required_gates": ["gate:<id>"],
+  "passed_gates": ["gate_result:<id>"],
+  "evidence_ids": ["ev_<ULID>"],
+  "claim_boundary": "bounded scope of what is promoted",
+  "non_claims": ["what this promotion does not prove"],
+  "policy_version": "epigov.policy.0.1",
+  "ruleset_semver": "1.3.0",
+  "ruleset_hash": "sha256:<hex>",
+  "model_hashes": ["sha256:<hex>"],
+  "audit_id": "aud_<ULID>",
+  "timestamp": "2026-05-12T00:00:00Z"
+}
+```
+
+## 3. Authority model
+
+Every material operation must be governed by role and attribute policy.
+
+Initial authority actions:
+
+```text
+create_claim
+challenge_claim
+run_detector
+clear_detector
+confirm_detector
+override_detector
+request_counter_test
+waive_counter_test
+attach_evidence
+classify_evidence
+promote_claim
+reverse_claim
+create_decision
+authorize_action
+execute_action
+rollback_action
+view_sensitive_event
+export_manifest
+change_policy_threshold
+approve_ruleset_update
+view_reasoning_calibration_projection
+appeal_profile_update
+```
+
+## 4. RBAC / ABAC matrix
+
+| Action | Minimum authority | Notes |
+|---|---|---|
+| `create_claim` | participant, agent, service | must preserve speaker/agent context |
+| `challenge_claim` | participant, reviewer, detector, policy engine | challenge does not prove defect |
+| `run_detector` | detector service, authorized reviewer | must record ruleset hash |
+| `override_detector` | reviewer or governance authority | requires rationale and audit |
+| `waive_counter_test` | governance authority | requires controlled exception |
+| `attach_evidence` | participant, agent, retrieval service | evidence authority required |
+| `classify_evidence` | evidence authority service or reviewer | must record source class |
+| `promote_claim` | promotion authority | cannot be automated without policy grant |
+| `reverse_claim` | reversal authority | must preserve prior state and rationale |
+| `create_decision` | decision authority | must cite claims and value premises |
+| `authorize_action` | action authority | must cite decision record |
+| `change_policy_threshold` | policy authority quorum | requires backtest and signed update |
+| `view_reasoning_calibration_projection` | profile owner or consented viewer | scope-limited |
+| `export_manifest` | export authority | must apply privacy tiers and redactions |
+
+## 5. Claim, decision, and action law
+
+Claims do not authorize actions directly.
+
+A valid governance sequence is:
+
+```text
+Claim(s) -> DecisionRecord -> ActionRecord
+```
+
+A decision must cite:
+
+- claims used;
+- claims rejected or unresolved;
+- evidence summary;
+- value premises;
+- policy refs;
+- decision authority;
+- jurisdiction/scope;
+- uncertainty;
+- appeal path.
+
+An action must cite:
+
+- authorizing decision;
+- action authority;
+- execution subject;
+- expected effect;
+- rollback path, if applicable;
+- evidence emitted after execution.
+
+## 6. Reversal law
+
+A canonized claim can be reversed only through a reversal record.
+
+Reversal causes include:
+
+```text
+contradictory evidence
+failed replay
+invalid evidence authority
+policy change
+successful appeal
+fraud or tampering
+scope error
+model/ruleset defect
+```
+
+A reversal record must include:
+
+- reversed claim ID;
+- prior state;
+- new state;
+- reversal cause;
+- authority;
+- evidence or failed gate;
+- downstream affected decisions/actions;
+- notification requirements;
+- audit ID.
+
+## 7. Contradiction handling
+
+Contradictions must become ledger objects, not silent overwrites.
+
+Outcomes:
+
+```text
+coexist_with_scope
+supersede
+reverse
+split_claim
+bounded_uncertainty
+escalate_to_review
+```
+
+If two canonized claims conflict, the system must create a `contradiction.record.v1` event and prevent unreviewed promotion of dependent claims.
+
+## 8. Appeal requirement
+
+Promotion, reversal, detector confirmation, evidence rejection, decision authorization, action authorization, and profile projection updates must be appealable unless law or safety policy explicitly forbids it.
+
+Appeal outcomes:
+
+```text
+upheld
+partially_upheld
+denied
+requires_more_evidence
+policy_exception_granted
+detector_bug_confirmed
+profile_update_reversed
+claim_state_changed
+decision_changed
+action_reversed
+```
+
+## 9. Release gate for this standard
+
+An implementation is not release-ready unless it can prove:
+
+- schemas validate;
+- fixtures pass;
+- negative tests fail for expected reasons;
+- audit replay works;
+- SourceOS lane mapping exists where local-first state is used;
+- AgentPlane replay bundle exists where executable detector/counter-test runs are used;
+- Policy Fabric contracts validate where policy gates are enforced;
+- privacy tiers are enforced;
+- appeal path exists;
+- migration compatibility is documented.


### PR DESCRIPTION
## Summary

Adds the SocioSphere anchor for the Epistemic Governance Standard v0.2.1 and registers the cross-repo ownership map for downstream implementation.

This PR is intentionally contract/documentation-only. It keeps SocioSphere within its workspace-controller boundary while making the standard visible to the estate.

## What changed

- Added `standards/epistemic-governance/README.md` as the standard anchor.
- Added `claim-lifecycle.md` defining claim, decision, action, contradiction, appeal, repair, detector-finding, and privacy-tier lifecycle semantics.
- Added `promotion-law.md` defining promotion, reversal, authority, claim/decision/action separation, and release gates.
- Added `detector-countertest-map.yaml` with initial LOGFALL/COGBIAS/TECHCLAIM bindings, required counter-tests, default repairs, and small-N policy.
- Added `migration-ledger.md` mapping Debater 2.0 / Argument Hygiene / Ruleset v1.3.0 into Epistemic Governance v0.2.1.
- Added `protocol/epistemic-governance/v1/topic-catalog.v1.yaml` aligned with the QES event/topic discipline.
- Added `protocol/epistemic-governance/v1/runspec.v1.yaml` for deterministic detector, counter-test, replay, backtest, and MVS-1 smoke runs.
- Added `registry/epistemic-governance.yaml` as the estate ownership map.
- Updated `governance/CANONICAL_SOURCES.yaml` with Epistemic Governance namespaces.
- Updated `docs/INTEGRATION_STATUS.md` with the current integration status and downstream targets.

## Estate placement

- `sociosphere`: standard, protocol surface, migration ledger, ownership map.
- `ProCybernetica`: doctrine and epistemic control law.
- `policy-fabric`: intervention/profile/retention/drift/promotion policy as code.
- `agentplane`: executable detector/counter-test/replay bundles.
- `sourceos-syncd`: local-first discourse events and SourceOS lane mapping.
- `HolographMe` / `human-digital-twin`: self-owned Reasoning Calibration Projections.
- `delivery-excellence`: epistemic governance metrics and release-readiness signals.
- `ontogenesis`: claim/evidence/detector/counter-test ontology.

## Validation

Not run locally through CI in this connector session. Changes are documentation, YAML registry/catalog files, and protocol skeletons. CI should exercise SocioSphere's existing workspace/topology checks on PR.

## Follow-up work

1. Create downstream issues/PRs in Policy Fabric, AgentPlane, SourceOS, HolographMe, DeliveryExcellence, ProCybernetica, and Ontogenesis.
2. Generate JSON Schemas for the event contracts and MVS-1 smoke path.
3. Add valid/invalid fixtures and a stdlib-first validator.
4. Wire the first AgentPlane replay bundle and SourceOS event-store example.