### PR TITLE
Bind authority dependency graph to Tier 2 invariants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ ui-dev: ui-preflight
 # --- end ui-workbench targets ---
 
 # --- standards validation targets ---
-.PHONY: validate validate-standards agent-reliability-governance-queue-validate multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate superconscious-reasoning-validate
+.PHONY: validate validate-standards agent-reliability-governance-queue-validate multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate superconscious-reasoning-validate sociosphere-authority-dependency-graph-tier2-binding-ci
 
-validate: validate-standards agent-reliability-governance-queue-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate superconscious-reasoning-validate
+validate: validate-standards agent-reliability-governance-queue-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate superconscious-reasoning-validate sociosphere-authority-dependency-graph-tier2-binding-ci
 	@echo "OK: validate"
 
 validate-standards:
@@ -90,6 +90,13 @@ lattice-environment-fingerprints-validate:
 
 superconscious-reasoning-validate:
 	python3 tools/validate_superconscious_reasoning.py tests/fixtures/superconscious/deterministic >/dev/null
+
+sociosphere-authority-dependency-graph-tier2-binding-ci:
+	python3 -m json.tool schemas/composition/sociosphere-authority-dependency-graph-tier2-binding.v1.json >/dev/null
+	python3 -m json.tool tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.synthetic.json >/dev/null
+	python3 -m json.tool tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.runtime-field.invalid.synthetic.json >/dev/null
+	python3 tools/check_sociosphere_authority_dependency_tier2_binding.py tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.synthetic.json
+	! python3 tools/check_sociosphere_authority_dependency_tier2_binding.py tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.runtime-field.invalid.synthetic.json
 
 multidomain-geospatial-standards-compliance-validate:
 	python3 tools/check_multidomain_geospatial_standards_compliance.py

--- a/schemas/composition/sociosphere-authority-dependency-graph-tier2-binding.v1.json
+++ b/schemas/composition/sociosphere-authority-dependency-graph-tier2-binding.v1.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/composition/sociosphere-authority-dependency-graph-tier2-binding.v1.json",
+  "title": "SocioSphere Authority Dependency Graph — Tier 2 Invariant Binding",
+  "description": "Doctrine-only schema binding SocioSphere authority-dependency graph compositions to ProCybernetica Tier 2 invariant declared modes. Opaque hashes only; no runtime authority resolution, cancellation propagation, estate-topology verification, chain traversal, or cross-plane attestation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "composition_id",
+    "composition_kind",
+    "binding_doctrine_version",
+    "authority_dependency_refs",
+    "control_effect_refs",
+    "cancellation_binding_refs",
+    "plane_owner_refs",
+    "bound_modes",
+    "non_claims"
+  ],
+  "properties": {
+    "composition_id": {"const": "sociosphere.authority_dependency_graph"},
+    "composition_kind": {"const": "estate_authority_dependency_graph_composition"},
+    "binding_doctrine_version": {
+      "type": "string",
+      "pattern": "^v[0-9]+\\.[0-9]+$",
+      "description": "Doctrine version under which this binding is declared. Pins the binding to a specific Tier 2 invariant binding revision."
+    },
+    "authority_dependency_refs": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/graph_ref"}},
+    "control_effect_refs": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/graph_ref"}},
+    "cancellation_binding_refs": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/graph_ref"}},
+    "plane_owner_refs": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/plane_owner_ref"}},
+    "bound_modes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "receipt_integration",
+        "authority_scope_analysis",
+        "non_claim_analysis",
+        "monitor_independence_analysis",
+        "evidence_freshness_analysis"
+      ],
+      "properties": {
+        "receipt_integration": {"const": "hash_bound_reference"},
+        "authority_scope_analysis": {"const": "declared_scope_lattice_v1"},
+        "non_claim_analysis": {"const": "explicit_propagate_or_resolve_v1"},
+        "monitor_independence_analysis": {"const": "declared_monitor_independence_v1"},
+        "evidence_freshness_analysis": {"const": "declared_evidence_freshness_v1"}
+      }
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 10,
+      "maxItems": 10,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "no_runtime_receipt_lookup",
+          "no_runtime_non_claim_verification",
+          "no_runtime_monitor_attestation",
+          "no_timestamp_authenticity",
+          "opaque_hashes_not_resolved",
+          "no_runtime_authority_resolution",
+          "no_runtime_cancellation_propagation",
+          "no_estate_topology_verification",
+          "no_authority_chain_traversal",
+          "no_cross_plane_runtime_attestation"
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "graph_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ref_kind", "ref_id", "opaque_hash"],
+      "properties": {
+        "ref_kind": {
+          "type": "string",
+          "enum": ["authority_dependency", "control_effect", "cancellation_binding"]
+        },
+        "ref_id": {"type": "string"},
+        "opaque_hash": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "Opaque content-addressed reference. This binding schema does not resolve the hash at validation time."
+        }
+      }
+    },
+    "plane_owner_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["plane_id", "owner_repo", "opaque_hash"],
+      "properties": {
+        "plane_id": {
+          "type": "string",
+          "enum": [
+            "superconscious",
+            "procybernetica",
+            "sociosphere",
+            "policy-fabric",
+            "agentplane",
+            "sourceos-syncd",
+            "model-governance-ledger",
+            "prophet-platform",
+            "other"
+          ]
+        },
+        "owner_repo": {"type": "string"},
+        "opaque_hash": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "Opaque content-addressed reference for declared plane ownership. This binding schema does not verify ownership at validation time."
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.runtime-field.invalid.synthetic.json
+++ b/tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.runtime-field.invalid.synthetic.json
@@ -1,0 +1,58 @@
+{
+  "composition_id": "sociosphere.authority_dependency_graph",
+  "composition_kind": "estate_authority_dependency_graph_composition",
+  "binding_doctrine_version": "v0.1",
+  "authority_dependency_refs": [
+    {
+      "ref_kind": "authority_dependency",
+      "ref_id": "authority.superconscious-to-policy-fabric",
+      "opaque_hash": "sha256:b123456789abcdefb123456789abcdefb123456789abcdefb123456789abcdef"
+    }
+  ],
+  "control_effect_refs": [
+    {
+      "ref_kind": "control_effect",
+      "ref_id": "control.cancellation-governs-agent-action",
+      "opaque_hash": "sha256:d3456789abcdef12d3456789abcdef12d3456789abcdef12d3456789abcdef12"
+    }
+  ],
+  "cancellation_binding_refs": [
+    {
+      "ref_kind": "cancellation_binding",
+      "ref_id": "cancel.policy-fabric-agentplane-demo",
+      "opaque_hash": "sha256:e456789abcdef123e456789abcdef123e456789abcdef123e456789abcdef123"
+    }
+  ],
+  "plane_owner_refs": [
+    {
+      "plane_id": "superconscious",
+      "owner_repo": "SocioProphet/superconscious",
+      "opaque_hash": "sha256:f56789abcdef1234f56789abcdef1234f56789abcdef1234f56789abcdef1234"
+    },
+    {
+      "plane_id": "policy-fabric",
+      "owner_repo": "SocioProphet/policy-fabric",
+      "opaque_hash": "sha256:a6789abcdef12345a6789abcdef12345a6789abcdef12345a6789abcdef12345"
+    }
+  ],
+  "bound_modes": {
+    "receipt_integration": "hash_bound_reference",
+    "authority_scope_analysis": "declared_scope_lattice_v1",
+    "non_claim_analysis": "explicit_propagate_or_resolve_v1",
+    "monitor_independence_analysis": "declared_monitor_independence_v1",
+    "evidence_freshness_analysis": "declared_evidence_freshness_v1"
+  },
+  "non_claims": [
+    "no_runtime_receipt_lookup",
+    "no_runtime_non_claim_verification",
+    "no_runtime_monitor_attestation",
+    "no_timestamp_authenticity",
+    "opaque_hashes_not_resolved",
+    "no_runtime_authority_resolution",
+    "no_runtime_cancellation_propagation",
+    "no_estate_topology_verification",
+    "no_authority_chain_traversal",
+    "no_cross_plane_runtime_attestation"
+  ],
+  "runtime_authority_resolution": true
+}

--- a/tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.synthetic.json
+++ b/tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.synthetic.json
@@ -1,0 +1,67 @@
+{
+  "composition_id": "sociosphere.authority_dependency_graph",
+  "composition_kind": "estate_authority_dependency_graph_composition",
+  "binding_doctrine_version": "v0.1",
+  "authority_dependency_refs": [
+    {
+      "ref_kind": "authority_dependency",
+      "ref_id": "authority.superconscious-to-policy-fabric",
+      "opaque_hash": "sha256:b123456789abcdefb123456789abcdefb123456789abcdefb123456789abcdef"
+    },
+    {
+      "ref_kind": "authority_dependency",
+      "ref_id": "authority.policy-fabric-to-agentplane",
+      "opaque_hash": "sha256:c23456789abcdef1c23456789abcdef1c23456789abcdef1c23456789abcdef1"
+    }
+  ],
+  "control_effect_refs": [
+    {
+      "ref_kind": "control_effect",
+      "ref_id": "control.cancellation-governs-agent-action",
+      "opaque_hash": "sha256:d3456789abcdef12d3456789abcdef12d3456789abcdef12d3456789abcdef12"
+    }
+  ],
+  "cancellation_binding_refs": [
+    {
+      "ref_kind": "cancellation_binding",
+      "ref_id": "cancel.policy-fabric-agentplane-demo",
+      "opaque_hash": "sha256:e456789abcdef123e456789abcdef123e456789abcdef123e456789abcdef123"
+    }
+  ],
+  "plane_owner_refs": [
+    {
+      "plane_id": "superconscious",
+      "owner_repo": "SocioProphet/superconscious",
+      "opaque_hash": "sha256:f56789abcdef1234f56789abcdef1234f56789abcdef1234f56789abcdef1234"
+    },
+    {
+      "plane_id": "policy-fabric",
+      "owner_repo": "SocioProphet/policy-fabric",
+      "opaque_hash": "sha256:a6789abcdef12345a6789abcdef12345a6789abcdef12345a6789abcdef12345"
+    },
+    {
+      "plane_id": "agentplane",
+      "owner_repo": "SocioProphet/agentplane",
+      "opaque_hash": "sha256:b789abcdef123456b789abcdef123456b789abcdef123456b789abcdef123456"
+    }
+  ],
+  "bound_modes": {
+    "receipt_integration": "hash_bound_reference",
+    "authority_scope_analysis": "declared_scope_lattice_v1",
+    "non_claim_analysis": "explicit_propagate_or_resolve_v1",
+    "monitor_independence_analysis": "declared_monitor_independence_v1",
+    "evidence_freshness_analysis": "declared_evidence_freshness_v1"
+  },
+  "non_claims": [
+    "no_runtime_receipt_lookup",
+    "no_runtime_non_claim_verification",
+    "no_runtime_monitor_attestation",
+    "no_timestamp_authenticity",
+    "opaque_hashes_not_resolved",
+    "no_runtime_authority_resolution",
+    "no_runtime_cancellation_propagation",
+    "no_estate_topology_verification",
+    "no_authority_chain_traversal",
+    "no_cross_plane_runtime_attestation"
+  ]
+}

--- a/tools/check_sociosphere_authority_dependency_tier2_binding.py
+++ b/tools/check_sociosphere_authority_dependency_tier2_binding.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_NON_CLAIMS = {
+    "no_runtime_receipt_lookup",
+    "no_runtime_non_claim_verification",
+    "no_runtime_monitor_attestation",
+    "no_timestamp_authenticity",
+    "opaque_hashes_not_resolved",
+    "no_runtime_authority_resolution",
+    "no_runtime_cancellation_propagation",
+    "no_estate_topology_verification",
+    "no_authority_chain_traversal",
+    "no_cross_plane_runtime_attestation",
+}
+
+FORBIDDEN_RUNTIME_OR_FULL_COMPOSITION_FIELDS = {
+    "receipt_integration",
+    "authority_scope_analysis",
+    "non_claim_analysis",
+    "monitor_independence_analysis",
+    "evidence_freshness_analysis",
+    "evidence_receipt_refs",
+    "constituent_authority_chain_refs",
+    "composition_authority_chain_ref",
+    "composition_rule",
+    "composed_authority_scope",
+    "execution_status",
+    "ledger_entry",
+    "runtime_receipt_lookup",
+    "resolved_at",
+    "monitor_attestation_token",
+    "timestamp_authenticity_proof",
+    "runtime_authority_resolution",
+    "runtime_cancellation_propagation",
+    "estate_topology_verification",
+    "authority_chain_traversal",
+    "cross_plane_runtime_attestation",
+    "resolved_authority_edges",
+    "propagated_cancellation_effects",
+    "verified_plane_owners",
+    "traversed_authority_chains",
+}
+
+MULTI_REF_FIELDS = (
+    "authority_dependency_refs",
+    "control_effect_refs",
+    "cancellation_binding_refs",
+    "plane_owner_refs",
+)
+
+
+def _check_hash_ref(ref: dict, label: str) -> tuple[bool, str]:
+    opaque_hash = ref.get("opaque_hash", "")
+    if not opaque_hash.startswith("sha256:"):
+        return False, f"{label}.opaque_hash must use sha256: prefix"
+    return True, ""
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: check_sociosphere_authority_dependency_tier2_binding.py <fixture.json>", file=sys.stderr)
+        return 2
+
+    path = Path(sys.argv[1])
+    data = json.loads(path.read_text(encoding="utf-8"))
+
+    non_claims = set(data.get("non_claims", []))
+    if non_claims != REQUIRED_NON_CLAIMS:
+        missing = sorted(REQUIRED_NON_CLAIMS - non_claims)
+        extra = sorted(non_claims - REQUIRED_NON_CLAIMS)
+        print(
+            f"non_claims must exactly match required SocioSphere doctrine boundary; missing={missing} extra={extra}",
+            file=sys.stderr,
+        )
+        return 1
+
+    forbidden_present = sorted(FORBIDDEN_RUNTIME_OR_FULL_COMPOSITION_FIELDS & set(data))
+    if forbidden_present:
+        print(
+            "SocioSphere authority-dependency Tier 2 binding must remain doctrine-only; forbidden fields present: "
+            + ", ".join(forbidden_present),
+            file=sys.stderr,
+        )
+        return 1
+
+    for field in MULTI_REF_FIELDS:
+        for idx, ref in enumerate(data.get(field, [])):
+            ok, message = _check_hash_ref(ref, f"{field}[{idx}]")
+            if not ok:
+                print(message, file=sys.stderr)
+                return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a strict doctrine-only Tier 2 binding for the SocioSphere authority-dependency graph composition.

This consumes the ProCybernetica Tier 2 invariant family by reference and binds estate-level authority graph composition to the current declared modes.

## Changes

Adds:

- `schemas/composition/sociosphere-authority-dependency-graph-tier2-binding.v1.json`
- `tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.synthetic.json`
- `tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.runtime-field.invalid.synthetic.json`
- `tools/check_sociosphere_authority_dependency_tier2_binding.py`

Updates:

- `Makefile`

## Bound modes

The schema pins exactly these modes:

```text
receipt_integration: hash_bound_reference
authority_scope_analysis: declared_scope_lattice_v1
non_claim_analysis: explicit_propagate_or_resolve_v1
monitor_independence_analysis: declared_monitor_independence_v1
evidence_freshness_analysis: declared_evidence_freshness_v1
```

## SocioSphere-specific boundary

Required non-claims are exact:

```text
no_runtime_receipt_lookup
no_runtime_non_claim_verification
no_runtime_monitor_attestation
no_timestamp_authenticity
opaque_hashes_not_resolved
no_runtime_authority_resolution
no_runtime_cancellation_propagation
no_estate_topology_verification
no_authority_chain_traversal
no_cross_plane_runtime_attestation
```

The invalid fixture intentionally includes `runtime_authority_resolution`. The new checker rejects it while accepting the doctrine-only fixture.

## CI

Adds:

```bash
make sociosphere-authority-dependency-graph-tier2-binding-ci
```

and wires it into:

```bash
make validate
```

## Non-claims

This PR does not add runtime authority resolution, cancellation propagation, estate topology verification, authority-chain traversal, cross-plane runtime attestation, recursive composition, runtime receipt lookup, or full ProCybernetica composition-certificate instantiation.