### PR TITLE
Register lawful-learning lane in SocioSphere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ ui-dev: ui-preflight
 # --- end ui-workbench targets ---
 
 # --- standards validation targets ---
-.PHONY: validate validate-standards agent-reliability-governance-queue-validate multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate superconscious-reasoning-validate sociosphere-authority-dependency-graph-tier2-binding-ci
+.PHONY: validate validate-standards agent-reliability-governance-queue-validate multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate superconscious-reasoning-validate sociosphere-authority-dependency-graph-tier2-binding-ci lawful-learning-phase8-registration-validate
 
-validate: validate-standards agent-reliability-governance-queue-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate superconscious-reasoning-validate sociosphere-authority-dependency-graph-tier2-binding-ci
+validate: validate-standards agent-reliability-governance-queue-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate superconscious-reasoning-validate sociosphere-authority-dependency-graph-tier2-binding-ci lawful-learning-phase8-registration-validate
 	@echo "OK: validate"
 
 validate-standards:
@@ -97,6 +97,10 @@ sociosphere-authority-dependency-graph-tier2-binding-ci:
 	python3 -m json.tool tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.runtime-field.invalid.synthetic.json >/dev/null
 	python3 tools/check_sociosphere_authority_dependency_tier2_binding.py tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.synthetic.json
 	! python3 tools/check_sociosphere_authority_dependency_tier2_binding.py tests/fixtures/composition/sociosphere-authority-dependency-graph-tier2-binding.runtime-field.invalid.synthetic.json
+
+lawful-learning-phase8-registration-validate:
+	python3 -m pip install --user pyyaml >/dev/null
+	python3 tools/validate_lawful_learning_phase8_registration.py
 
 multidomain-geospatial-standards-compliance-validate:
 	python3 tools/check_multidomain_geospatial_standards_compliance.py

--- a/governance/lawful-learning-canonical-sources.yaml
+++ b/governance/lawful-learning-canonical-sources.yaml
@@ -1,0 +1,74 @@
+# Lawful-learning Phase 8 canonical source map
+#
+# Additive canonical-source pack corresponding to governance/CANONICAL_SOURCES.yaml
+# without rewriting the large aggregate canonical source file.
+
+schema_version: "1.0.0"
+status: active
+updated_at: "2026-05-13"
+source_pack_id: lawful-learning.phase8.canonical_sources
+
+namespaces:
+  research/lawful-learning:
+    canonical_repo: superconscious
+    canonical_path: docs/lawful-learning/
+    note: "Lawful-learning doctrine, categorical foundations, governance invariants, repo-local schemas, checker, and fixtures."
+
+  research/lawful-learning/sources:
+    canonical_repo: systems-learning-loops
+    canonical_path: kb/sources/lawful-learning-sources.yaml
+    upstream_repo: superconscious
+    note: "Phase 7 research source registry derived from superconscious lawful-learning Phases 1-6 and ProCybernetica Tier 2 doctrine."
+
+  research/lawful-learning/claims:
+    canonical_repo: systems-learning-loops
+    canonical_path: kb/claims/lawful-learning-claims.yaml
+    upstream_repo: superconscious
+    note: "Phase 7 claim registry preserving M/T/S/E/G boundaries."
+
+  research/lawful-learning/patterns:
+    canonical_repo: systems-learning-loops
+    canonical_path: kb/patterns/lawful-learning-seven-invariants.md
+    upstream_repo: superconscious
+    note: "Pattern synthesis for seven governance invariants plus categorical substrate."
+
+  ontology/lawful-learning:
+    canonical_repo: systems-learning-loops
+    canonical_path: ontology/lawful-learning.ttl
+    upstream_repo: superconscious
+    note: "RDF/Turtle lawful-learning ontology for source, claim, invariant, trust-surface, schema, fixture, and checker relationships."
+
+  standards/lawful-learning-schema-promotion:
+    canonical_repo: sourceos-spec
+    upstream_repo: superconscious
+    state: deferred
+    note: "Future promotion target for stable lawful-learning schemas after checker-backed use and sourceos-spec review. No promotion is claimed by Phase 8."
+
+  execution/lawful-learning-runtime-evidence:
+    canonical_repo: agentplane
+    upstream_repo: superconscious
+    state: deferred
+    note: "Future Phase 9 runtime evidence integration target. No runtime execution or evidence integration is claimed by Phase 8."
+
+binding_refs:
+  lawful_learning_trust_surface:
+    repo: superconscious
+    path: schemas/composition/lawful-learning-trust-surface-tier2-binding.v1.json
+    non_claims:
+      - no_runtime_receipt_lookup
+      - no_runtime_non_claim_verification
+      - no_runtime_monitor_attestation
+      - no_timestamp_authenticity
+      - opaque_hashes_not_resolved
+      - no_runtime_circuit_discovery
+      - no_runtime_ablation_verification
+      - no_tag_promotion_at_composition
+      - no_substrate_verification
+      - no_frontier_claim_promotion
+
+non_claims:
+  - does_not_rewrite_governance_CANONICAL_SOURCES_yaml
+  - does_not_promote_schemas_to_sourceos_spec
+  - does_not_claim_runtime_execution
+  - does_not_claim_runtime_evidence_integration
+  - does_not_change_doctrine_owner

--- a/registry/lawful-learning-dependency-edges.yaml
+++ b/registry/lawful-learning-dependency-edges.yaml
@@ -1,0 +1,51 @@
+# Lawful-learning Phase 8 dependency edges
+#
+# Additive edge pack corresponding to registry/dependency-graph.yaml without
+# rewriting the large aggregate graph file.
+
+schema_version: "1.0.0"
+status: active
+updated_at: "2026-05-13"
+edge_pack_id: lawful-learning.phase8.dependency_edges
+
+edges:
+  - from: superconscious
+    to: sourceos-spec
+    type: schema_promotion_path
+    state: pre_promotion
+    lane: lawful-learning
+    comment: "Lawful-learning repo-local schemas promote to SourceOS-Linux/sourceos-spec only after checker-backed stabilization and sourceos-spec review."
+
+  - from: superconscious
+    to: systems-learning-loops
+    type: research_evidence_reference
+    state: active
+    lane: lawful-learning
+    comment: "Lawful-learning doctrine/checker lane references systems-learning-loops Phase 7 source, claim, pattern, and ontology pack."
+
+  - from: systems-learning-loops
+    to: sociosphere
+    type: estate_registration_reference
+    state: active
+    lane: lawful-learning
+    comment: "The lawful-learning research pack is registered into SocioSphere for estate discovery in Phase 8."
+
+  - from: sociosphere
+    to: superconscious
+    type: doctrine_owner_reference
+    state: active
+    lane: lawful-learning
+    comment: "SocioSphere records superconscious as lawful-learning doctrine/checker owner; it does not replace that ownership."
+
+  - from: superconscious
+    to: agentplane
+    type: future_runtime_evidence_integration
+    state: deferred
+    lane: lawful-learning
+    comment: "Phase 9 runtime evidence integration is deferred; no runtime execution is claimed by Phase 8."
+
+non_claims:
+  - does_not_create_runtime_dependency
+  - does_not_promote_schemas_to_sourceos_spec
+  - does_not_claim_phase9_runtime_integration
+  - does_not_change_dependency_graph_aggregate

--- a/registry/lawful-learning-registration.yaml
+++ b/registry/lawful-learning-registration.yaml
@@ -1,0 +1,73 @@
+# Lawful-learning Phase 8 estate registration
+#
+# This additive registry file records the lawful-learning lane in SocioSphere
+# without rewriting the large aggregate repository ontology file.
+
+schema_version: "1.0.0"
+status: active
+updated_at: "2026-05-13"
+registration_id: lawful-learning.phase8.registration
+
+lane:
+  id: lawful-learning
+  title: "Lawful Learning"
+  owner_repo: SocioProphet/superconscious
+  owner_plane: superconscious
+  role: doctrine-and-checker-lane
+  status: phase8_registered
+
+surfaces:
+  doctrine:
+    repo: SocioProphet/superconscious
+    paths:
+      - docs/lawful-learning/01-framework-substrates-structures-circuits.md
+      - docs/lawful-learning/02-categorical-foundations.md
+      - docs/lawful-learning/03-lawful-learning-invariants.md
+  schemas:
+    repo: SocioProphet/superconscious
+    path: schemas/lawful-learning/
+    promotion_state: repo_local_draft
+    promotion_target: SourceOS-Linux/sourceos-spec
+    promotion_condition: "stabilize after checker-backed use and sourceos-spec review"
+  checker:
+    repo: SocioProphet/superconscious
+    path: scripts/check-lawful-learning.py
+    ci_target: make lawful-learning-ci
+  fixtures:
+    repo: SocioProphet/superconscious
+    path: tests/fixtures/lawful-learning/
+  trust_surface:
+    repo: SocioProphet/superconscious
+    path: examples/TRUST_SURFACE.lawful-learning.yaml
+  tier2_binding:
+    repo: SocioProphet/superconscious
+    path: schemas/composition/lawful-learning-trust-surface-tier2-binding.v1.json
+    bound_modes:
+      receipt_integration: hash_bound_reference
+      authority_scope_analysis: declared_scope_lattice_v1
+      non_claim_analysis: explicit_propagate_or_resolve_v1
+      monitor_independence_analysis: declared_monitor_independence_v1
+      evidence_freshness_analysis: declared_evidence_freshness_v1
+  research_pack:
+    repo: SocioProphet/systems-learning-loops
+    paths:
+      - kb/sources/lawful-learning-sources.yaml
+      - kb/claims/lawful-learning-claims.yaml
+      - kb/patterns/lawful-learning-seven-invariants.md
+      - ontology/lawful-learning.ttl
+    ci_target: make validate-lawful-learning-pack
+
+canonical_relationships:
+  doctrine_owner: SocioProphet/superconscious
+  evidence_pack_owner: SocioProphet/systems-learning-loops
+  registry_owner: SocioProphet/sociosphere
+  future_schema_standard_owner: SourceOS-Linux/sourceos-spec
+  runtime_evidence_owner: SocioProphet/agentplane
+
+non_claims:
+  - does_not_promote_schemas_to_sourceos_spec
+  - does_not_claim_runtime_execution
+  - does_not_claim_runtime_evidence_integration
+  - does_not_claim_tier2_verified_modes
+  - does_not_claim_cross_plane_evidence_resolution
+  - does_not_replace_superconscious_as_doctrine_owner

--- a/tools/validate_lawful_learning_phase8_registration.py
+++ b/tools/validate_lawful_learning_phase8_registration.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+try:
+    import yaml  # type: ignore
+except Exception as exc:  # noqa: BLE001
+    raise SystemExit(f"ERROR: pyyaml required ({exc})")
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRATION = ROOT / "registry" / "lawful-learning-registration.yaml"
+DEPENDENCIES = ROOT / "registry" / "lawful-learning-dependency-edges.yaml"
+CANONICAL = ROOT / "governance" / "lawful-learning-canonical-sources.yaml"
+
+REQUIRED_BOUND_MODES = {
+    "receipt_integration": "hash_bound_reference",
+    "authority_scope_analysis": "declared_scope_lattice_v1",
+    "non_claim_analysis": "explicit_propagate_or_resolve_v1",
+    "monitor_independence_analysis": "declared_monitor_independence_v1",
+    "evidence_freshness_analysis": "declared_evidence_freshness_v1",
+}
+
+REQUIRED_REGISTRATION_NON_CLAIMS = {
+    "does_not_promote_schemas_to_sourceos_spec",
+    "does_not_claim_runtime_execution",
+    "does_not_claim_runtime_evidence_integration",
+    "does_not_claim_tier2_verified_modes",
+    "does_not_claim_cross_plane_evidence_resolution",
+    "does_not_replace_superconscious_as_doctrine_owner",
+}
+
+REQUIRED_DEPENDENCY_EDGES = {
+    ("superconscious", "sourceos-spec", "schema_promotion_path", "pre_promotion"),
+    ("superconscious", "systems-learning-loops", "research_evidence_reference", "active"),
+    ("systems-learning-loops", "sociosphere", "estate_registration_reference", "active"),
+    ("sociosphere", "superconscious", "doctrine_owner_reference", "active"),
+    ("superconscious", "agentplane", "future_runtime_evidence_integration", "deferred"),
+}
+
+REQUIRED_CANONICAL_NAMESPACES = {
+    "research/lawful-learning": "superconscious",
+    "research/lawful-learning/sources": "systems-learning-loops",
+    "research/lawful-learning/claims": "systems-learning-loops",
+    "research/lawful-learning/patterns": "systems-learning-loops",
+    "ontology/lawful-learning": "systems-learning-loops",
+    "standards/lawful-learning-schema-promotion": "sourceos-spec",
+    "execution/lawful-learning-runtime-evidence": "agentplane",
+}
+
+
+def load_yaml(path: Path) -> dict:
+    if not path.exists():
+        raise SystemExit(f"ERROR: missing required file: {path}")
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERROR: expected mapping in {path}")
+    return data
+
+
+def validate_registration() -> None:
+    data = load_yaml(REGISTRATION)
+    lane = data.get("lane", {})
+    if lane.get("id") != "lawful-learning":
+        raise SystemExit("ERROR: registration lane.id must be lawful-learning")
+    if lane.get("owner_repo") != "SocioProphet/superconscious":
+        raise SystemExit("ERROR: lawful-learning doctrine owner must be SocioProphet/superconscious")
+
+    surfaces = data.get("surfaces", {})
+    checker = surfaces.get("checker", {})
+    if checker.get("ci_target") != "make lawful-learning-ci":
+        raise SystemExit("ERROR: checker ci_target must be make lawful-learning-ci")
+
+    schemas = surfaces.get("schemas", {})
+    if schemas.get("promotion_target") != "SourceOS-Linux/sourceos-spec":
+        raise SystemExit("ERROR: schema promotion target must be SourceOS-Linux/sourceos-spec")
+    if schemas.get("promotion_state") != "repo_local_draft":
+        raise SystemExit("ERROR: schema promotion_state must be repo_local_draft")
+
+    binding = surfaces.get("tier2_binding", {})
+    modes = binding.get("bound_modes", {})
+    for key, expected in REQUIRED_BOUND_MODES.items():
+        actual = modes.get(key)
+        if actual != expected:
+            raise SystemExit(f"ERROR: bound mode {key} expected {expected}, got {actual}")
+
+    relationships = data.get("canonical_relationships", {})
+    expected_relationships = {
+        "doctrine_owner": "SocioProphet/superconscious",
+        "evidence_pack_owner": "SocioProphet/systems-learning-loops",
+        "registry_owner": "SocioProphet/sociosphere",
+        "future_schema_standard_owner": "SourceOS-Linux/sourceos-spec",
+        "runtime_evidence_owner": "SocioProphet/agentplane",
+    }
+    for key, expected in expected_relationships.items():
+        if relationships.get(key) != expected:
+            raise SystemExit(f"ERROR: canonical_relationships.{key} expected {expected}, got {relationships.get(key)}")
+
+    missing_non_claims = REQUIRED_REGISTRATION_NON_CLAIMS - set(data.get("non_claims", []))
+    if missing_non_claims:
+        raise SystemExit(f"ERROR: registration missing non-claims: {sorted(missing_non_claims)}")
+
+
+def validate_dependencies() -> None:
+    data = load_yaml(DEPENDENCIES)
+    seen = set()
+    for edge in data.get("edges", []):
+        seen.add((edge.get("from"), edge.get("to"), edge.get("type"), edge.get("state")))
+        if edge.get("lane") != "lawful-learning":
+            raise SystemExit(f"ERROR: dependency edge missing lane lawful-learning: {edge}")
+    missing = REQUIRED_DEPENDENCY_EDGES - seen
+    if missing:
+        raise SystemExit(f"ERROR: missing required dependency edges: {sorted(missing)}")
+
+    non_claims = set(data.get("non_claims", []))
+    for required in [
+        "does_not_create_runtime_dependency",
+        "does_not_promote_schemas_to_sourceos_spec",
+        "does_not_claim_phase9_runtime_integration",
+        "does_not_change_dependency_graph_aggregate",
+    ]:
+        if required not in non_claims:
+            raise SystemExit(f"ERROR: dependency pack missing non-claim {required}")
+
+
+def validate_canonical_sources() -> None:
+    data = load_yaml(CANONICAL)
+    namespaces = data.get("namespaces", {})
+    for namespace, expected_repo in REQUIRED_CANONICAL_NAMESPACES.items():
+        entry = namespaces.get(namespace)
+        if not isinstance(entry, dict):
+            raise SystemExit(f"ERROR: missing canonical namespace {namespace}")
+        if entry.get("canonical_repo") != expected_repo:
+            raise SystemExit(
+                f"ERROR: canonical namespace {namespace} expected repo {expected_repo}, got {entry.get('canonical_repo')}"
+            )
+
+    binding = data.get("binding_refs", {}).get("lawful_learning_trust_surface", {})
+    if binding.get("repo") != "superconscious":
+        raise SystemExit("ERROR: binding_refs.lawful_learning_trust_surface.repo must be superconscious")
+    if "schemas/composition/lawful-learning-trust-surface-tier2-binding.v1.json" != binding.get("path"):
+        raise SystemExit("ERROR: lawful-learning trust-surface binding path mismatch")
+
+    non_claims = set(data.get("non_claims", []))
+    for required in [
+        "does_not_rewrite_governance_CANONICAL_SOURCES_yaml",
+        "does_not_promote_schemas_to_sourceos_spec",
+        "does_not_claim_runtime_execution",
+        "does_not_claim_runtime_evidence_integration",
+        "does_not_change_doctrine_owner",
+    ]:
+        if required not in non_claims:
+            raise SystemExit(f"ERROR: canonical source pack missing non-claim {required}")
+
+
+def main() -> None:
+    validate_registration()
+    validate_dependencies()
+    validate_canonical_sources()
+    print("OK: lawful-learning Phase 8 registration validates")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Lawful-learning Phase 8 estate registration into SocioSphere as additive registration packs rather than rewriting the existing large aggregate registry files.

## Adds

- `registry/lawful-learning-registration.yaml`
- `registry/lawful-learning-dependency-edges.yaml`
- `governance/lawful-learning-canonical-sources.yaml`
- `tools/validate_lawful_learning_phase8_registration.py`

Updates:

- `Makefile`

## What this records

The registration declares:

- `SocioProphet/superconscious` as lawful-learning doctrine/checker owner;
- `SocioProphet/systems-learning-loops` as research pack owner;
- `SocioProphet/sociosphere` as registry owner;
- `SourceOS-Linux/sourceos-spec` as future schema standard promotion target;
- `SocioProphet/agentplane` as future runtime evidence integration owner.

## Validation

Adds:

```bash
make lawful-learning-phase8-registration-validate
```

and wires it into:

```bash
make validate
```

The validator checks registration ownership, required Tier 2 bound modes, dependency edge consistency, canonical source ownership, and explicit non-claims.

## Boundary

This PR does not:

- rewrite `registry/repository-ontology.yaml`;
- rewrite `registry/dependency-graph.yaml`;
- rewrite `governance/CANONICAL_SOURCES.yaml`;
- promote schemas to `sourceos-spec`;
- claim runtime execution;
- claim Phase 9 runtime evidence integration;
- claim Tier 2 verified modes;
- change lawful-learning doctrine ownership away from `superconscious`.

## Next after merge

Lawful-learning Phase 9: runtime evidence integration planning in `agentplane`, or a status consolidation pass before starting Phase 9.