### PR TITLE
Add Identity Prime ER+ conformance lane

### DIFF
--- a/docs/conformance/identity-prime-er-plus-conformance.md
+++ b/docs/conformance/identity-prime-er-plus-conformance.md
@@ -1,0 +1,68 @@
+# Identity Prime ER+ Conformance Lane
+
+Status: v0.1 workspace conformance registration.
+
+This lane binds the merged ER+ reference implementation in `identity-is-prime-reference` to the merged ER+ graph evidence contract in `regis-entity-graph`.
+
+## Purpose
+
+The ER+ conformance lane checks that the estate now has a complete, portable path from executable reference semantics to graph-stored evidence:
+
+1. Identity Is Prime defines and tests intrinsic record path costs.
+2. Identity Is Prime defines and tests intrinsic entity move path costs.
+3. Identity Is Prime defines and tests behavioral delay-coordinate features.
+4. Identity Is Prime defines and tests finite-graph expansion diagnostics.
+5. Identity Is Prime defines and tests neutrality replay certificates.
+6. Regis stores those outputs as proof-carrying graph evidence.
+7. Regis validates ER+ evidence bundles and decision-ledger references.
+
+## Upstream merged anchors
+
+- `SocioProphet/identity-is-prime-reference` PR #4: ER+ intrinsic geometry reference implementation.
+- `SocioProphet/regis-entity-graph` PR #15: ER+ graph evidence contracts.
+
+## Workspace inputs
+
+The focused workspace overlay is `manifest/identity-prime-workspace.toml`.
+
+Required Identity Is Prime artifacts under `components/identity_is_prime_reference`:
+
+- `docs/70_ER_PLUS_INTRINSIC_GEOMETRY.md`
+- `schemas/er_plus/ERPlusConfig.v0.1.json`
+- `src/prime_er/edit_geometry.py`
+- `src/prime_er/entity_geometry.py`
+- `src/prime_er/behavior.py`
+- `src/prime_er/neutrality.py`
+- `tests/test_er_plus_geometry.py`
+
+Required Regis artifacts under `components/regis_entity_graph`:
+
+- `docs/architecture/er-plus-regis-graph-contract.md`
+- `schemas/er_plus/ERPlusEvidenceBundle.v0.1.json`
+- `fixtures/er_plus/er_plus_evidence_bundle.valid.json`
+- `tools/validate_er_plus_evidence_bundle.py`
+
+## Conformance command
+
+From the Sociosphere workspace root after materializing the overlay:
+
+```bash
+python tools/conformance/validate_er_plus_workspace.py
+```
+
+The validator is intentionally dependency-free. It checks file presence and parses the ER+ JSON schema/fixture surfaces. It does not execute the full upstream ER+ algorithm. That remains owned by the reference repo tests.
+
+## Acceptance criteria
+
+- The workspace overlay declares ER+ capabilities for Identity Is Prime and Regis.
+- The materialized Identity Is Prime component exposes ER+ docs, schema, modules, and tests.
+- The materialized Regis component exposes ER+ graph contract docs, schema, fixture, and validator.
+- Regis ER+ evidence bundle fixture parses as JSON.
+- Regis evidence bundle declares `schema_version = regis.er_plus.evidence_bundle.v0.1`.
+- Identity ER+ config declares `schema_version = er_plus.config.v0.1`.
+
+## Non-goals
+
+This lane does not deploy runtime behavior into `prophet-platform/apps/identity-prime`.
+
+This lane does not allow search, Holmes, Sherlock, or agents to write canonical human identity truth directly. They remain evidence, finding, retrieval, or proposal surfaces unless a governed Regis reducer emits a decision-ledger entry.

--- a/manifest/identity-prime-workspace.toml
+++ b/manifest/identity-prime-workspace.toml
@@ -4,8 +4,8 @@
 # the Sociosphere conformance lane introduced by issue #284 and PR #285.
 # The canonical workspace manifest already contains identity-is-prime-reference
 # and regis-entity-graph. This overlay adds the Agent Registry, Holmes,
-# Sherlock Search, and MeshRush materialization requirements without disturbing
-# the broad canonical manifest in this scaffold PR.
+# Sherlock Search, MeshRush, and ER+ materialization requirements without
+# disturbing the broad canonical manifest.
 
 [[repos]]
 name = "agent_registry"
@@ -36,6 +36,10 @@ required_capabilities = [
   "policy_polytope",
   "congruence_lane",
   "proof_artifact",
+  "er_plus_record_geometry",
+  "er_plus_entity_geometry",
+  "er_plus_behavior_features",
+  "er_plus_neutrality_replay",
 ]
 
 [[repos]]
@@ -51,6 +55,10 @@ required_capabilities = [
   "concordance_link",
   "decision_ledger",
   "proof_certificate",
+  "er_plus_graph_contract",
+  "er_plus_evidence_bundle",
+  "er_plus_decision_ledger",
+  "er_plus_validator",
 ]
 
 [[repos]]

--- a/tools/conformance/validate_er_plus_workspace.py
+++ b/tools/conformance/validate_er_plus_workspace.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+IDENTITY = ROOT / "components" / "identity_is_prime_reference"
+REGIS = ROOT / "components" / "regis_entity_graph"
+MANIFEST = ROOT / "manifest" / "identity-prime-workspace.toml"
+
+IDENTITY_REQUIRED = [
+    "docs/70_ER_PLUS_INTRINSIC_GEOMETRY.md",
+    "schemas/er_plus/ERPlusConfig.v0.1.json",
+    "src/prime_er/edit_geometry.py",
+    "src/prime_er/entity_geometry.py",
+    "src/prime_er/behavior.py",
+    "src/prime_er/neutrality.py",
+    "tests/test_er_plus_geometry.py",
+]
+
+REGIS_REQUIRED = [
+    "docs/architecture/er-plus-regis-graph-contract.md",
+    "schemas/er_plus/ERPlusEvidenceBundle.v0.1.json",
+    "fixtures/er_plus/er_plus_evidence_bundle.valid.json",
+    "tools/validate_er_plus_evidence_bundle.py",
+]
+
+IDENTITY_CAPABILITIES = [
+    "er_plus_record_geometry",
+    "er_plus_entity_geometry",
+    "er_plus_behavior_features",
+    "er_plus_neutrality_replay",
+]
+
+REGIS_CAPABILITIES = [
+    "er_plus_graph_contract",
+    "er_plus_evidence_bundle",
+    "er_plus_decision_ledger",
+    "er_plus_validator",
+]
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def require_path(base: Path, rel: str) -> Path:
+    path = base / rel
+    if not path.exists():
+        fail(f"missing required ER+ workspace artifact: {path}")
+    return path
+
+
+def require_manifest_capabilities() -> None:
+    text = MANIFEST.read_text(encoding="utf-8")
+    for capability in IDENTITY_CAPABILITIES + REGIS_CAPABILITIES:
+        if capability not in text:
+            fail(f"workspace overlay missing ER+ capability: {capability}")
+
+
+def load_json(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+    if not isinstance(data, dict):
+        fail(f"top-level JSON must be object: {path}")
+    return data
+
+
+def main() -> None:
+    require_path(ROOT, "manifest/identity-prime-workspace.toml")
+    require_manifest_capabilities()
+
+    for rel in IDENTITY_REQUIRED:
+        require_path(IDENTITY, rel)
+    for rel in REGIS_REQUIRED:
+        require_path(REGIS, rel)
+
+    identity_config = load_json(IDENTITY / "schemas/er_plus/ERPlusConfig.v0.1.json")
+    if identity_config.get("properties", {}).get("schema_version", {}).get("const") != "er_plus.config.v0.1":
+        fail("Identity ER+ config schema_version const mismatch")
+
+    regis_schema = load_json(REGIS / "schemas/er_plus/ERPlusEvidenceBundle.v0.1.json")
+    if regis_schema.get("properties", {}).get("schema_version", {}).get("const") != "regis.er_plus.evidence_bundle.v0.1":
+        fail("Regis ER+ evidence bundle schema_version const mismatch")
+
+    regis_fixture = load_json(REGIS / "fixtures/er_plus/er_plus_evidence_bundle.valid.json")
+    if regis_fixture.get("schema_version") != "regis.er_plus.evidence_bundle.v0.1":
+        fail("Regis ER+ evidence bundle fixture schema_version mismatch")
+
+    certs = regis_fixture.get("certificates", {})
+    for required_family in ("record_paths", "entity_paths", "behavioral_evidence", "local_expansion", "neutrality_replays"):
+        if not certs.get(required_family):
+            fail(f"Regis ER+ fixture missing non-empty certificate family: {required_family}")
+
+    print("OK: Identity Prime ER+ workspace conformance validated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Registers the Sociosphere conformance lane for the merged ER+ work across Identity Is Prime and Regis.

This PR follows the upstream merges:

- `SocioProphet/identity-is-prime-reference` PR #4: ER+ intrinsic geometry reference implementation
- `SocioProphet/regis-entity-graph` PR #15: ER+ graph evidence contracts

## Changes

- Updates `manifest/identity-prime-workspace.toml` with explicit ER+ capabilities for the Identity and Regis components.
- Adds `docs/conformance/identity-prime-er-plus-conformance.md` documenting the lane purpose, required component artifacts, and acceptance criteria.
- Adds `tools/conformance/validate_er_plus_workspace.py`, a dependency-free validator that checks materialized component paths, ER+ schema-version constants, and Regis evidence-bundle fixture families.

## Boundary discipline

This does not deploy runtime behavior into `prophet-platform/apps/identity-prime`.

This also preserves the graph-truth boundary: Holmes, Sherlock, search, and agents may provide findings or retrieval/evidence pointers, but canonical human identity mutation must still flow through governed Regis reducers and decision-ledger entries.

## Validation note

The validator is designed to run after the focused workspace overlay is materialized under `components/`. It intentionally checks cross-repo artifact presence and schema/fixture surfaces rather than re-running the full Identity Is Prime ER+ algorithm.
