### PR TITLE
Add ProCybernetica safety-case registry mapping

### DIFF
--- a/docs/integrations/PROCYBERNETICA_REGISTRY_MAPPING.md
+++ b/docs/integrations/PROCYBERNETICA_REGISTRY_MAPPING.md
@@ -1,0 +1,53 @@
+# ProCybernetica Registry Mapping
+
+Status: v0.1 registry mapping  
+Upstream issue: `SocioProphet/ProCybernetica#28`  
+SocioSphere issue: `SocioProphet/sociosphere#342`  
+Runtime claim: none
+
+## Purpose
+
+This document defines how SocioSphere consumes ProCybernetica cybernetic-governance objects for workspace governance, safety-case registry, and cross-repo promotion mapping.
+
+ProCybernetica owns the public constitutional schemas, fixtures, validators, and conformance vocabulary. SocioSphere owns workspace governance, registry behavior, and cross-repo orchestration.
+
+## Upstream anchors
+
+- `SocioProphet/ProCybernetica#26` — Tier 1 cybernetic-governance schemas.
+- `SocioProphet/ProCybernetica#27` — defensive fixtures and validator.
+- `SocioProphet/ProCybernetica#28` — integration-boundary record.
+
+## Registry rule
+
+SocioSphere registry entries may reference ProCybernetica safety cases, promotion decisions, evidence receipts, privacy/evidence classifications, incidents, release deltas, and authority graph snapshots.
+
+SocioSphere-specific fields must remain adapter metadata around the referenced ProCybernetica object. They must not silently redefine the source object.
+
+## Object mapping
+
+| ProCybernetica object | SocioSphere consumption |
+| --- | --- |
+| `cybernetic_safety_case.v1.json` | Safety-case registry entry. |
+| `promotion_decision.v1.json` | Cross-repo promotion, hold, or quarantine mapping. |
+| `authority_graph_snapshot.v1.json` | Separation-of-powers and authority-concentration view. |
+| `evidence_receipt.v1.json` | Governance-board evidence reference. |
+| `privacy_evidence_classification.v1.json` | Public/private evidence boundary display. |
+| `incident_record.v1.json` | Incident or control-failure triage reference. |
+| `release_delta_report.v1.json` | Release or change governance view. |
+| `authority_chain.v1.json` | Authority path displayed during review. |
+| `agent_action_trace.v1.json` | Action trace reference for governed work. |
+| `tool_permission_scope.v1.json` | Capability or permission boundary reference. |
+
+## Public-synthetic fixture
+
+The initial fixture is:
+
+```text
+registry/procybernetica/safety-case-registry.synthetic.json
+```
+
+It demonstrates a SocioSphere registry entry that points to ProCybernetica safety-case, promotion, evidence, privacy, incident, release-delta, and authority graph objects without importing private evidence or claiming runtime readiness.
+
+## Non-goals
+
+This mapping does not implement registry runtime, production promotion, policy runtime, or downstream runtime changes. It records a public registry contract and fixture surface only.

--- a/registry/procybernetica/safety-case-registry.synthetic.json
+++ b/registry/procybernetica/safety-case-registry.synthetic.json
@@ -1,0 +1,75 @@
+{
+  "fixture_kind": "procybernetica_safety_case_registry_mapping",
+  "fixture_version": "v0.1",
+  "publication_state": "public-synthetic",
+  "upstream_anchor": {
+    "procybernetica_issue": "SocioProphet/ProCybernetica#28",
+    "schema_bundle_issue": "SocioProphet/ProCybernetica#26",
+    "validator_issue": "SocioProphet/ProCybernetica#27"
+  },
+  "registry_entry": {
+    "registry_entry_id": "sociosphere-procybernetica-safety-case-synthetic-001",
+    "workspace_ref": "workspace://synthetic/procybernetica-governance",
+    "registry_owner": "SocioProphet/sociosphere",
+    "runtime_claim": "none",
+    "private_evidence_included": false
+  },
+  "procybernetica_references": [
+    {
+      "object_kind": "cybernetic_safety_case",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/cybernetic_safety_case.v1.json",
+      "object_ref": "safety-case:sociosphere:synthetic:001",
+      "sociosphere_use": "safety-case registry entry"
+    },
+    {
+      "object_kind": "promotion_decision",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/promotion_decision.v1.json",
+      "object_ref": "promotion:sociosphere:synthetic:001",
+      "sociosphere_use": "cross-repo promotion mapping"
+    },
+    {
+      "object_kind": "authority_graph_snapshot",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/authority_graph_snapshot.v1.json",
+      "object_ref": "authority-graph:sociosphere:synthetic:001",
+      "sociosphere_use": "workspace authority and separation-of-powers view"
+    },
+    {
+      "object_kind": "evidence_receipt",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/evidence_receipt.v1.json",
+      "object_ref": "receipt:sociosphere:synthetic:001",
+      "sociosphere_use": "governance-board evidence reference"
+    },
+    {
+      "object_kind": "privacy_evidence_classification",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/privacy_evidence_classification.v1.json",
+      "object_ref": "privacy-classification:sociosphere:synthetic:001",
+      "sociosphere_use": "public/private evidence boundary display"
+    },
+    {
+      "object_kind": "incident_record",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/incident_record.v1.json",
+      "object_ref": "incident:sociosphere:synthetic:001",
+      "sociosphere_use": "incident or control-failure triage reference"
+    },
+    {
+      "object_kind": "release_delta_report",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/release_delta_report.v1.json",
+      "object_ref": "release-delta:sociosphere:synthetic:001",
+      "sociosphere_use": "release or change governance view"
+    }
+  ],
+  "registry_rules": {
+    "do_not_fork_schema_names": true,
+    "sociosphere_registry_ownership_preserved": true,
+    "procybernetica_semantics_preserved": true,
+    "redaction_boundary_required_for_private_evidence": true,
+    "safety_case_is_not_production_readiness_by_default": true
+  },
+  "non_claims": [
+    "This fixture does not represent live workspace governance data.",
+    "This fixture does not claim production readiness.",
+    "This fixture does not implement registry runtime.",
+    "This fixture does not implement policy enforcement.",
+    "This fixture does not redefine ProCybernetica schemas."
+  ]
+}


### PR DESCRIPTION
## Summary

Implements the first concrete downstream tranche for `SocioProphet/sociosphere#342`, created from `SocioProphet/ProCybernetica#28`.

Adds:

- `docs/integrations/PROCYBERNETICA_REGISTRY_MAPPING.md`
- `registry/procybernetica/safety-case-registry.synthetic.json`

## Purpose

Defines how SocioSphere consumes ProCybernetica cybernetic-governance objects for workspace governance, safety-case registry, and cross-repo promotion mapping without forking their constitutional semantics.

## Upstream anchors

- `SocioProphet/ProCybernetica#26` — Tier 1 `schemas/cybernetic-governance/*` schema bundle
- `SocioProphet/ProCybernetica#27` — defensive fixtures and validator
- `SocioProphet/ProCybernetica#28` — integration-boundary record

## Implementation posture

This PR is not only an issue placeholder. It lands the first SocioSphere-side registry mapping artifact and a public-synthetic fixture.

The fixture demonstrates SocioSphere references to ProCybernetica:

- `cybernetic_safety_case.v1.json`
- `promotion_decision.v1.json`
- `authority_graph_snapshot.v1.json`
- `evidence_receipt.v1.json`
- `privacy_evidence_classification.v1.json`
- `incident_record.v1.json`
- `release_delta_report.v1.json`

## Non-claims

- Does not implement registry runtime.
- Does not add production governance data.
- Does not add policy enforcement.
- Does not redefine ProCybernetica schemas.
- Does not claim production readiness.
- Does not include private evidence, secrets, customer data, or live governance records.