### PR TITLE
Replay authority dependency graph v0 on current main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ ui-dev: ui-preflight
 # --- end ui-workbench targets ---
 
 # --- standards validation targets ---
-.PHONY: validate validate-standards agent-reliability-governance-queue-validate multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate superconscious-reasoning-validate sociosphere-authority-dependency-graph-tier2-binding-ci lawful-learning-phase8-registration-validate evidence-fabric-repos-validate evidence-fabric-surface-integrations-validate
+.PHONY: validate validate-standards agent-reliability-governance-queue-validate authority-dependencies-validate multidomain-geospatial-standards-compliance-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate superconscious-reasoning-validate sociosphere-authority-dependency-graph-tier2-binding-ci lawful-learning-phase8-registration-validate evidence-fabric-repos-validate evidence-fabric-surface-integrations-validate
 
-validate: validate-standards agent-reliability-governance-queue-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate superconscious-reasoning-validate sociosphere-authority-dependency-graph-tier2-binding-ci lawful-learning-phase8-registration-validate evidence-fabric-repos-validate evidence-fabric-surface-integrations-validate
+validate: validate-standards agent-reliability-governance-queue-validate authority-dependencies-validate program-dashboard-validate model-fabric-work-register-validate lattice-data-governai-topology-validate lattice-runtime-profile-consumer-parity-validate lattice-demo-readiness-validate lattice-replay-evidence-membrane-validate lattice-runtime-release-readiness-validate lattice-product-readiness-program-validate lattice-operating-model-validate lattice-deployment-topology-validate lattice-security-isolation-model-validate lattice-observability-sre-validate lattice-release-rollback-controls-validate lattice-environment-fingerprints-validate superconscious-reasoning-validate sociosphere-authority-dependency-graph-tier2-binding-ci lawful-learning-phase8-registration-validate evidence-fabric-repos-validate evidence-fabric-surface-integrations-validate
 	@echo "OK: validate"
 
 validate-standards:
@@ -33,6 +33,9 @@ validate-standards:
 
 agent-reliability-governance-queue-validate:
 	python3 tools/validate_agent_reliability_governance_queue.py
+
+authority-dependencies-validate:
+	python3 tools/validate_authority_dependencies.py
 
 program-dashboard-validate:
 	python3 tools/validate_program_dashboard.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 - [UI workbench app README](../apps/ui-workbench/README.md)
 - [Overview](architecture/overview.md)
 - [Governed DevSecOps as the first hypergraph use case](architecture/governed-devsecops-first-usecase.md)
+- [Authority dependency graph](architecture/authority-dependency-graph.md)
 - [Sovereign civic computation estate alignment](architecture/sovereign-civic-computation-alignment.md)
 - [Estate control graph](architecture/estate-control-graph.md)
 - [Runtime, content, and orchestration placement](architecture/runtime-content-placement.md)
@@ -52,6 +53,7 @@
 - **Current workspace behavior**: `../README.md`, `architecture/overview.md`, `SCOPE_PURPOSE_STATUS_BACKLOG.md`
 - **Current proof workspace behavior**: `../manifest/proof-workspace.toml`, `../protocol/proof-apparatus-workspace/v0/README.md`, `architecture/proof-apparatus-workspace-controller.md`
 - **Current governed DevSecOps use case**: `architecture/governed-devsecops-first-usecase.md`
+- **Current authority-dependency graph**: `architecture/authority-dependency-graph.md`
 - **Current integration facts**: `INTEGRATION_STATUS.md`
 - **Archival history only**: `ECOSYSTEM-BRIEF.md`
 

--- a/docs/architecture/authority-dependency-graph.md
+++ b/docs/architecture/authority-dependency-graph.md
@@ -1,0 +1,220 @@
+# Authority Dependency Graph v0
+
+Status: draft v0.1  
+Owner: `SocioProphet/sociosphere`  
+Tracking issue: `SocioProphet/sociosphere#326`  
+Upstream reconciliation: `SocioProphet/ProCybernetica#49`
+
+## Purpose
+
+SocioSphere owns the estate topology and cross-repo control graph. The authority dependency graph is the authority-aware layer of that graph.
+
+It records the specific cybernetic control path:
+
+```text
+source -> authority surface -> control effect -> target -> policy -> evidence -> cancellation / recovery
+```
+
+This is narrower than the general dependency graph. `registry/dependency-graph.yaml` records broad component dependency direction. `registry/authority-dependencies.yaml` records declared authority propagation: who or what may affect another target, under which policy, with which evidence, and with which cancellation semantics.
+
+## Doctrine
+
+The control law is:
+
+```text
+No invisible authority.
+No undeclared control effect.
+No control effect without policy reference.
+No high-risk effect without evidence reference.
+No revocable effect without cancellation binding.
+No recovery without an explicit recovery or prove-clean path where applicable.
+```
+
+The authority dependency graph does not grant authority by itself. It makes declared authority inspectable, validates that references exist in the right ownership plane, and gives downstream systems a stable id for policy, evidence, and state-integrity binding.
+
+## Ownership split
+
+| Concern | Owner |
+| --- | --- |
+| Visible cognition/control loop and trust-surface seed | `SocioProphet/superconscious` |
+| Estate authority-dependency registry and topology | `SocioProphet/sociosphere` |
+| Policy admission, inheritance, cancellation, break-glass | `SocioProphet/policy-fabric` |
+| Execution, run evidence, replay artifacts | `SocioProphet/agentplane` |
+| Local state-integrity, diagnosis, repair, attestation | `SourceOS-Linux/sourceos-syncd` |
+| Public cybernetic doctrine and conformance law | `SocioProphet/ProCybernetica` |
+
+## Contract files
+
+This tranche adds:
+
+```text
+docs/architecture/authority-dependency-graph.md
+registry/authority-dependencies.yaml
+schemas/authority-dependency.schema.json
+examples/authority-dependencies/valid/agentplane-network-door.authority-dependency.json
+examples/authority-dependencies/invalid/prose-only-authority.authority-dependency.json
+tools/validate_authority_dependencies.py
+```
+
+## Object model
+
+An `AuthorityDependency` has these required fields:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Stable graph identifier. |
+| `owner_repo` | Repo accountable for the edge. |
+| `status` | Lifecycle state: `draft`, `active`, `deprecated`, or `blocked`. |
+| `source` | Source repo/component/kind that can initiate the effect. |
+| `target` | Target repo/component/kind that may be affected. |
+| `authority_surface_refs` | Machine-readable refs to trust surfaces or equivalent authority declarations. |
+| `control_effects` | Bounded effect vocabulary. |
+| `policy_refs` | Policy or admission refs that govern the effect. |
+| `evidence_refs` | Evidence contracts that prove use, denial, non-use, or replay posture. |
+| `cancellation_binding_refs` | Policy/state refs that deny, revoke, quarantine, degrade, expire, or recover the effect. |
+| `recovery_refs` | Recovery, repair, attestation, or prove-clean refs. |
+| `related_refs` | Optional upstream issue, PR, ADR, or registry refs. |
+
+## v0 control-effect vocabulary
+
+The first vocabulary is deliberately small:
+
+```text
+read
+write
+execute
+route
+publish
+persist_memory
+promote
+merge
+deploy
+replicate
+quarantine
+revoke
+repair
+model_route
+network_egress
+credential_access
+browser_control
+terminal_control
+host_mutation
+```
+
+The vocabulary is not a permission system. It is a graph classification used to decide which references are mandatory.
+
+## Effect-risk classes
+
+For validation, these effects are high-risk in v0 and require explicit evidence references:
+
+```text
+execute
+route
+publish
+persist_memory
+promote
+merge
+deploy
+replicate
+quarantine
+revoke
+repair
+model_route
+network_egress
+credential_access
+browser_control
+terminal_control
+host_mutation
+```
+
+These effects are revocable in v0 and require cancellation bindings:
+
+```text
+execute
+route
+publish
+persist_memory
+promote
+merge
+deploy
+replicate
+model_route
+network_egress
+credential_access
+browser_control
+terminal_control
+host_mutation
+```
+
+## Registry relationship
+
+`registry/dependency-graph.yaml` remains the general dependency-direction registry.
+
+`registry/authority-dependencies.yaml` is an overlay. It is used when a dependency carries authority, not merely implementation dependency.
+
+For example:
+
+```text
+agentplane -> sourceos-syncd
+```
+
+as a general dependency might mean that AgentPlane consumes a SourceOS evidence contract.
+
+The authority dependency overlay must say more:
+
+```text
+agentplane guarded invocation may request a SourceOS network-door plan
+under a Policy Fabric policy reference
+with AgentPlane evidence
+and SourceOS state-integrity cancellation/recovery semantics.
+```
+
+## Validation expectations
+
+`tools/validate_authority_dependencies.py` is dependency-free. It validates:
+
+1. schema file shape;
+2. registry file shape;
+3. valid fixtures;
+4. invalid fixtures;
+5. required fields;
+6. bounded status vocabulary;
+7. bounded control-effect vocabulary;
+8. high-risk effects have evidence refs;
+9. revocable effects have cancellation bindings;
+10. runtime-bearing or authority-bearing edges have authority-surface refs;
+11. cancellation bindings preserve evidence by requiring at least one evidence ref;
+12. prose-only authority is rejected.
+
+## First fixture
+
+The first valid fixture is intentionally cross-plane:
+
+```text
+AgentPlane guarded invocation
+  -> SourceOS network-door plan
+  -> Policy Fabric sourceos repo-context policy
+  -> AgentPlane NetworkDoorPlanEvidence
+  -> Policy Fabric cancellation binding
+  -> SourceOS state-integrity recovery binding
+```
+
+This is a contract fixture, not a runtime mutation. It does not install a mesh, contact model providers, mutate firewall state, or perform host actions.
+
+## Non-goals
+
+- SocioSphere does not become the policy engine.
+- SocioSphere does not become the execution engine.
+- SocioSphere does not define Superconscious trust-surface semantics.
+- SocioSphere does not define AgentPlane evidence artifact internals.
+- SocioSphere does not define SourceOS local repair mechanics.
+- This tranche does not implement runtime behavior.
+
+## Next tranche
+
+After this contract lands, downstream repos should add their side of the binding:
+
+1. `SocioProphet/superconscious#10`: trust-surface authority-dependency binding.
+2. `SocioProphet/policy-fabric#75`: cancellation binding contract.
+3. `SocioProphet/agentplane#157`: authority-dependency evidence contract.
+4. `SourceOS-Linux/sourceos-syncd#27`: state-integrity binding.

--- a/examples/authority-dependencies/invalid/prose-only-authority.authority-dependency.json
+++ b/examples/authority-dependencies/invalid/prose-only-authority.authority-dependency.json
@@ -1,0 +1,26 @@
+{
+  "id": "prose-only-authority",
+  "owner_repo": "SocioProphet/sociosphere",
+  "status": "draft",
+  "source": {
+    "repo": "SocioProphet/agentplane",
+    "component": "guarded-invocation",
+    "kind": "execution-control-plane"
+  },
+  "target": {
+    "repo": "SourceOS-Linux/sourceos-syncd",
+    "component": "network-door-plan",
+    "kind": "local-control-plane-plan"
+  },
+  "authority_surface_refs": [],
+  "control_effects": [
+    "network_egress"
+  ],
+  "policy_refs": [],
+  "evidence_refs": [],
+  "cancellation_binding_refs": [],
+  "recovery_refs": [],
+  "related_refs": [
+    "This should fail because it tries to rely on prose and omits machine-readable authority, policy, evidence, and cancellation references."
+  ]
+}

--- a/examples/authority-dependencies/valid/agentplane-network-door.authority-dependency.json
+++ b/examples/authority-dependencies/valid/agentplane-network-door.authority-dependency.json
@@ -1,0 +1,44 @@
+{
+  "id": "agentplane-guarded-invocation-to-sourceos-network-door",
+  "owner_repo": "SocioProphet/sociosphere",
+  "status": "draft",
+  "source": {
+    "repo": "SocioProphet/agentplane",
+    "component": "guarded-invocation",
+    "kind": "execution-control-plane"
+  },
+  "target": {
+    "repo": "SourceOS-Linux/sourceos-syncd",
+    "component": "network-door-plan",
+    "kind": "local-control-plane-plan"
+  },
+  "authority_surface_refs": [
+    "SocioProphet/superconscious#TRUST_SURFACE.yaml:agent_orchestrator"
+  ],
+  "control_effects": [
+    "route",
+    "network_egress"
+  ],
+  "policy_refs": [
+    "SocioProphet/policy-fabric#sourceos.repo_context.read_only"
+  ],
+  "evidence_refs": [
+    "SocioProphet/agentplane#NetworkDoorPlanEvidence"
+  ],
+  "cancellation_binding_refs": [
+    "SocioProphet/policy-fabric#75:cancellation-binding-v1",
+    "SourceOS-Linux/sourceos-syncd#27:state-integrity-unsafe"
+  ],
+  "recovery_refs": [
+    "SourceOS-Linux/sourceos-syncd#27:state-integrity-recovery",
+    "SocioProphet/superconscious#10:prove-clean-binding"
+  ],
+  "related_refs": [
+    "SocioProphet/ProCybernetica#49",
+    "SocioProphet/sociosphere#326",
+    "SocioProphet/superconscious#10",
+    "SocioProphet/policy-fabric#75",
+    "SocioProphet/agentplane#157",
+    "SourceOS-Linux/sourceos-syncd#27"
+  ]
+}

--- a/registry/authority-dependencies.yaml
+++ b/registry/authority-dependencies.yaml
@@ -1,0 +1,50 @@
+{
+  "schema_version": "0.1",
+  "kind": "AuthorityDependencyGraph",
+  "authority_dependencies": [
+    {
+      "id": "agentplane-guarded-invocation-to-sourceos-network-door",
+      "owner_repo": "SocioProphet/sociosphere",
+      "status": "draft",
+      "source": {
+        "repo": "SocioProphet/agentplane",
+        "component": "guarded-invocation",
+        "kind": "execution-control-plane"
+      },
+      "target": {
+        "repo": "SourceOS-Linux/sourceos-syncd",
+        "component": "network-door-plan",
+        "kind": "local-control-plane-plan"
+      },
+      "authority_surface_refs": [
+        "SocioProphet/superconscious#TRUST_SURFACE.yaml:agent_orchestrator"
+      ],
+      "control_effects": [
+        "route",
+        "network_egress"
+      ],
+      "policy_refs": [
+        "SocioProphet/policy-fabric#sourceos.repo_context.read_only"
+      ],
+      "evidence_refs": [
+        "SocioProphet/agentplane#NetworkDoorPlanEvidence"
+      ],
+      "cancellation_binding_refs": [
+        "SocioProphet/policy-fabric#75:cancellation-binding-v1",
+        "SourceOS-Linux/sourceos-syncd#27:state-integrity-unsafe"
+      ],
+      "recovery_refs": [
+        "SourceOS-Linux/sourceos-syncd#27:state-integrity-recovery",
+        "SocioProphet/superconscious#10:prove-clean-binding"
+      ],
+      "related_refs": [
+        "SocioProphet/ProCybernetica#49",
+        "SocioProphet/sociosphere#326",
+        "SocioProphet/superconscious#10",
+        "SocioProphet/policy-fabric#75",
+        "SocioProphet/agentplane#157",
+        "SourceOS-Linux/sourceos-syncd#27"
+      ]
+    }
+  ]
+}

--- a/schemas/authority-dependency.schema.json
+++ b/schemas/authority-dependency.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SocioProphet/sociosphere/schemas/authority-dependency.schema.json",
+  "title": "SocioSphere Authority Dependency Graph",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "authority_dependencies"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^0\\.1$"
+    },
+    "kind": {
+      "type": "string",
+      "const": "AuthorityDependencyGraph"
+    },
+    "authority_dependencies": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/authorityDependency"
+      }
+    }
+  },
+  "$defs": {
+    "repoRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repo",
+        "component",
+        "kind"
+      ],
+      "properties": {
+        "repo": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "component": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "authorityDependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "owner_repo",
+        "status",
+        "source",
+        "target",
+        "authority_surface_refs",
+        "control_effects",
+        "policy_refs",
+        "evidence_refs",
+        "cancellation_binding_refs",
+        "recovery_refs"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_.-]*$"
+        },
+        "owner_repo": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "active",
+            "deprecated",
+            "blocked"
+          ]
+        },
+        "source": {
+          "$ref": "#/$defs/repoRef"
+        },
+        "target": {
+          "$ref": "#/$defs/repoRef"
+        },
+        "authority_surface_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "control_effects": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "read",
+              "write",
+              "execute",
+              "route",
+              "publish",
+              "persist_memory",
+              "promote",
+              "merge",
+              "deploy",
+              "replicate",
+              "quarantine",
+              "revoke",
+              "repair",
+              "model_route",
+              "network_egress",
+              "credential_access",
+              "browser_control",
+              "terminal_control",
+              "host_mutation"
+            ]
+          }
+        },
+        "policy_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "cancellation_binding_refs": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "recovery_refs": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "related_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/validate_authority_dependencies.py
+++ b/tools/validate_authority_dependencies.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Validate SocioSphere authority-dependency graph contracts.
+
+Dependency-free by design. The registry is JSON-compatible YAML so the stdlib
+json parser can validate it while preserving the canonical registry/*.yaml path.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "authority-dependency.schema.json"
+REGISTRY = ROOT / "registry" / "authority-dependencies.yaml"
+VALID_DIR = ROOT / "examples" / "authority-dependencies" / "valid"
+INVALID_DIR = ROOT / "examples" / "authority-dependencies" / "invalid"
+
+VALID_STATUSES = {"draft", "active", "deprecated", "blocked"}
+VALID_EFFECTS = {
+    "read", "write", "execute", "route", "publish", "persist_memory",
+    "promote", "merge", "deploy", "replicate", "quarantine", "revoke",
+    "repair", "model_route", "network_egress", "credential_access",
+    "browser_control", "terminal_control", "host_mutation",
+}
+HIGH_RISK_EFFECTS = VALID_EFFECTS - {"read", "write"}
+REVOCABLE_EFFECTS = HIGH_RISK_EFFECTS - {"quarantine", "revoke", "repair"}
+REQUIRED_EDGE_KEYS = [
+    "id", "owner_repo", "status", "source", "target", "authority_surface_refs",
+    "control_effects", "policy_refs", "evidence_refs", "cancellation_binding_refs",
+    "recovery_refs",
+]
+REQUIRED_REF_KEYS = ["repo", "component", "kind"]
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    print(f"[authority-dependencies] ERROR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def load_json(path: Path) -> Any:
+    if not path.exists():
+        fail(f"missing file: {path.relative_to(ROOT)}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON-compatible content in {path.relative_to(ROOT)}: {exc}")
+
+
+def require_object(value: Any, path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValidationError(f"{path} must be an object")
+    return value
+
+
+def require_string(value: Any, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{path} must be a non-empty string")
+    return value
+
+
+def require_list(value: Any, path: str, *, allow_empty: bool = False) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValidationError(f"{path} must be a list")
+    if not allow_empty and not value:
+        raise ValidationError(f"{path} must not be empty")
+    return value
+
+
+def validate_schema_shape(schema: dict[str, Any]) -> None:
+    for key in ["$schema", "$id", "title", "type", "required", "properties", "$defs"]:
+        if key not in schema:
+            raise ValidationError(f"schema missing {key}")
+    required = set(schema.get("required", []))
+    for key in ["schema_version", "kind", "authority_dependencies"]:
+        if key not in required:
+            raise ValidationError(f"schema.required missing {key}")
+
+
+def validate_repo_ref(ref: Any, path: str) -> None:
+    obj = require_object(ref, path)
+    for key in REQUIRED_REF_KEYS:
+        require_string(obj.get(key), f"{path}.{key}")
+    if "/" not in obj["repo"]:
+        raise ValidationError(f"{path}.repo must be owner/name")
+
+
+def validate_edge(edge: Any, path: str) -> None:
+    obj = require_object(edge, path)
+    missing = [key for key in REQUIRED_EDGE_KEYS if key not in obj]
+    if missing:
+        raise ValidationError(f"{path} missing keys: {missing}")
+
+    require_string(obj["id"], f"{path}.id")
+    owner_repo = require_string(obj["owner_repo"], f"{path}.owner_repo")
+    if "/" not in owner_repo:
+        raise ValidationError(f"{path}.owner_repo must be owner/name")
+
+    status = require_string(obj["status"], f"{path}.status")
+    if status not in VALID_STATUSES:
+        raise ValidationError(f"{path}.status unsupported: {status}")
+
+    validate_repo_ref(obj["source"], f"{path}.source")
+    validate_repo_ref(obj["target"], f"{path}.target")
+
+    authority_refs = require_list(obj["authority_surface_refs"], f"{path}.authority_surface_refs")
+    policy_refs = require_list(obj["policy_refs"], f"{path}.policy_refs")
+    evidence_refs = require_list(obj["evidence_refs"], f"{path}.evidence_refs", allow_empty=True)
+    cancellation_refs = require_list(obj["cancellation_binding_refs"], f"{path}.cancellation_binding_refs", allow_empty=True)
+    recovery_refs = require_list(obj["recovery_refs"], f"{path}.recovery_refs", allow_empty=True)
+    effects = [require_string(v, f"{path}.control_effects[]") for v in require_list(obj["control_effects"], f"{path}.control_effects")]
+
+    for index, ref in enumerate(authority_refs):
+        require_string(ref, f"{path}.authority_surface_refs[{index}]")
+    for index, ref in enumerate(policy_refs):
+        require_string(ref, f"{path}.policy_refs[{index}]")
+    for index, ref in enumerate(evidence_refs):
+        require_string(ref, f"{path}.evidence_refs[{index}]")
+    for index, ref in enumerate(cancellation_refs):
+        require_string(ref, f"{path}.cancellation_binding_refs[{index}]")
+    for index, ref in enumerate(recovery_refs):
+        require_string(ref, f"{path}.recovery_refs[{index}]")
+
+    unknown_effects = sorted(set(effects) - VALID_EFFECTS)
+    if unknown_effects:
+        raise ValidationError(f"{path}.control_effects unsupported values: {unknown_effects}")
+    if len(effects) != len(set(effects)):
+        raise ValidationError(f"{path}.control_effects must be unique")
+
+    high_risk = set(effects) & HIGH_RISK_EFFECTS
+    if high_risk and not evidence_refs:
+        raise ValidationError(f"{path} high-risk effects require evidence refs: {sorted(high_risk)}")
+
+    revocable = set(effects) & REVOCABLE_EFFECTS
+    if revocable and not cancellation_refs:
+        raise ValidationError(f"{path} revocable effects require cancellation bindings: {sorted(revocable)}")
+
+    if cancellation_refs and not evidence_refs:
+        raise ValidationError(f"{path} cancellation bindings require evidence preservation refs")
+
+    if {"quarantine", "revoke", "repair"} & set(effects) and not recovery_refs:
+        raise ValidationError(f"{path} quarantine/revoke/repair effects require recovery refs")
+
+    for index, ref in enumerate(obj.get("related_refs", [])):
+        require_string(ref, f"{path}.related_refs[{index}]")
+
+
+def validate_graph(graph: Any) -> None:
+    obj = require_object(graph, "registry")
+    if obj.get("schema_version") != "0.1":
+        raise ValidationError("registry.schema_version must be 0.1")
+    if obj.get("kind") != "AuthorityDependencyGraph":
+        raise ValidationError("registry.kind must be AuthorityDependencyGraph")
+    seen: set[str] = set()
+    for index, edge in enumerate(require_list(obj.get("authority_dependencies"), "registry.authority_dependencies")):
+        validate_edge(edge, f"registry.authority_dependencies[{index}]")
+        edge_id = edge["id"]
+        if edge_id in seen:
+            raise ValidationError(f"duplicate authority dependency id: {edge_id}")
+        seen.add(edge_id)
+
+
+def validate_invalid_fixtures() -> None:
+    fixtures = sorted(INVALID_DIR.glob("*.json"))
+    if not fixtures:
+        raise ValidationError("missing invalid authority-dependency fixtures")
+    for fixture in fixtures:
+        try:
+            validate_edge(load_json(fixture), f"invalid/{fixture.name}")
+        except ValidationError:
+            continue
+        raise ValidationError(f"invalid fixture unexpectedly passed: {fixture.relative_to(ROOT)}")
+
+
+def main() -> int:
+    try:
+        validate_schema_shape(require_object(load_json(SCHEMA), "schema"))
+        validate_graph(load_json(REGISTRY))
+        valid_fixtures = sorted(VALID_DIR.glob("*.json"))
+        if not valid_fixtures:
+            raise ValidationError("missing valid authority-dependency fixtures")
+        for fixture in valid_fixtures:
+            validate_edge(load_json(fixture), f"valid/{fixture.name}")
+        validate_invalid_fixtures()
+    except ValidationError as exc:
+        fail(str(exc))
+
+    print("[authority-dependencies] OK: schema, registry, valid fixtures, and invalid fixtures validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Clean replay of the authority-dependency graph v0 payload from #328 onto current `main`.

Original PR #328 was useful but reported `mergeable: false`. This replacement branch was reset to current `main` before replay, then only the intended payload was carried forward.

## Added

- `docs/architecture/authority-dependency-graph.md`
- `registry/authority-dependencies.yaml`
- `schemas/authority-dependency.schema.json`
- `examples/authority-dependencies/valid/agentplane-network-door.authority-dependency.json`
- `examples/authority-dependencies/invalid/prose-only-authority.authority-dependency.json`
- `tools/validate_authority_dependencies.py`

## Updated

- `Makefile`
  - adds `authority-dependencies-validate`
  - wires it into `make validate`
- `docs/README.md`
  - indexes the authority dependency graph doc

## Validation

The new target is dependency-free:

```bash
python3 tools/validate_authority_dependencies.py
make authority-dependencies-validate
```

Expected validator output:

```text
[authority-dependencies] OK: schema, registry, valid fixtures, and invalid fixtures validated
```

## Boundary

This is a contract/topology tranche only. It does not add runtime behavior, policy-engine behavior, AgentPlane execution internals, Superconscious trust-surface semantics, or SourceOS repair implementation.

## Supersedes

Supersedes #328 after content capture/replay. Do not close #328 until this PR lands or this PR is explicitly abandoned with a capture comment.