### PR TITLE
Replay session event reconciliation support

### DIFF
--- a/automation/session_quarantine.py
+++ b/automation/session_quarantine.py
@@ -1,0 +1,320 @@
+"""
+Session-quarantine protocol.
+
+Every agent/runtime lifecycle event must attach to a known session DAG node
+or enter the orphan event queue.  After TTL expiry without reconciliation,
+the event is quarantined and an OrphanEventReceipt is emitted.
+
+Flow
+----
+event_received(event)
+  → session known  → append to session DAG node
+  → session unknown → append to orphan_event_queue
+
+reconcile()
+  → tries to match orphan events to sessions via
+    conversation_id / parent_id / workspace_id / task_id
+  → matched  → attach to session, mark recovered
+  → unmatched after TTL → quarantine + emit OrphanEventReceipt
+"""
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SessionDAGNode:
+    """A node in a session's event DAG."""
+    session_id: str
+    events: List[dict] = field(default_factory=list)
+    created_at: str = field(default_factory=_now_iso)
+
+
+@dataclass
+class OrphanEntry:
+    """An event waiting for reconciliation."""
+    event_id: str
+    event: dict
+    received_at: str
+    reconciled: bool = False
+    recovered_session_id: Optional[str] = None
+
+
+@dataclass
+class EvidenceRef:
+    """A reference to evidence without including the full payload."""
+    ref_id: str
+    event_id: str
+    kind: str
+    hint: str  # e.g. "conversation_id=abc123"
+
+    def to_dict(self) -> dict:
+        return {
+            "ref_id": self.ref_id,
+            "event_id": self.event_id,
+            "kind": self.kind,
+            "hint": self.hint,
+        }
+
+
+@dataclass
+class OrphanEventReceipt:
+    """
+    SourceOS-compatible receipt for a quarantined or recovered orphan event.
+
+    Compatible with SourceOS receipt conventions (SessionReceipt shape).
+    Evidence refs reference payload metadata without dumping full context.
+    """
+    receipt_id: str
+    event_id: str
+    status: str  # "quarantined" | "recovered"
+    quarantined_at: str
+    ttl_seconds: int
+    reconciliation_attempts: int
+    evidence_refs: List[EvidenceRef] = field(default_factory=list)
+    recovered_session_id: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "receipt_id": self.receipt_id,
+            "event_id": self.event_id,
+            "status": self.status,
+            "quarantined_at": self.quarantined_at,
+            "ttl_seconds": self.ttl_seconds,
+            "reconciliation_attempts": self.reconciliation_attempts,
+            "evidence_refs": [r.to_dict() for r in self.evidence_refs],
+            "recovered_session_id": self.recovered_session_id,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Core protocol
+# ---------------------------------------------------------------------------
+
+# Keys used for reconciliation attempts
+_RECONCILE_KEYS = ("conversation_id", "parent_id", "workspace_id", "task_id")
+
+DEFAULT_TTL_SECONDS = 300
+
+
+class SessionQuarantineProtocol:
+    """Enforce session-DAG attachment for every lifecycle event.
+
+    Parameters
+    ----------
+    ttl_seconds:
+        Time-to-live (seconds) for orphan events before they are quarantined.
+        Defaults to :data:`DEFAULT_TTL_SECONDS`.
+    """
+
+    def __init__(self, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> None:
+        self.ttl_seconds = ttl_seconds
+
+        # session_id → DAG node
+        self._sessions: Dict[str, SessionDAGNode] = {}
+
+        # event_id → OrphanEntry
+        self._orphan_queue: Dict[str, OrphanEntry] = {}
+
+        # All emitted receipts (quarantined and recovered)
+        self._receipts: List[OrphanEventReceipt] = []
+
+        # Reconciliation attempt count per event_id
+        self._reconcile_counts: Dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # Session management
+    # ------------------------------------------------------------------
+
+    def register_session(self, session_id: str) -> SessionDAGNode:
+        """Register a new known session and return its DAG node."""
+        if session_id not in self._sessions:
+            self._sessions[session_id] = SessionDAGNode(session_id=session_id)
+            logger.info("Session registered: %s", session_id)
+        return self._sessions[session_id]
+
+    def get_session(self, session_id: str) -> Optional[SessionDAGNode]:
+        """Return the DAG node for *session_id*, or ``None`` if unknown."""
+        return self._sessions.get(session_id)
+
+    # ------------------------------------------------------------------
+    # Event ingress
+    # ------------------------------------------------------------------
+
+    def event_received(self, event: dict) -> str:
+        """Process an incoming lifecycle event.
+
+        Returns
+        -------
+        ``"attached"``
+            The event was immediately attached to a known session DAG node.
+        ``"orphaned"``
+            No matching session was found; the event was added to the orphan queue.
+        """
+        session_id = event.get("session_id", "")
+        event_id = event.get("event_id") or str(uuid.uuid4())
+
+        # Ensure the event carries a stable id
+        if "event_id" not in event:
+            event = dict(event, event_id=event_id)
+
+        if session_id and session_id in self._sessions:
+            self._attach_to_session(session_id, event)
+            return "attached"
+
+        self._enqueue_orphan(event_id, event)
+        return "orphaned"
+
+    # ------------------------------------------------------------------
+    # Reconciliation
+    # ------------------------------------------------------------------
+
+    def reconcile(self) -> None:
+        """Attempt reconciliation of all currently queued orphan events.
+
+        For each unreconciled orphan:
+
+        - tries to find a matching session via *conversation_id*, *parent_id*,
+          *workspace_id*, or *task_id*
+        - if matched: attaches the event, marks it recovered, and emits a receipt
+        - if TTL exceeded without a match: quarantines the event and emits a receipt
+        """
+        now = datetime.now(timezone.utc)
+        to_quarantine = []
+
+        for entry in list(self._orphan_queue.values()):
+            if entry.reconciled:
+                continue
+
+            self._reconcile_counts[entry.event_id] = (
+                self._reconcile_counts.get(entry.event_id, 0) + 1
+            )
+
+            matched_session = self._find_matching_session(entry.event)
+            if matched_session:
+                self._attach_to_session(matched_session, entry.event)
+                entry.reconciled = True
+                entry.recovered_session_id = matched_session
+                self._emit_receipt(entry, status="recovered")
+                logger.info(
+                    "Orphan event %s recovered → session %s",
+                    entry.event_id,
+                    matched_session,
+                )
+                continue
+
+            received_dt = datetime.fromisoformat(entry.received_at)
+            # Make received_dt timezone-aware if it isn't already
+            if received_dt.tzinfo is None:
+                received_dt = received_dt.replace(tzinfo=timezone.utc)
+            age_seconds = (now - received_dt).total_seconds()
+            if age_seconds >= self.ttl_seconds:
+                to_quarantine.append(entry)
+
+        for entry in to_quarantine:
+            self._quarantine(entry)
+
+    # ------------------------------------------------------------------
+    # Accessors
+    # ------------------------------------------------------------------
+
+    def get_orphan_queue(self) -> List[OrphanEntry]:
+        """Return pending (unreconciled) orphan entries."""
+        return [e for e in self._orphan_queue.values() if not e.reconciled]
+
+    def get_receipts(self) -> List[OrphanEventReceipt]:
+        """Return all emitted receipts (quarantined and recovered)."""
+        return list(self._receipts)
+
+    def get_sessions(self) -> Dict[str, SessionDAGNode]:
+        """Return all registered session DAG nodes."""
+        return dict(self._sessions)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _attach_to_session(self, session_id: str, event: dict) -> None:
+        node = self._sessions[session_id]
+        node.events.append(event)
+        logger.debug(
+            "Event %s attached to session %s (total events: %d)",
+            event.get("event_id", "?"),
+            session_id,
+            len(node.events),
+        )
+
+    def _enqueue_orphan(self, event_id: str, event: dict) -> None:
+        entry = OrphanEntry(
+            event_id=event_id,
+            event=event,
+            received_at=_now_iso(),
+        )
+        self._orphan_queue[event_id] = entry
+        logger.info("Orphan event queued: event_id=%s", event_id)
+
+    def _find_matching_session(self, event: dict) -> Optional[str]:
+        """Return a session_id if the event can be reconciled, else ``None``."""
+        for key in _RECONCILE_KEYS:
+            value = event.get(key)
+            if not value:
+                continue
+            for session_id, node in self._sessions.items():
+                # Check whether any existing event on the session shares the key
+                for session_event in node.events:
+                    if session_event.get(key) == value:
+                        return session_id
+        return None
+
+    def _quarantine(self, entry: OrphanEntry) -> None:
+        """Quarantine an irreconcilable orphan and emit a receipt."""
+        entry.reconciled = True  # remove from active queue
+        self._emit_receipt(entry, status="quarantined")
+        logger.warning(
+            "Event quarantined: event_id=%s (attempts=%d)",
+            entry.event_id,
+            self._reconcile_counts.get(entry.event_id, 0),
+        )
+
+    def _emit_receipt(self, entry: OrphanEntry, status: str) -> None:
+        evidence_refs = self._build_evidence_refs(entry)
+        receipt = OrphanEventReceipt(
+            receipt_id=str(uuid.uuid4()),
+            event_id=entry.event_id,
+            status=status,
+            quarantined_at=_now_iso(),
+            ttl_seconds=self.ttl_seconds,
+            reconciliation_attempts=self._reconcile_counts.get(entry.event_id, 0),
+            evidence_refs=evidence_refs,
+            recovered_session_id=entry.recovered_session_id,
+        )
+        self._receipts.append(receipt)
+
+    def _build_evidence_refs(self, entry: OrphanEntry) -> List[EvidenceRef]:
+        """Build evidence refs that reference payload metadata without dumping full context."""
+        refs = []
+        for key in _RECONCILE_KEYS:
+            value = entry.event.get(key)
+            if value:
+                refs.append(
+                    EvidenceRef(
+                        ref_id=str(uuid.uuid4()),
+                        event_id=entry.event_id,
+                        kind=key,
+                        hint=f"{key}={value}",
+                    )
+                )
+        return refs

--- a/tests/test_session_quarantine.py
+++ b/tests/test_session_quarantine.py
@@ -1,0 +1,311 @@
+"""Tests for automation/session_quarantine.py."""
+
+import pytest
+
+from automation.session_quarantine import (
+    DEFAULT_TTL_SECONDS,
+    EvidenceRef,
+    OrphanEntry,
+    OrphanEventReceipt,
+    SessionDAGNode,
+    SessionQuarantineProtocol,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(**kwargs) -> dict:
+    """Return a minimal lifecycle event, overridable via kwargs."""
+    base = {
+        "event_id": "evt-001",
+        "session_id": "ses-001",
+        "conversation_id": "conv-abc",
+    }
+    base.update(kwargs)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestKnownSessionEvent:
+    """Acceptance: known-session event is attached to the session DAG."""
+
+    def test_known_session_returns_attached(self):
+        proto = SessionQuarantineProtocol()
+        proto.register_session("ses-001")
+
+        result = proto.event_received(_make_event(event_id="evt-001", session_id="ses-001"))
+
+        assert result == "attached"
+
+    def test_event_appears_in_dag_node(self):
+        proto = SessionQuarantineProtocol()
+        proto.register_session("ses-001")
+        proto.event_received(_make_event(event_id="evt-001", session_id="ses-001"))
+
+        node = proto.get_session("ses-001")
+        assert node is not None
+        assert len(node.events) == 1
+        assert node.events[0]["event_id"] == "evt-001"
+
+    def test_multiple_events_accumulate_in_dag(self):
+        proto = SessionQuarantineProtocol()
+        proto.register_session("ses-a")
+
+        for i in range(3):
+            proto.event_received({"event_id": f"evt-{i}", "session_id": "ses-a"})
+
+        assert len(proto.get_session("ses-a").events) == 3
+
+
+class TestUnknownSessionEvent:
+    """Acceptance: unknown-session event enters the orphan queue."""
+
+    def test_unknown_session_returns_orphaned(self):
+        proto = SessionQuarantineProtocol()
+
+        result = proto.event_received(_make_event(session_id="ses-missing"))
+
+        assert result == "orphaned"
+
+    def test_orphan_appears_in_queue(self):
+        proto = SessionQuarantineProtocol()
+        proto.event_received(_make_event(event_id="evt-002", session_id="ses-missing"))
+
+        orphans = proto.get_orphan_queue()
+        assert len(orphans) == 1
+        assert orphans[0].event_id == "evt-002"
+
+    def test_event_without_session_id_is_orphaned(self):
+        proto = SessionQuarantineProtocol()
+        result = proto.event_received({"event_id": "evt-nosess", "payload": "data"})
+
+        assert result == "orphaned"
+        assert len(proto.get_orphan_queue()) == 1
+
+    def test_multiple_sessions_mixed_events(self):
+        proto = SessionQuarantineProtocol()
+        proto.register_session("ses-a")
+        proto.register_session("ses-b")
+
+        proto.event_received({"event_id": "e1", "session_id": "ses-a"})
+        proto.event_received({"event_id": "e2", "session_id": "ses-b"})
+        proto.event_received({"event_id": "e3", "session_id": "ses-unknown"})
+
+        assert len(proto.get_session("ses-a").events) == 1
+        assert len(proto.get_session("ses-b").events) == 1
+        assert len(proto.get_orphan_queue()) == 1
+
+
+class TestTTLExpiry:
+    """Acceptance: events not reconciled within TTL are quarantined with a receipt."""
+
+    def test_ttl_zero_quarantines_immediately(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=0)
+        proto.event_received(_make_event(event_id="evt-ttl", session_id="ses-missing"))
+
+        proto.reconcile()
+
+        assert len(proto.get_orphan_queue()) == 0
+
+    def test_quarantine_emits_receipt(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=0)
+        proto.event_received(_make_event(event_id="evt-ttl", session_id="ses-missing"))
+
+        proto.reconcile()
+
+        receipts = proto.get_receipts()
+        assert len(receipts) == 1
+        assert receipts[0].status == "quarantined"
+        assert receipts[0].event_id == "evt-ttl"
+
+    def test_high_ttl_does_not_quarantine(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=DEFAULT_TTL_SECONDS)
+        proto.event_received(_make_event(event_id="evt-keep", session_id="ses-missing"))
+
+        proto.reconcile()
+
+        # Still in queue, not yet quarantined
+        assert len(proto.get_orphan_queue()) == 1
+        assert len(proto.get_receipts()) == 0
+
+    def test_receipt_records_ttl(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=0)
+        proto.event_received(_make_event(event_id="evt-ttl2", session_id="ses-x"))
+        proto.reconcile()
+
+        receipt = proto.get_receipts()[0]
+        assert receipt.ttl_seconds == 0
+
+
+class TestRecoveredEvent:
+    """Acceptance: reconciled events attach correctly to sessions with recovered receipts."""
+
+    def test_reconcile_via_conversation_id(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=300)
+        proto.register_session("ses-recover")
+        # Seed the session with an event sharing conversation_id
+        proto._sessions["ses-recover"].events.append(
+            {"event_id": "seed-0", "conversation_id": "conv-xyz"}
+        )
+
+        # Orphan event with matching conversation_id
+        proto.event_received(
+            _make_event(event_id="evt-rec", session_id="ses-unknown", conversation_id="conv-xyz")
+        )
+        proto.reconcile()
+
+        assert len(proto.get_orphan_queue()) == 0
+        node = proto.get_session("ses-recover")
+        assert any(e["event_id"] == "evt-rec" for e in node.events)
+
+    def test_reconcile_emits_recovered_receipt(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=300)
+        proto.register_session("ses-r2")
+        proto._sessions["ses-r2"].events.append(
+            {"event_id": "s0", "workspace_id": "ws-999"}
+        )
+
+        proto.event_received(
+            {"event_id": "evt-ws", "session_id": "ses-gone", "workspace_id": "ws-999"}
+        )
+        proto.reconcile()
+
+        receipts = proto.get_receipts()
+        recovered = [r for r in receipts if r.status == "recovered"]
+        assert len(recovered) == 1
+        assert recovered[0].event_id == "evt-ws"
+        assert recovered[0].recovered_session_id == "ses-r2"
+
+    def test_reconcile_via_task_id(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=300)
+        proto.register_session("ses-task")
+        proto._sessions["ses-task"].events.append(
+            {"event_id": "s-task", "task_id": "task-42"}
+        )
+
+        proto.event_received(
+            {"event_id": "evt-task", "session_id": "ses-nope", "task_id": "task-42"}
+        )
+        proto.reconcile()
+
+        node = proto.get_session("ses-task")
+        assert any(e["event_id"] == "evt-task" for e in node.events)
+
+    def test_reconcile_via_parent_id(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=300)
+        proto.register_session("ses-parent")
+        proto._sessions["ses-parent"].events.append(
+            {"event_id": "s-par", "parent_id": "par-7"}
+        )
+
+        proto.event_received(
+            {"event_id": "evt-par", "session_id": "ses-nope", "parent_id": "par-7"}
+        )
+        proto.reconcile()
+
+        node = proto.get_session("ses-parent")
+        assert any(e["event_id"] == "evt-par" for e in node.events)
+
+
+class TestEvidenceReferences:
+    """Acceptance: quarantined events emit receipts with evidenceRefs."""
+
+    def test_evidence_refs_present_for_conversation_id(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=0)
+        proto.event_received(
+            {
+                "event_id": "evt-evid",
+                "session_id": "ses-missing",
+                "conversation_id": "conv-evid",
+            }
+        )
+        proto.reconcile()
+
+        receipt = proto.get_receipts()[0]
+        assert len(receipt.evidence_refs) >= 1
+        kinds = [r.kind for r in receipt.evidence_refs]
+        assert "conversation_id" in kinds
+
+    def test_evidence_refs_include_workspace_and_task(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=0)
+        proto.event_received(
+            {
+                "event_id": "evt-multi",
+                "session_id": "ses-x",
+                "workspace_id": "ws-abc",
+                "task_id": "t-99",
+            }
+        )
+        proto.reconcile()
+
+        receipt = proto.get_receipts()[0]
+        kinds = [r.kind for r in receipt.evidence_refs]
+        assert "workspace_id" in kinds
+        assert "task_id" in kinds
+
+    def test_evidence_refs_hint_is_concise(self):
+        """Evidence refs must reference metadata, not dump full payload."""
+        proto = SessionQuarantineProtocol(ttl_seconds=0)
+        proto.event_received(
+            {
+                "event_id": "evt-hint",
+                "session_id": "ses-y",
+                "conversation_id": "conv-hint",
+                "large_field": "x" * 10_000,
+            }
+        )
+        proto.reconcile()
+
+        receipt = proto.get_receipts()[0]
+        for ref in receipt.evidence_refs:
+            # Hint must not contain the large payload
+            assert len(ref.hint) < 200
+
+    def test_no_evidence_refs_when_no_reconcile_keys(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=0)
+        proto.event_received({"event_id": "evt-bare", "session_id": "ses-z"})
+        proto.reconcile()
+
+        receipt = proto.get_receipts()[0]
+        assert receipt.evidence_refs == []
+
+
+class TestReceiptSerialization:
+    """Verify OrphanEventReceipt.to_dict() produces correct output."""
+
+    def test_to_dict_structure(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=0)
+        proto.event_received(
+            {"event_id": "evt-serial", "session_id": "ses-s", "task_id": "task-7"}
+        )
+        proto.reconcile()
+
+        d = proto.get_receipts()[0].to_dict()
+
+        assert d["status"] == "quarantined"
+        assert d["event_id"] == "evt-serial"
+        assert d["ttl_seconds"] == 0
+        assert isinstance(d["evidence_refs"], list)
+        assert d["recovered_session_id"] is None
+
+    def test_recovered_receipt_to_dict_has_session(self):
+        proto = SessionQuarantineProtocol(ttl_seconds=300)
+        proto.register_session("ses-ser")
+        proto._sessions["ses-ser"].events.append(
+            {"event_id": "sx", "conversation_id": "conv-ser"}
+        )
+        proto.event_received(
+            {"event_id": "evt-ser", "session_id": "s-gone", "conversation_id": "conv-ser"}
+        )
+        proto.reconcile()
+
+        receipts = [r for r in proto.get_receipts() if r.status == "recovered"]
+        assert len(receipts) == 1
+        d = receipts[0].to_dict()
+        assert d["recovered_session_id"] == "ses-ser"
+        assert isinstance(d["receipt_id"], str) and len(d["receipt_id"]) > 0


### PR DESCRIPTION
## Summary

Clean replay of #289 onto current `main`.

Original PR #289 is valid and check-green but reported `mergeable: false`. This replacement carries forward the intended two-file payload without forcing a stale branch merge.

## Added

- `automation/session_quarantine.py`
- `tests/test_session_quarantine.py`

## Scope

Adds the session DAG/orphan-event queue and receipt protocol plus tests. No UI, runtime deployment, policy-engine, or external integration behavior is introduced.

## Validation

Original PR head `83e0a36fca26891768b0a0267c3c27acda575f9d` had visible checks passing, including `validate`, `workspace-spine`, `ui-check`, `compliance`, and standards/lattice workflows.

## Supersedes

Supersedes #289 after this PR lands. Do not close #289 until this replay merges or another capture location is recorded.