### PR TITLE
Register Workspace Context Fabric estate roles

### DIFF
--- a/docs/context-fabric-estate-registration.md
+++ b/docs/context-fabric-estate-registration.md
@@ -1,0 +1,39 @@
+# Workspace Context Fabric estate registration
+
+## Purpose
+
+This note records the first Sociosphere topology registration for Workspace Context Fabric.
+
+The fabric spans several repositories, but no repository loses its boundary:
+
+- `prophet-workspace` owns workspace product/domain contracts.
+- `prophet-platform` owns runtime services, contracts, storage, and deployment.
+- `agentplane` owns governed execution evidence.
+- `agent-registry` owns agent identity, sessions, grants, and revocation references.
+- `memory-mesh` owns recall services, context packs, and review-based promotion.
+- `socioprophet-agent-standards` owns profile, compatibility, and conformance overlays.
+- `policy-fabric` owns policy decision surfaces.
+- `mcp-a2a-zero-trust` owns mediated provider/tool/agent/interface grants.
+
+## Registration fragment
+
+The initial registration is staged in:
+
+- `manifest/context-fabric.registration.toml`
+
+It is intentionally separate from `manifest/workspace.toml` for the first review so the new entries can be checked before canonical manifest and lock regeneration.
+
+## New entries
+
+- `prophet_workspace`
+- `agent_registry`
+- `memory_mesh`
+- `socioprophet_agent_standards`
+
+## Follow-up after merge
+
+1. Fold the fragment into `manifest/workspace.toml`.
+2. Regenerate `manifest/workspace.lock.json`.
+3. Add boundary catalog entries.
+4. Add dependency-graph edges from `prophet_workspace` to platform, agentplane, agent-registry, memory-mesh, policy-fabric, and mcp-a2a-zero-trust.
+5. Add source-exposure review for public context-sharing surfaces.

--- a/manifest/context-fabric.registration.toml
+++ b/manifest/context-fabric.registration.toml
@@ -1,0 +1,44 @@
+# Workspace Context Fabric estate registration fragment.
+#
+# This fragment is intended to be folded into manifest/workspace.toml after
+# topology review. It keeps the first registration tranche additive and easy to
+# audit before the canonical workspace lock is regenerated.
+
+[[repos]]
+name = "prophet_workspace"
+role = "component"
+url = "https://github.com/SocioProphet/prophet-workspace"
+ref = "main"
+local_path = "components/prophet_workspace"
+license_hint = "MIT"
+trust_zone = "workspace"
+required_capabilities = ["workspace_context", "provider_projection", "policy_aware_ux"]
+
+[[repos]]
+name = "agent_registry"
+role = "security"
+url = "https://github.com/SocioProphet/agent-registry"
+ref = "main"
+local_path = "components/agent_registry"
+license_hint = "MIT"
+trust_zone = "control"
+required_capabilities = ["agent_identity", "tool_grants", "session_authority", "revocation"]
+
+[[repos]]
+name = "memory_mesh"
+role = "component"
+url = "https://github.com/SocioProphet/memory-mesh"
+ref = "main"
+local_path = "components/memory_mesh"
+license_hint = "MIT"
+trust_zone = "memory"
+required_capabilities = ["recall", "context_pack", "learning_proposal"]
+
+[[repos]]
+name = "socioprophet_agent_standards"
+role = "standards"
+url = "https://github.com/SocioProphet/socioprophet-agent-standards"
+ref = "main"
+local_path = "components/socioprophet_agent_standards"
+license_hint = "MIT"
+required_capabilities = ["agent_profile", "conformance", "compatibility_matrix"]


### PR DESCRIPTION
## Summary

Stages the first Sociosphere registration for Workspace Context Fabric and adjacent authority/memory/standards repositories.

This PR does not rewrite the canonical manifest/lock directly. It adds a reviewable registration fragment plus a short estate role map so the topology can be checked before folding the entries into `manifest/workspace.toml` and regenerating the lock.

## Changes

- Add `manifest/context-fabric.registration.toml`
- Add `docs/context-fabric-estate-registration.md`

## New staged entries

- `prophet_workspace`
- `agent_registry`
- `memory_mesh`
- `socioprophet_agent_standards`

## Boundary posture

- `prophet-workspace` owns workspace/product semantics.
- `prophet-platform` remains runtime/deployment hub.
- `agentplane` remains execution evidence authority.
- `agent-registry` remains agent/session/grant authority.
- `memory-mesh` remains recall/context-pack/promotion authority.
- `socioprophet-agent-standards` remains profile/conformance overlay.

## Follow-up after review

1. Fold entries into `manifest/workspace.toml`.
2. Regenerate `manifest/workspace.lock.json`.
3. Add boundary catalog and dependency graph edges.
4. Add source-exposure review for public context/projection surfaces.
