### PR TITLE
Add active spine registry v0

### DIFF
--- a/registry/spine-v0.txt
+++ b/registry/spine-v0.txt
@@ -1,0 +1,23 @@
+Active spine v0
+
+Canonical:
+SocioProphet/sociosphere
+SocioProphet/prophet-platform
+SocioProphet/TriTRPC
+SocioProphet/socioprophet-standards-storage
+SocioProphet/socioprophet-standards-knowledge
+
+Candidates:
+SocioProphet/prophet-platform-standards
+SocioProphet/socioprophet-agent-standards
+SocioProphet/prophet-workspace
+SocioProphet/hellgraph
+
+Adjacent:
+SourceOS-Linux/sourceos-spec
+
+Required follow-up:
+- patch manifest workspace
+- refresh lockfile
+- normalize canonical repo registry
+- add coverage validators

--- a/tools/check_spine_v0.py
+++ b/tools/check_spine_v0.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+REG = ROOT / "registry" / "spine-v0.txt"
+REQUIRED = [
+    "SocioProphet/sociosphere",
+    "SocioProphet/prophet-platform",
+    "SocioProphet/TriTRPC",
+    "SocioProphet/socioprophet-standards-storage",
+    "SocioProphet/socioprophet-standards-knowledge",
+    "SocioProphet/prophet-platform-standards",
+    "SocioProphet/socioprophet-agent-standards",
+    "SocioProphet/prophet-workspace",
+    "SocioProphet/hellgraph",
+    "SourceOS-Linux/sourceos-spec",
+]
+
+
+def main() -> int:
+    text = REG.read_text(encoding="utf-8")
+    missing = [item for item in REQUIRED if item not in text]
+    if missing:
+        for item in missing:
+            print(f"ERR: missing {item}", file=sys.stderr)
+        return 1
+    print("OK: active spine v0 registry covers required repos")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a compact active-spine registry and stdlib validator for the corrected SocioProphet governance spine.