### PR TITLE
Capture symbolic regression insertion points

### DIFF
--- a/docs/integration/symbolic-regression-insertion-points.md
+++ b/docs/integration/symbolic-regression-insertion-points.md
@@ -1,0 +1,248 @@
+# Symbolic Regression Insertion Points
+
+Status: v0.1 doctrine capture.
+
+This document captures the symbolic-regression / equation-discovery field map as a CHRONOS sublane. It extends the neuro-symbolic reasoning work already captured in SocioSphere, but it is not the same lane. The controlling object here is an equation or program candidate that must move through evidence, replay, semantic review, and governance before it can become a law, ontology assertion, policy, controller, or pedagogical answer.
+
+This document does not vendor papers, install tools, promote schemas, or assign runtime authority.
+
+## Position
+
+Symbolic regression and scientific-law discovery are CHRONOS carrier sources, not authorities.
+
+```text
+data / telemetry / graph / notebook / experiment
+  -> SR method run
+  -> equation candidate
+  -> evidence + metrics + complexity + operator library
+  -> SRAssertion proposal
+  -> ontology / policy / replay review
+  -> admitted law, rejected candidate, or learning update
+```
+
+The output of PySR, SINDy, TPSR, SNIP, LLM-SR, FunSearch-style program search, KAN-based extraction, or Hamiltonian-learning workflows is an `EquationCandidate` or `ProgramCandidate`. It is not a law by itself.
+
+## Field map
+
+| Track | Example methods | CHRONOS role | Forbidden promotion |
+|---|---|---|---|
+| GP / evolutionary SR | PySR, SymbolicRegression.jl, InceptionSR | equation candidate generation and baseline tooling | equation as ontology truth |
+| Sparse regression / system identification | SINDy, SINDy-SI | telemetry or physical-dynamics model candidate | telemetry model as policy authority |
+| Transformer pretraining | NeSymReS, E2E SR Transformer, SymFormer | pretrained expression generator | one-pass equation as admitted law |
+| MCTS decoding | Symbolic Physics Learner, TPSR | feedback-aware search over expressions | search score as proof |
+| Cross-modal pretraining | SNIP | symbolic-numeric bridge and latent candidate retrieval | latent similarity as validation |
+| LLM evolutionary SR | LLM-SR, LaSR, ICSR, SR-LLM | domain-prior-assisted hypothesis search | LLM equation as evidence |
+| LLM program search | FunSearch-style search, AlphaTensor-style precedent | program candidate search with evaluator | generated program as policy/controller without admission |
+| KAN-based SR | KAN, KAN-SR, KAN-LEx | interpretable function decomposition and formula extraction | spline/plot/extraction as hard truth |
+| Physics-constrained SR | units-guided SR, SINDy-SI, materials SR | constrained equation proposal | dimensional consistency as sufficient validation |
+| Benchmarking | SRBench, Feynman, LLM-SRBench | evaluation surface and regression corpus | benchmark score as production admission |
+
+## Seven insertion points
+
+### 1. memory-mesh: symbolic-numeric bridge
+
+`SocioProphet/memory-mesh` is the natural home for a symbolic-numeric bridge service. A SNIP-style bridge may align symbolic expressions, graph concepts, and numeric observations in a shared latent space.
+
+Candidate service name:
+
+```text
+symbolic-numeric-bridge
+```
+
+Allowed outputs:
+
+- latent-neighbor suggestions;
+- candidate symbolic expressions;
+- graph relation candidates;
+- cluster-to-symbol hypotheses;
+- equation search seeds.
+
+Forbidden outputs:
+
+- canonical ontology assertions;
+- graph truth;
+- memory promotion;
+- evidence admission.
+
+Required handoff:
+
+```text
+memory-mesh candidate
+  -> CHRONOS carrier
+  -> AgentPlane evidence/replay
+  -> Ontogenesis / WebProtégé review
+```
+
+### 2. prophet-platform telemetry: SINDy platform dynamics
+
+`SocioProphet/prophet-platform` telemetry can feed SINDy-style sparse-regression system identification. This produces candidate closed-form dynamics for agent throughput, memory load, mesh traffic, RPC convergence, queue pressure, and learning-loop behavior.
+
+Allowed outputs:
+
+- `PlatformDynamicsCandidate`;
+- discovered ODE candidate;
+- feature library report;
+- residual and sparsity metrics;
+- stability or side-information report.
+
+Forbidden outputs:
+
+- direct autoscaling policy;
+- direct routing policy;
+- SRE action without policy admission;
+- controller use without AgentPlane replay and policy review.
+
+### 3. JupyterHub / notebook layer: PySR and KAN primitives
+
+The notebook layer should make PySR and KAN-style workflows first-class computational verbs. Notebook output should become a CHRONOS carrier, not an untracked markdown result.
+
+Allowed outputs:
+
+- `NotebookEquationCandidate`;
+- LaTeX equation string;
+- operator library;
+- fit metric;
+- complexity metric;
+- dataset reference;
+- reproducibility metadata.
+
+Forbidden outputs:
+
+- direct WebProtégé mutation;
+- ontology assertion without review;
+- untracked notebook equation as curriculum truth.
+
+### 4. Ontogenesis / WebProtégé: SRAssertion
+
+`SocioProphet/ontogenesis` should draft the semantic vocabulary for `SRAssertion`. WebProtégé becomes the editor/surface for reviewed assertions, not the first place raw SR output lands.
+
+Proposed object:
+
+```text
+SRAssertion
+  hasDataset
+  hasFeatureSet
+  hasEquation
+  hasOperatorLibrary
+  hasComplexity
+  hasFitMetric
+  hasUnitsConstraint
+  hasDimensionalStatus
+  discoveredBy
+  discoveredAt
+  hasEvidenceReplay
+  hasPromotionStatus
+```
+
+Forbidden outputs:
+
+- raw equation as OWL axiom;
+- SR fit metric as truth;
+- notebook result as semantic promotion.
+
+### 5. AgentPlane: SR discovery agents
+
+`SocioProphet/agentplane` should own the evidence/replay surface for SR agents.
+
+Candidate agent types:
+
+- `SRDiscoveryAgent` for PySR / TPSR-style search;
+- `SRHypothesisAgent` for LLM-SR-style domain-prior search;
+- `SINDyDynamicsAgent` for telemetry and physical-dynamics system identification;
+- `ProgramSearchAgent` for FunSearch-style program candidates.
+
+Each agent emits replayable artifacts, not authority.
+
+### 6. Alexandrian / OVAL: Feynman curriculum and Socratic SR
+
+`SocioProphet/alexandrian-academy` should own curriculum/canonization. OVAL-style tutoring should treat SR as a pedagogy engine: student hypothesis, operator choice, dimensional check, complexity discussion, and guided convergence.
+
+Allowed outputs:
+
+- curriculum exercise;
+- student hypothesis trace;
+- hint policy;
+- SR scoring trace;
+- admitted educational explanation.
+
+Forbidden outputs:
+
+- model reveals target equation prematurely;
+- benchmark answer treated as child-facing truth without pedagogy policy;
+- unreviewed generated explanation as canon.
+
+### 7. Quantum / Hamiltonian-learning lane
+
+The quantum lane is longer-run. PySR / KAN / SINDy-like workflows may propose Hamiltonian forms from measurement data. The immediate role is source capture and interface design, not implementation.
+
+Allowed outputs:
+
+- `HamiltonianCandidate`;
+- measurement dataset reference;
+- operator basis;
+- fit metric;
+- uncertainty / identifiability report.
+
+Forbidden outputs:
+
+- quantum experiment truth without replay;
+- Hamiltonian candidate as canonical physics law;
+- runtime control without policy and safety review.
+
+## Required CHRONOS carrier fields
+
+A symbolic-regression carrier should include:
+
+- method family;
+- implementation reference;
+- dataset URI or telemetry source;
+- feature set;
+- target variable;
+- operator library;
+- equation or program candidate;
+- constants and units;
+- dimensional status;
+- fit metric;
+- complexity metric;
+- baseline comparison;
+- replay artifact reference;
+- semantic promotion status;
+- policy / runtime admission status;
+- non-authority declaration.
+
+## Failure modes
+
+The symbolic-regression lane introduces these failure modes:
+
+```text
+equation_as_authority
+telemetry_model_as_policy
+notebook_equation_as_ontology
+latent_similarity_as_validation
+benchmark_score_as_admission
+program_candidate_as_controller
+units_check_as_full_validation
+```
+
+## Priority order
+
+```text
+P0 — SocioSphere SR insertion map and negative fixtures
+P1 — Ontogenesis SRAssertion vocabulary draft
+P1 — AgentPlane SR evidence/replay schemas
+P2 — memory-mesh symbolic-numeric-bridge service contract
+P2 — JupyterHub PySR/KAN notebook primitive spec
+P2 — prophet-platform telemetry/SINDy lane
+P3 — Alexandrian/OVAL Feynman curriculum
+P3 — Quantum/Hamiltonian-learning lane
+```
+
+## Non-goals
+
+This document does not claim any SR method is correct for all domains.
+
+This document does not promote equations into ontology or policy.
+
+This document does not choose PySR, SINDy, TPSR, SNIP, LLM-SR, KAN, or FunSearch as an exclusive implementation.
+
+This document creates an estate alignment map and identifies follow-on work.

--- a/registry/corpus-loop-v0/invalid.equation-as-authority.json
+++ b/registry/corpus-loop-v0/invalid.equation-as-authority.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": "0.1.0",
+  "kind": "ChronosCarrierRegistration",
+  "id": "chronos-carrier.invalid.equation-as-authority",
+  "title": "Invalid carrier treating symbolic regression output as admitted law",
+  "source": {
+    "sourceType": "symbolic-regression-run",
+    "evidenceRefs": ["synthetic-negative-fixture"]
+  },
+  "carrier": {
+    "status": "admitted",
+    "claimStatus": "law",
+    "validationState": "fit-metric-only",
+    "methodFamilies": ["SR-GP-EVOLUTIONARY"],
+    "equationCandidate": "F = m * a",
+    "fitMetric": {"name": "NMSE", "value": 0.0001},
+    "complexityMetric": {"name": "operator_count", "value": 3},
+    "semanticPromotionStatus": "self-promoted",
+    "nonAuthorityDeclaration": "missing"
+  },
+  "authority": {
+    "integrationPlane": "SocioProphet/sociosphere",
+    "semanticVocabularyDraft": "bypassed",
+    "schemaAuthority": "bypassed",
+    "evidenceReplayAuthority": "missing",
+    "policyAdmissionAuthority": "missing"
+  },
+  "expectedValidationFailure": {
+    "reason": "A symbolic-regression equation candidate cannot be promoted as law or ontology truth from fit metrics alone.",
+    "failureMode": "equation_as_authority"
+  }
+}

--- a/registry/corpus-loop-v0/invalid.notebook-equation-as-ontology.json
+++ b/registry/corpus-loop-v0/invalid.notebook-equation-as-ontology.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "0.1.0",
+  "kind": "ChronosCarrierRegistration",
+  "id": "chronos-carrier.invalid.notebook-equation-as-ontology",
+  "title": "Invalid carrier treating notebook equation output as ontology assertion",
+  "source": {
+    "sourceType": "jupyter-notebook-symbolic-regression",
+    "evidenceRefs": ["synthetic-negative-fixture"]
+  },
+  "carrier": {
+    "status": "admitted",
+    "claimStatus": "ontology_assertion",
+    "validationState": "notebook-output-only",
+    "methodFamilies": ["SR-GP-EVOLUTIONARY", "SR-KAN-BASED"],
+    "equationCandidate": "y = sin(x) + x^2",
+    "notebookRef": "notebook://unreviewed/example.ipynb",
+    "webProtegeMutation": "direct",
+    "semanticPromotionStatus": "self-promoted",
+    "nonAuthorityDeclaration": "missing"
+  },
+  "authority": {
+    "integrationPlane": "SocioProphet/sociosphere",
+    "semanticVocabularyDraft": "bypassed",
+    "schemaAuthority": "bypassed",
+    "evidenceReplayAuthority": "missing"
+  },
+  "expectedValidationFailure": {
+    "reason": "A notebook-generated equation cannot directly mutate ontology or WebProtege without SRAssertion review, evidence replay, and semantic authority handoff.",
+    "failureMode": "notebook_equation_as_ontology"
+  }
+}

--- a/registry/corpus-loop-v0/invalid.telemetry-model-as-policy.json
+++ b/registry/corpus-loop-v0/invalid.telemetry-model-as-policy.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "0.1.0",
+  "kind": "ChronosCarrierRegistration",
+  "id": "chronos-carrier.invalid.telemetry-model-as-policy",
+  "title": "Invalid carrier treating discovered telemetry dynamics as policy",
+  "source": {
+    "sourceType": "platform-telemetry-sindy-run",
+    "evidenceRefs": ["synthetic-negative-fixture"]
+  },
+  "carrier": {
+    "status": "admitted",
+    "claimStatus": "policy",
+    "validationState": "telemetry-fit-only",
+    "methodFamilies": ["SR-SPARSE-REGRESSION"],
+    "equationCandidate": "dQ_dt = a * Q - b * R",
+    "fitMetric": {"name": "residual", "value": 0.02},
+    "policyAction": "auto-scale-agentplane-workers",
+    "runtimeAdmissionStatus": "self-authorized",
+    "nonAuthorityDeclaration": "missing"
+  },
+  "authority": {
+    "integrationPlane": "SocioProphet/sociosphere",
+    "evidenceReplayAuthority": "missing",
+    "policyAdmissionAuthority": "bypassed",
+    "runtimeAuthority": "bypassed"
+  },
+  "expectedValidationFailure": {
+    "reason": "A telemetry-derived dynamics equation cannot become policy or runtime control without evidence replay, policy admission, and runtime authority review.",
+    "failureMode": "telemetry_model_as_policy"
+  }
+}

--- a/registry/corpus-loop-v0/valid.symbolic-regression-insertion-map.json
+++ b/registry/corpus-loop-v0/valid.symbolic-regression-insertion-map.json
@@ -1,0 +1,82 @@
+{
+  "schemaVersion": "0.1.0",
+  "kind": "ChronosCarrierRegistration",
+  "id": "chronos-carrier.symbolic-regression-insertion-map.v0",
+  "title": "Symbolic regression insertion-point map for CHRONOS",
+  "source": {
+    "sourceType": "field-map-capture",
+    "provider": "symbolic regression and scientific-law discovery literature",
+    "licenseStatus": "external-reference-only",
+    "vendoredContent": false,
+    "evidenceRefs": [
+      "TPSR / transformer-based planning for symbolic regression",
+      "SNIP / symbolic-numeric integrated pre-training",
+      "LLM-SR / LLM evolutionary symbolic regression",
+      "PySR / SymbolicRegression.jl",
+      "SINDy sparse system identification",
+      "KAN / Kolmogorov-Arnold Networks",
+      "FunSearch program search",
+      "Feynman symbolic-regression benchmark family"
+    ]
+  },
+  "carrier": {
+    "status": "candidate",
+    "claimStatus": "derived-integration-summary",
+    "validationState": "human-reviewed-field-map",
+    "methodFamilies": [
+      "SR-GP-EVOLUTIONARY",
+      "SR-SPARSE-REGRESSION",
+      "SR-TRANSFORMER-PRETRAINING",
+      "SR-MCTS-DECODING",
+      "SR-CROSS-MODAL-PRETRAINING",
+      "SR-LLM-EVOLUTIONARY",
+      "SR-PROGRAM-SEARCH",
+      "SR-KAN-BASED",
+      "SR-PHYSICS-CONSTRAINED",
+      "SR-BENCHMARKING"
+    ],
+    "insertionPoints": [
+      "SocioProphet/memory-mesh",
+      "SocioProphet/prophet-platform",
+      "notebook-layer",
+      "SocioProphet/ontogenesis",
+      "SocioProphet/webprotege",
+      "SocioProphet/agentplane",
+      "SocioProphet/alexandrian-academy",
+      "quantum-hamiltonian-learning-lane"
+    ],
+    "nonAuthorityDeclaration": "This carrier classifies symbolic-regression insertion points. It does not promote equations to ontology truth, evidence, policy, controller status, memory, routing, or runtime authority."
+  },
+  "authority": {
+    "integrationPlane": "SocioProphet/sociosphere",
+    "schemaAuthority": "SourceOS-Linux/sourceos-spec",
+    "semanticVocabularyDraft": "SocioProphet/ontogenesis",
+    "evidenceReplayAuthority": "SocioProphet/agentplane",
+    "policyAdmissionAuthority": "SocioProphet/policy-fabric",
+    "modelGovernanceAuthority": "SocioProphet/model-governance-ledger",
+    "routingAuthority": "SocioProphet/model-router",
+    "educationCanonAuthority": "SocioProphet/alexandrian-academy"
+  },
+  "requiredBoundaries": [
+    "equation candidate is not law",
+    "telemetry model is not policy",
+    "notebook equation is not ontology assertion",
+    "latent similarity is not validation",
+    "benchmark score is not admission",
+    "program candidate is not controller",
+    "units check is not full validation"
+  ],
+  "replay": {
+    "expectedLifecycle": [
+      "dataset_anchor",
+      "method_run_record",
+      "equation_candidate",
+      "metric_report",
+      "complexity_report",
+      "semantic_review_request",
+      "governance_decision",
+      "receipt_or_rejection",
+      "learning_update"
+    ]
+  }
+}

--- a/tools/check_neurosymbolic_chronos.py
+++ b/tools/check_neurosymbolic_chronos.py
@@ -7,13 +7,17 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 FIXTURES = ROOT / "registry" / "corpus-loop-v0"
-VALID = FIXTURES / "valid.asu-nsr-chronos.json"
+VALID_ASU_NSR = FIXTURES / "valid.asu-nsr-chronos.json"
+VALID_SR = FIXTURES / "valid.symbolic-regression-insertion-map.json"
 INVALIDS = [
     FIXTURES / "invalid.soft-score-as-authority.json",
     FIXTURES / "invalid.ungrounded-symbol-promotion.json",
     FIXTURES / "invalid.label-leakage-carrier.json",
     FIXTURES / "invalid.visual-embedding-as-evidence.json",
     FIXTURES / "invalid.transduction-certificate-missing.json",
+    FIXTURES / "invalid.equation-as-authority.json",
+    FIXTURES / "invalid.telemetry-model-as-policy.json",
+    FIXTURES / "invalid.notebook-equation-as-ontology.json",
 ]
 
 REQUIRED_METHOD_FAMILIES = {
@@ -26,6 +30,19 @@ REQUIRED_METHOD_FAMILIES = {
     "NSR-RULE-LEARNING",
     "NSR-ONTOLOGY-INFERENCE",
     "NSR-SYMBOLIC-POLICY",
+}
+
+REQUIRED_SR_METHOD_FAMILIES = {
+    "SR-GP-EVOLUTIONARY",
+    "SR-SPARSE-REGRESSION",
+    "SR-TRANSFORMER-PRETRAINING",
+    "SR-MCTS-DECODING",
+    "SR-CROSS-MODAL-PRETRAINING",
+    "SR-LLM-EVOLUTIONARY",
+    "SR-PROGRAM-SEARCH",
+    "SR-KAN-BASED",
+    "SR-PHYSICS-CONSTRAINED",
+    "SR-BENCHMARKING",
 }
 
 REQUIRED_AUTHORITIES = {
@@ -44,6 +61,9 @@ FAILURE_MODE_BY_FILE = {
     "invalid.label-leakage-carrier.json": "label_leakage_grounding_failure",
     "invalid.visual-embedding-as-evidence.json": "visual_embedding_as_evidence",
     "invalid.transduction-certificate-missing.json": "transduction_certificate_missing",
+    "invalid.equation-as-authority.json": "equation_as_authority",
+    "invalid.telemetry-model-as-policy.json": "telemetry_model_as_policy",
+    "invalid.notebook-equation-as-ontology.json": "notebook_equation_as_ontology",
 }
 
 
@@ -68,28 +88,62 @@ def dotted(data: dict[str, Any], path: str) -> Any:
     return current
 
 
-def validate_valid_fixture(data: dict[str, Any]) -> None:
-    require(data.get("kind") == "ChronosCarrierRegistration", "valid fixture wrong kind")
-    require(data.get("schemaVersion") == "0.1.0", "valid fixture wrong schemaVersion")
-    require(dotted(data, "carrier.status") == "candidate", "valid carrier must remain candidate")
+def validate_valid_nsr_fixture(data: dict[str, Any]) -> None:
+    require(data.get("kind") == "ChronosCarrierRegistration", "valid NSR fixture wrong kind")
+    require(data.get("schemaVersion") == "0.1.0", "valid NSR fixture wrong schemaVersion")
+    require(dotted(data, "carrier.status") == "candidate", "valid NSR carrier must remain candidate")
     require(
         dotted(data, "carrier.claimStatus") == "derived-integration-summary",
-        "valid carrier claimStatus must be derived-integration-summary",
+        "valid NSR carrier claimStatus must be derived-integration-summary",
     )
     require(
         dotted(data, "carrier.validationState") == "human-reviewed-corpus-map",
-        "valid carrier validationState mismatch",
+        "valid NSR carrier validationState mismatch",
     )
     families = set(dotted(data, "carrier.methodFamilies"))
-    require(families == REQUIRED_METHOD_FAMILIES, "valid carrier method family set drifted")
+    require(families == REQUIRED_METHOD_FAMILIES, "valid NSR carrier method family set drifted")
     declaration = dotted(data, "carrier.nonAuthorityDeclaration")
-    require(isinstance(declaration, str) and "does not promote" in declaration, "valid fixture missing non-authority declaration")
+    require(isinstance(declaration, str) and "does not promote" in declaration, "valid NSR fixture missing non-authority declaration")
     authorities = dotted(data, "authority")
     for key, expected in REQUIRED_AUTHORITIES.items():
         require(authorities.get(key) == expected, f"authority mismatch for {key}")
     lifecycle = dotted(data, "replay.expectedLifecycle")
-    require("governance_decision" in lifecycle, "valid fixture must include governance_decision lifecycle step")
-    require("receipt_or_rejection" in lifecycle, "valid fixture must include receipt_or_rejection lifecycle step")
+    require("governance_decision" in lifecycle, "valid NSR fixture must include governance_decision lifecycle step")
+    require("receipt_or_rejection" in lifecycle, "valid NSR fixture must include receipt_or_rejection lifecycle step")
+
+
+def validate_valid_sr_fixture(data: dict[str, Any]) -> None:
+    require(data.get("kind") == "ChronosCarrierRegistration", "valid SR fixture wrong kind")
+    require(data.get("schemaVersion") == "0.1.0", "valid SR fixture wrong schemaVersion")
+    require(dotted(data, "carrier.status") == "candidate", "valid SR carrier must remain candidate")
+    require(
+        dotted(data, "carrier.validationState") == "human-reviewed-field-map",
+        "valid SR carrier validationState mismatch",
+    )
+    families = set(dotted(data, "carrier.methodFamilies"))
+    require(families == REQUIRED_SR_METHOD_FAMILIES, "valid SR carrier method family set drifted")
+    insertion_points = set(dotted(data, "carrier.insertionPoints"))
+    required_insertion_points = {
+        "SocioProphet/memory-mesh",
+        "SocioProphet/prophet-platform",
+        "notebook-layer",
+        "SocioProphet/ontogenesis",
+        "SocioProphet/webprotege",
+        "SocioProphet/agentplane",
+        "SocioProphet/alexandrian-academy",
+        "quantum-hamiltonian-learning-lane",
+    }
+    require(required_insertion_points <= insertion_points, "valid SR fixture missing insertion point")
+    declaration = dotted(data, "carrier.nonAuthorityDeclaration")
+    require(isinstance(declaration, str) and "does not promote equations" in declaration, "valid SR fixture missing equation non-authority declaration")
+    authorities = dotted(data, "authority")
+    for key, expected in REQUIRED_AUTHORITIES.items():
+        require(authorities.get(key) == expected, f"SR authority mismatch for {key}")
+    require(authorities.get("educationCanonAuthority") == "SocioProphet/alexandrian-academy", "SR education authority mismatch")
+    lifecycle = dotted(data, "replay.expectedLifecycle")
+    require("equation_candidate" in lifecycle, "valid SR fixture must include equation_candidate lifecycle step")
+    require("semantic_review_request" in lifecycle, "valid SR fixture must include semantic_review_request lifecycle step")
+    require("receipt_or_rejection" in lifecycle, "valid SR fixture must include receipt_or_rejection lifecycle step")
 
 
 def assert_invalid_rejected(path: Path, data: dict[str, Any]) -> None:
@@ -130,12 +184,31 @@ def assert_invalid_rejected(path: Path, data: dict[str, Any]) -> None:
         require(carrier.get("heldOutGroundingValidation") == "missing", "transduction fixture must lack held-out grounding validation")
         require(authority.get("evidenceReplayAuthority") == "missing", "transduction fixture must lack evidence replay authority")
 
+    if path.name == "invalid.equation-as-authority.json":
+        require(carrier.get("status") == "admitted", "equation fixture must try invalid admission")
+        require(carrier.get("claimStatus") == "law", "equation fixture must try law claim")
+        require(carrier.get("validationState") == "fit-metric-only", "equation fixture must expose fit-metric-only validation")
+        require(authority.get("semanticVocabularyDraft") == "bypassed", "equation fixture must bypass semantic vocabulary authority")
+
+    if path.name == "invalid.telemetry-model-as-policy.json":
+        require(carrier.get("claimStatus") == "policy", "telemetry fixture must try policy claim")
+        require(carrier.get("validationState") == "telemetry-fit-only", "telemetry fixture must expose telemetry-fit-only validation")
+        require(authority.get("policyAdmissionAuthority") == "bypassed", "telemetry fixture must bypass policy admission")
+        require(authority.get("runtimeAuthority") == "bypassed", "telemetry fixture must bypass runtime authority")
+
+    if path.name == "invalid.notebook-equation-as-ontology.json":
+        require(carrier.get("claimStatus") == "ontology_assertion", "notebook fixture must try ontology assertion")
+        require(carrier.get("validationState") == "notebook-output-only", "notebook fixture must expose notebook-output-only validation")
+        require(carrier.get("webProtegeMutation") == "direct", "notebook fixture must try direct WebProtege mutation")
+        require(authority.get("semanticVocabularyDraft") == "bypassed", "notebook fixture must bypass semantic vocabulary authority")
+
 
 def main() -> int:
-    validate_valid_fixture(load(VALID))
+    validate_valid_nsr_fixture(load(VALID_ASU_NSR))
+    validate_valid_sr_fixture(load(VALID_SR))
     for path in INVALIDS:
         assert_invalid_rejected(path, load(path))
-    print("OK: neuro-symbolic CHRONOS carrier fixtures validated")
+    print("OK: neuro-symbolic and symbolic-regression CHRONOS carrier fixtures validated")
     return 0
 
 


### PR DESCRIPTION
## Summary

Captures the symbolic-regression / equation-discovery field map as a CHRONOS sublane. This extends the neuro-symbolic evidence work with a focused law-discovery lane covering PySR, SINDy, TPSR, SNIP, LLM-SR, KAN, FunSearch-style program search, Feynman curriculum use, WebProtégé SRAssertion, and telemetry / Hamiltonian-learning insertion points.

## Changes

- Add `docs/integration/symbolic-regression-insertion-points.md`
- Add `registry/corpus-loop-v0/valid.symbolic-regression-insertion-map.json`
- Add negative fixtures:
  - `invalid.equation-as-authority.json`
  - `invalid.telemetry-model-as-policy.json`
  - `invalid.notebook-equation-as-ontology.json`
- Extend `tools/check_neurosymbolic_chronos.py` to validate the SR lane and new negative fixtures

## Claim boundary

This PR does not install SR tools, vendor papers, promote ontology/schema terms, create agents, mutate WebProtégé, or authorize runtime control.

Symbolic-regression output is treated as `EquationCandidate` / `ProgramCandidate` only until CHRONOS evidence, AgentPlane replay, Ontogenesis/WebProtégé semantic review, and any relevant policy/runtime authority admit it.

## Acceptance criteria

- Valid SR insertion map remains `candidate`, not admitted.
- SR method families and insertion points are explicit.
- Equation candidate is not law by itself.
- Telemetry-derived model is not policy by itself.
- Notebook equation is not ontology mutation by itself.
- Validator enforces all new failure modes.
