### PR TITLE
docs(integration): register TritFabric recovered work absorption

### DIFF
--- a/docs/INTEGRATION_STATUS.md
+++ b/docs/INTEGRATION_STATUS.md
@@ -47,6 +47,25 @@ facts that were previously repeated in multiple places.
 - Status: removed as an independent workspace dependency
 - Notes/content: folded into TritRPC docs during de-commingling
 
+### TritFabric recovered Atlas / Community / Serve work
+- Detailed ledger: `docs/integration/tritfabric-recovered-work-ledger-2026-05-27.md`
+- Canonical implementation owner: `SocioProphet/tritfabric`
+- SocioSphere role: estate registration, boundary routing, and follow-on propagation only
+- Integration range: TritFabric PR #9 through PR #23, excluding duplicate PR #13
+- Status: first major recovered Atlas / TritFabric / Community Learning / Serve work package absorbed downstream
+- Captured planes:
+  - framework and calculus contracts;
+  - Trit-visible promotion semantics;
+  - Network Atlas framework catalog and adapter governance;
+  - Community Learning workflows, API stubs, and stream contracts;
+  - Serve p95/inflight autoscaler core, observability, integration tests, and readiness docs.
+- Non-scope in SocioSphere: TritFabric implementation, runtime endpoints, model promotion execution, community event persistence, Serve deployment, and adapter implementation
+- Follow-on targets:
+  - `SocioProphet/ontogenesis` for stabilized ontology / SHACL vocabulary once TritFabric schemas settle
+  - `SocioProphet/prophet-platform` for product/runtime use of Community Learning and Network Atlas surfaces after gates are explicit
+  - `SocioProphet/superconscious` for mentor/learner coordination semantics only, not authority-plane ownership
+  - SociOS / SourceOS runtime repos for opt-in runtime packaging only after TritFabric readiness notes advance to runtime tranches
+
 ### Edge capabilities upstream bindings
 - Narrative binding doc: `docs/architecture/upstream-bindings-edge-capabilities.md`
 - Machine-readable baseline map: `registry/upstream-bindings-edge-capabilities.yaml`
@@ -85,3 +104,8 @@ namespace responsibilities.
 For Agent Harness Delivery Routing, treat `docs/integration/agent-harness-delivery-routing.md`
 as the routing baseline. SocioSphere records topology and owner-plane routing;
 Delivery Excellence owns delivery metrics and scoreboards.
+
+For TritFabric recovered work, treat `docs/integration/tritfabric-recovered-work-ledger-2026-05-27.md`
+as the estate registration baseline. TritFabric owns implementation and immediate
+contracts; SocioSphere owns only cross-repo status, owner-plane routing, and
+follow-on propagation records.

--- a/docs/integration/tritfabric-recovered-work-ledger-2026-05-27.md
+++ b/docs/integration/tritfabric-recovered-work-ledger-2026-05-27.md
@@ -1,0 +1,126 @@
+# TritFabric recovered work absorption ledger — 2026-05-27
+
+## Status
+
+Captured in downstream implementation repo and registered for estate governance.
+
+This ledger records that recovered Atlas / TritFabric / Community Learning / Serve Plane chat material was integrated into `SocioProphet/tritfabric` through a tranche sequence of executable contracts, validators, tests, API stubs, catalog records, and readiness documentation.
+
+Sociosphere does not reimplement the downstream work. It records estate-level absorption status, boundaries, and follow-on planes.
+
+## Downstream repo
+
+- Repository: `SocioProphet/tritfabric`
+- Integration range: PR #9 through PR #23, excluding duplicate PR #13
+- Duplicate PR: #13 closed unmerged because #12 had already landed the StatusReply / Promote contract tranche
+
+## Merged tranche map
+
+| PR | Plane | Estate status |
+|---:|---|---|
+| #9 | Recovered framework executable contracts | Merged |
+| #10 | Registry calculus promotion gates | Merged |
+| #11 | HTTP Trit-visible promotion route | Merged |
+| #12 | TriTRPC / proto StatusReply Promote contract | Merged |
+| #13 | Duplicate StatusReply Promote PR | Closed unmerged as duplicate |
+| #14 | Network Atlas framework catalog contracts | Merged |
+| #15 | Network Atlas framework governance expansion | Merged |
+| #16 | Third recovered framework catalog batch | Merged |
+| #17 | Community Learning workflow stubs | Merged |
+| #18 | Community event API stubs | Merged |
+| #19 | Community event stream contracts | Merged |
+| #20 | Serve p95/inflight autoscaler core | Merged |
+| #21 | Serve autoscaler observability metrics | Merged |
+| #22 | RouterCore / autoscaler integration tests | Merged |
+| #23 | Serve runtime deployment readiness notes | Merged |
+
+## Absorbed recovered-work planes
+
+### 1. Framework and calculus contracts
+
+TritFabric now has executable recovered-work contracts for:
+
+- community-learning Avro records;
+- JSON-LD contexts for community and model calculus terms;
+- SHACL gates for consent, license, lineage, rubric, math type, calculus operations, ledger references, and artifact references;
+- model-card promotion semantics carrying `mathType`, `calcOps`, `ledgerRef`, and `artifactRef` into JSON / JSON-LD / Turtle outputs.
+
+### 2. Trit-visible promotion semantics
+
+TritFabric now has:
+
+- HTTP `POST /v1/promote/{job_id}` structured status projection;
+- compatibility proto / gRPC `RegistryService.Promote(JobId) returns (StatusReply)`;
+- canonical contract notes that promotion failures must be protocol-visible as TRUE / MID / FALSE rather than only transport exceptions.
+
+### 3. Network Atlas catalog and framework governance
+
+TritFabric now has:
+
+- `catalog/frameworks/index.jsonl`;
+- framework catalog schema;
+- adapter scorecard schema;
+- capability descriptor schema;
+- Ray, ONNX, and Albumentations capability descriptors;
+- bounded recovered-source entries for CV, runtime, conversion, language, medical-imaging, graph-learning, neurosymbolic, and accelerator-specific candidates;
+- validator and tests for catalog, scorecards, and capabilities.
+
+Catalog entries are intake records only. They do not claim validated adapters or runtime support.
+
+### 4. Community Learning Plane
+
+TritFabric now has:
+
+- workflow schema;
+- community distillation workflow stub;
+- curriculum A/B evaluation workflow stub;
+- OPA policy stub for consent / license / lineage / rubric eligibility;
+- HTTP event intake stubs for feedback, curation, eval, proposals, and reputation;
+- stream topic contracts and fixtures for accepted feedback, curation, curriculum evaluation, and non-economic credit;
+- validators and tests.
+
+Community credit remains explicitly non-transferable and non-economic. No workflow currently trains models, mutates models, promotes artifacts, creates token obligations, or creates payout obligations.
+
+### 5. Serve Plane
+
+TritFabric now has:
+
+- dependency-light p95 / inflight router autoscaler core;
+- autoscaler observability metrics for pressure and decisions;
+- integration tests proving `RouterCore.status()` / `RouterCore.update()` compose with `RouterAutoscalerCore.step_from_status()` without Ray Serve deployment;
+- Serve runtime deployment readiness documentation.
+
+Serve work remains non-production-readiness unless a later opt-in runtime deployment tranche lands with rollback, report-only mode, and explicit gates.
+
+## Estate boundaries
+
+### Canonical implementation repo
+
+`SocioProphet/tritfabric` owns the implementation and immediate contract surfaces for this recovered work.
+
+### Sociosphere role
+
+`SocioProphet/sociosphere` records estate absorption, repo-plane boundaries, propagation requirements, and follow-on coordination.
+
+Sociosphere must not duplicate TritFabric implementation or become a second source of truth for TritFabric contracts.
+
+### Follow-on planes
+
+- `SocioProphet/ontogenesis`: promote stabilized community / model calculus / framework catalog semantics into ontology and SHACL vocabulary once TritFabric schemas settle.
+- `SocioProphet/prophet-platform`: consume Community Learning contracts and Network Atlas catalog as product/runtime capabilities only after policy and promotion gates are explicit.
+- `SocioProphet/superconscious`: consume mentor/learner/community semantics only as coordinator/advisory surfaces, not authority planes.
+- SociOS / SourceOS runtime repos: consume opt-in runtime packaging only after TritFabric runtime deployment docs advance beyond readiness notes.
+
+## Claim boundary
+
+This ledger does not claim that all recovered chat material has been exhausted.
+
+It does claim that the first major recovered Atlas / TritFabric / Community / Serve work package is no longer floating only in chat text and has been converted into version-controlled downstream artifacts with validators, tests, and claim boundaries.
+
+## Remaining estate work
+
+1. Decide when to promote stable TritFabric vocabularies into `ontogenesis`.
+2. Decide which Community Learning surfaces should become `prophet-platform` product/runtime capabilities.
+3. Decide which mentor/learner semantics belong in `superconscious` while preserving coordinator-vs-authority boundaries.
+4. Continue recovered Model Zoo catalog expansion only in bounded batches.
+5. Add explicit Sociosphere dependency/propagation entries if the manifest/lock should pin the resulting TritFabric revision.


### PR DESCRIPTION
## Summary
- add a detailed estate ledger for the recovered Atlas / TritFabric / Community Learning / Serve Plane work absorbed into `SocioProphet/tritfabric`
- update `docs/INTEGRATION_STATUS.md` with a current-state TritFabric recovered-work section
- record downstream implementation ownership, Sociosphere boundary, follow-on planes, and claim boundaries

## Why
The recovered chat material has now been converted into concrete TritFabric tranches through PR #9-#23. Sociosphere should record that estate status so the work is no longer floating in chat memory or hidden inside one implementation repo.

## Claim boundary
This PR is governance/ledger only. It does not reimplement TritFabric contracts, mutate downstream runtime behavior, or make production-readiness claims.

## Validation
- docs-only review

## Follow-on backlog
1. Decide whether the workspace manifest/lock should pin the resulting TritFabric revision.
2. Promote stable vocabulary to `ontogenesis` once TritFabric schemas settle.
3. Plan product/runtime consumption in `prophet-platform` and coordinator semantics in `superconscious`.
