### PR TITLE
docs(integration): record TritFabric workspace admission decision

### DIFF
--- a/docs/integration/tritfabric-workspace-admission-decision.md
+++ b/docs/integration/tritfabric-workspace-admission-decision.md
@@ -1,0 +1,25 @@
+# TritFabric workspace admission decision
+
+## Decision
+
+Admit TritFabric as a Sociosphere-tracked workspace component in a follow-on manifest tranche.
+
+Do not hand-edit the workspace lock in this tranche.
+
+## Basis
+
+TritFabric has absorbed the recovered Atlas, Community Learning, Network Atlas, and Serve work through the downstream tranche sequence already registered in Sociosphere.
+
+Review of the current Sociosphere workspace files shows that TritFabric is not yet a workspace dependency. Therefore there is no existing lock entry to bump.
+
+## Correct sequence
+
+1. Add TritFabric to the workspace manifest.
+2. Add TritFabric to the canonical repository registry.
+3. Regenerate the workspace lock with the Sociosphere runner.
+4. Verify the generated lock and policy checks.
+5. Commit the generated lock only after runner validation.
+
+## Boundary
+
+This document records the admission decision only. It does not materialize TritFabric, regenerate the lock, or claim runner validation.


### PR DESCRIPTION
## Summary
- record that TritFabric should be admitted as a Sociosphere-tracked workspace component
- explicitly defer lock mutation until the workspace runner can regenerate and verify the lock
- document the correct sequence: manifest entry, registry entry, runner lock update, lock verify, policy validation

## Why
Inspection showed that TritFabric is not currently present in the Sociosphere workspace manifest or lock. Since there is no existing lock entry to bump, hand-editing the lock would create false evidence. This PR records the admission decision without fabricating runner-verified state.

## Claim boundary
Decision record only. This PR does not materialize TritFabric, update the workspace lock, or claim runner validation.

## Follow-on backlog
1. Add TritFabric to `manifest/workspace.toml`.
2. Add TritFabric to `registry/canonical-repos.yaml`.
3. Regenerate and verify `manifest/workspace.lock.json` with the runner.
