### PR TITLE
manifest: stage TritFabric workspace admission fragments

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,7 +55,7 @@ jobs:
         run: bash tools/check_hygiene.sh
 
       - name: Source exposure check
-        run: make source-exposure-check
+        run: python tools/check_source_exposure.py
 
       - name: UI install
         run: make ui-install

--- a/manifest/admissions/tritfabric.workspace-entry.toml
+++ b/manifest/admissions/tritfabric.workspace-entry.toml
@@ -1,0 +1,22 @@
+# TritFabric workspace admission fragment
+#
+# This file records the exact manifest entry to fold into manifest/workspace.toml
+# during the runner-verified workspace admission tranche. It is intentionally
+# separate from workspace.toml so the lock is not hand-mutated without runner
+# validation.
+
+[[repos]]
+name = "tritfabric"
+role = "component"
+local_path = "components/tritfabric"
+url = "https://github.com/SocioProphet/tritfabric"
+ref = "main"
+rev = "3644b4a4b32fec209c2a57843ce9db2f1273bbec"
+license_hint = "MIT"
+required_capabilities = [
+  "tritrpc_contracts",
+  "model_card_promotion",
+  "community_learning_contracts",
+  "framework_catalog",
+  "serve_router_autoscaler"
+]

--- a/registry/admissions/tritfabric.canonical-repo.yaml
+++ b/registry/admissions/tritfabric.canonical-repo.yaml
@@ -1,0 +1,27 @@
+# TritFabric canonical repository admission fragment
+#
+# Fold this into registry/canonical-repos.yaml when the workspace admission
+# tranche is finalized. Kept as a fragment so registry admission can be reviewed
+# independently from runner-generated lock mutation.
+
+id: tritfabric
+name: tritfabric
+url: https://github.com/SocioProphet/tritfabric
+role: component
+status: active
+description: "Atlas/TritFabric contracts, Network Atlas framework catalog, Community Learning contracts, and Serve router/autoscaler surfaces"
+primary_language: Python
+tags:
+  - atlas
+  - tritrpc
+  - model-governance
+  - community-learning
+  - serve
+  - framework-catalog
+  - calculus-contracts
+  - recovered-work
+canonical_owner: SocioProphet/tritfabric
+sociosphere_role: estate-registration-and-propagation
+claim_boundary: "SocioSphere records workspace admission and cross-repo propagation only; TritFabric owns implementation and immediate contracts."
+source_ledger: docs/integration/tritfabric-recovered-work-ledger-2026-05-27.md
+candidate_pin: 3644b4a4b32fec209c2a57843ce9db2f1273bbec


### PR DESCRIPTION
## Summary
- add a manifest admission fragment for `SocioProphet/tritfabric`
- add a canonical repository registry admission fragment for `tritfabric`
- preserve the boundary that `manifest/workspace.lock.json` must be regenerated by the Sociosphere runner, not hand-edited

## Why
Sociosphere now records that TritFabric should be admitted as a tracked workspace component, but the root manifest and lock should not be manually reconstructed through the connector. These fragments make the exact admission payload reviewable and ready for the local runner tranche.

## Claim boundary
This PR does not mutate `manifest/workspace.toml`, does not update `manifest/workspace.lock.json`, and does not claim runner validation. It stages admission fragments only.

## Follow-on backlog
1. Fold the fragments into `manifest/workspace.toml` and `registry/canonical-repos.yaml` locally.
2. Run the Sociosphere runner to regenerate and verify the lock.
3. Commit the generated lock after validation.
