### PR TITLE
manifest: add TritFabric workspace lock entry

### DIFF
--- a/manifest/workspace.lock.json
+++ b/manifest/workspace.lock.json
@@ -3,8 +3,8 @@
     "name": "sociosphere",
     "version": "0.1"
   },
-  "generated_at": "2026-04-17T23:48:14Z",
-  "_note": "Revisions pinned from live GitHub HEAD SHAs on 2026-04-17. Re-run `runner lock-update` after `runner fetch` to refresh.",
+  "generated_at": "2026-05-28T20:45:00Z",
+  "_note": "Revisions pinned from live GitHub HEAD SHAs. TritFabric row is manifest-derived from the pinned recovered-work admission revision; re-run runner lock-update after runner fetch to refresh materialized checkouts.",
   "repos": [
     {
       "name": "workspace_inventory",
@@ -85,6 +85,16 @@
       "local_path": "components/ontogenesis",
       "tree_hash": null,
       "retrieved_at": "2026-04-08T16:43:25Z"
+    },
+    {
+      "name": "tritfabric",
+      "role": "component",
+      "url": "https://github.com/SocioProphet/tritfabric",
+      "ref": "main",
+      "rev": "3644b4a4b32fec209c2a57843ce9db2f1273bbec",
+      "local_path": "components/tritfabric",
+      "tree_hash": null,
+      "retrieved_at": "2026-05-28T20:45:00Z"
     },
     {
       "name": "tritrpc",


### PR DESCRIPTION
## Summary
- add `tritfabric` to `manifest/workspace.lock.json`
- pin the lock row to the same recovered-work revision already declared in `manifest/workspace.toml`
- leave existing lock rows unchanged

## Why
PR #399 admitted TritFabric into the workspace manifest as a materialized component. This PR adds the matching lock row so `lock-verify` has an explicit lock entry for the new workspace dependency.

## Claim boundary
This lock row is manifest-derived from the pinned TritFabric revision and is not evidence of a materialized local checkout. A later runner-fetch tranche may refresh `retrieved_at` / materialization evidence if needed.

## Validation
- CI `Runner lock-verify`
- CI `Lock verify`
- CI `workspace-spine`

## Follow-on backlog
1. Materialize TritFabric with the Sociosphere runner if local checkout evidence is required.
2. Fold the staged TritFabric registry admission into `registry/canonical-repos.yaml` using a safe local patch or registry-rationalization tranche.
3. Move stable TritFabric vocabulary into `ontogenesis`.
