### PR TITLE
Request SVF cross-repo validation observation

### DIFF
--- a/artifacts/svf/requests/cross-repo-validation.request.json
+++ b/artifacts/svf/requests/cross-repo-validation.request.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "1.0",
+  "request_id": "svf:validation-request:cross-repo:2026-05-28",
+  "owner": {
+    "repo": "SocioProphet/sociosphere",
+    "plane": "workspace-controller"
+  },
+  "purpose": "Trigger Sociosphere-owned pull-request validation for the cross-repo SVF workflow.",
+  "workflow": ".github/workflows/svf-cross-repo-validation.yml",
+  "expected_jobs": [
+    "superconscious",
+    "model-router",
+    "prophet-platform",
+    "sourceos-spec",
+    "ontogenesis",
+    "scope-d",
+    "sociosphere"
+  ],
+  "non_claims": [
+    "This request does not certify validation success.",
+    "This request does not execute validation outside GitHub Actions.",
+    "This request exists to create an observable Sociosphere PR validation surface."
+  ]
+}


### PR DESCRIPTION
## Status

Closed intentionally.

This PR was opened to force an observable GitHub Actions surface for SVF, but that was the wrong control-plane move. Sociosphere is the workspace controller, registry, selection, and stabilization plane. We should not treat it primarily as a generic cross-repo CI matrix host.

## Supersession

Superseded by the next Sociosphere-native tranche:

1. Harden `registry/sovereign-validation-fabric.yaml` validation for the fields already added downstream: `contract_refs`, `validation_command`, `required_receipt_classes`, advisory/blocking mode, and changed-path selectors.
2. Extend `tools/svf_runner.py` to produce workspace validation-state/readout artifacts from registry selection without executing downstream Actions.
3. Preserve explicit non-claims: selection is not execution, missing observations are not validation success, and advisory profiles are not blocking gates.

## Non-claim

Closing this PR does not invalidate the repo-local SVF contract work already committed across the estate. It only removes the premature CI-matrix observation path.