### PR TITLE
Observe SVF registry hardening

### DIFF
--- a/artifacts/svf/requests/registry-hardening-observation.json
+++ b/artifacts/svf/requests/registry-hardening-observation.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0",
+  "request_id": "svf:validation-request:registry-hardening:2026-05-29",
+  "repo": "SocioProphet/sociosphere",
+  "purpose": "Create an observable Sociosphere pull-request validation surface for SVF registry hardening.",
+  "changed_surfaces": [
+    "tools/validate_svf_registry.py",
+    "registry/sovereign-validation-fabric.yaml",
+    "tools/check_svf_workspace_state.py"
+  ],
+  "expected_checks": [
+    "svf-registry-validate",
+    "svf-workspace-validate",
+    "SVF Validation / sociosphere-svf"
+  ],
+  "non_claims": [
+    "This request does not certify downstream repository validation.",
+    "This request does not execute downstream SVF actions.",
+    "This request observes Sociosphere registry and workspace-state semantics only."
+  ]
+}


### PR DESCRIPTION
## Purpose

Create an observable Sociosphere pull-request validation surface after hardening `tools/validate_svf_registry.py` for `contract_refs` and `validation_command` semantics.

## Scope

This PR adds a request artifact under `artifacts/svf/requests/` to trigger the existing Sociosphere validation workflows against the hardened registry validator.

## Expected observations

- `SVF Validation / sociosphere-svf`
- `svf-registry-validate`
- `svf-workspace-validate`

## Non-claims

This PR does not certify downstream repositories.
It does not execute downstream SVF Actions.
It observes Sociosphere registry and workspace-state semantics only.