### PR TITLE
Observe environment sandbox profile validation

### DIFF
--- a/artifacts/svf/requests/environment-sandbox-profile-observation.json
+++ b/artifacts/svf/requests/environment-sandbox-profile-observation.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1.0",
+  "request_id": "environment-sandbox:validation-request:profiles:2026-05-29",
+  "repo": "SocioProphet/sociosphere",
+  "purpose": "Create an observable Sociosphere pull-request validation surface for the environment sandbox profile registry.",
+  "changed_surfaces": [
+    "registry/environment-sandbox-profiles.yaml",
+    "tools/validate_environment_sandbox_profiles.py",
+    ".github/workflows/svf-validation.yml"
+  ],
+  "expected_checks": [
+    "SVF Validation / sociosphere-svf",
+    "Validate environment sandbox profiles"
+  ],
+  "non_claims": [
+    "This request does not certify sandbox execution parity.",
+    "This request does not create or run sandbox environments.",
+    "This request validates Sociosphere environment-profile registry shape only."
+  ]
+}


### PR DESCRIPTION
## Purpose

Create an observable Sociosphere pull-request validation surface for the first environment/sandbox profile registry.

## Scope

This PR adds an observation request artifact for:

- `registry/environment-sandbox-profiles.yaml`
- `tools/validate_environment_sandbox_profiles.py`
- `.github/workflows/svf-validation.yml`

## Expected observations

- `SVF Validation / sociosphere-svf`
- `Validate environment sandbox profiles`

## Non-claims

This PR does not certify sandbox execution parity.
It does not create or run sandbox environments.
It validates Sociosphere environment-profile registry shape only.