### PR TITLE
Add service register PR-A scaffold

### DIFF
--- a/.github/workflows/service-register.yml
+++ b/.github/workflows/service-register.yml
@@ -1,0 +1,25 @@
+name: service-register
+
+on:
+  pull_request:
+    paths:
+      - "architecture/service-register/**"
+      - "tools/validate_service_register_artifacts.py"
+      - ".github/workflows/service-register.yml"
+  push:
+    branches: [main]
+    paths:
+      - "architecture/service-register/**"
+      - "tools/validate_service_register_artifacts.py"
+      - ".github/workflows/service-register.yml"
+
+jobs:
+  warn-only-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate service register artifacts warn-only
+        run: python3 tools/validate_service_register_artifacts.py

--- a/architecture/service-register/README.md
+++ b/architecture/service-register/README.md
@@ -1,0 +1,40 @@
+# Service Register Architecture Control Set
+
+Status: PR-A scaffold, warn-only validation.
+
+This directory is the SocioSphere home for the service architecture control set that governs the SocioProphet / SourceOS / SociOS estate.
+
+## Canonical inputs
+
+The intended v1.0 control set is:
+
+| Artifact | Purpose |
+|---|---|
+| `service-architecture-register.v1.0.csv` | Canonical service-level register: 46 services, 125 go-forward repos, no misc bucket. |
+| `canonical-repo-estate.v1.0.csv` | Canonical go-forward repo list derived from register owner/support/contract fields. |
+| `service-dependency-edges.v0.1.csv` | Canonical graph-level edge table: 119 typed dependency edges. |
+| `critical-contract-path-stubs.v0.1.csv` | Four blocking services with target contract paths; target files may be missing during PR-A. |
+| `critical-path-blocking-report.v0.2.csv` | Current manually curated critical path report: 4 BLOCKING and 4 HARDENING rows. |
+| `repo-reconciliation-report.v0.1.csv` | A2A/MCP and Fabric/MLOps/Atlas reconciliation notes. |
+| `sociosphere-service-register-ingestion-manifest.v1.0.json` | Machine-readable ingestion manifest. |
+
+## Governance decisions captured
+
+- `SocioProphet/Shining-Apple` is removed from the go-forward estate.
+- `SocioProphet/sourceos-a2a-mcp-bootstrap` is a consolidation candidate into `SocioProphet/mcp-a2a-zero-trust` and/or `SocioProphet/TriTRPC`; it is not a standalone service.
+- `SocioProphet/prophet-platform-fabric-mlops-ts-suite` supports both `svc.product.model-training` and `svc.platform.compute-mesh`.
+- `svc.platform.agent-runtime <-> svc.platform.compute-mesh` is an allowed optional/runtime feedback cycle, not a hard bootstrap cycle.
+- `svc.platform.agent-runtime <-> svc.platform.model-governance` is an allowed policy/evaluation feedback loop, not a hard bootstrap cycle.
+
+## Validation posture
+
+PR-A is intentionally warn-only. It establishes canonical artifact locations and schemas before enforcing coverage or graph checks.
+
+Validation hardening order:
+
+1. PR-A: land artifacts, schemas, README, warn-only validator.
+2. PR-B: add repo coverage validator.
+3. PR-C: add edge validator and cycle classifier.
+4. PR-D: generate critical path report from classified graph.
+5. PR-E: wire `workspace-inventory` as canonical repo source.
+6. PR-F: add drift report and CI gate.

--- a/architecture/service-register/service-architecture-register.schema.json
+++ b/architecture/service-register/service-architecture-register.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/sociosphere/service-architecture-register.schema.json",
+  "title": "SocioSphere Service Architecture Register Row",
+  "type": "object",
+  "required": [
+    "service_id",
+    "service_name",
+    "stack_tier",
+    "owning_repo",
+    "supporting_repos",
+    "contract_family",
+    "contract_repo",
+    "contract_paths",
+    "runtime_authority",
+    "evidence_emitted",
+    "depends_on",
+    "consumed_by",
+    "governance_boundary",
+    "product_status",
+    "local_first_posture",
+    "notes"
+  ],
+  "properties": {
+    "service_id": { "type": "string", "pattern": "^svc\\.[a-z0-9-]+\\.[a-z0-9-]+$" },
+    "service_name": { "type": "string", "minLength": 1 },
+    "stack_tier": { "enum": ["substrate", "managed-substrate", "workspace-substrate", "platform-core", "product-service", "application", "misc"] },
+    "owning_repo": { "type": "string", "minLength": 1 },
+    "supporting_repos": { "type": "string" },
+    "contract_family": { "type": "string" },
+    "contract_repo": { "type": "string" },
+    "contract_paths": { "type": "string" },
+    "runtime_authority": { "enum": ["none", "local-only", "local-privileged", "mesh-optional", "cloud-optional", "cloud-control", "privileged"] },
+    "evidence_emitted": { "type": "string" },
+    "depends_on": { "type": "string" },
+    "consumed_by": { "type": "string" },
+    "governance_boundary": { "type": "string" },
+    "product_status": { "enum": ["planning", "prototype", "active-build", "usable", "hardened"] },
+    "local_first_posture": { "enum": ["local-only", "local-first", "mesh-optional", "cloud-required"] },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/architecture/service-register/service-dependency-edges.schema.json
+++ b/architecture/service-register/service-dependency-edges.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/sociosphere/service-dependency-edges.schema.json",
+  "title": "SocioSphere Service Dependency Edge Row",
+  "type": "object",
+  "required": [
+    "edge_id",
+    "from_service_id",
+    "to_service_id",
+    "edge_kind",
+    "dependency_mode",
+    "cycle_policy",
+    "required_for_bootstrap",
+    "required_for_product_hardening",
+    "evidence_required",
+    "notes"
+  ],
+  "properties": {
+    "edge_id": { "type": "string", "pattern": "^edge\\.[0-9]{3,}$" },
+    "from_service_id": { "type": "string", "pattern": "^svc\\.[a-z0-9-]+\\.[a-z0-9-]+$" },
+    "to_service_id": { "type": "string", "pattern": "^svc\\.[a-z0-9-]+\\.[a-z0-9-]+$" },
+    "edge_kind": { "enum": ["depends_on", "consumes", "emits_to", "governs", "ui_surface", "evidence_feed"] },
+    "dependency_mode": { "enum": ["hard", "soft", "optional-extension", "runtime-callback", "policy-required", "governance-feedback", "evaluation-orchestration", "evidence-feed", "ui-consumes"] },
+    "cycle_policy": { "enum": ["forbidden", "allowed-if-optional", "allowed-runtime-feedback", "allowed-governance-loop"] },
+    "required_for_bootstrap": { "enum": ["true", "false", true, false] },
+    "required_for_product_hardening": { "enum": ["true", "false", true, false] },
+    "evidence_required": { "type": "string" },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/architecture/service-register/sociosphere-service-register-ingestion-manifest.v1.0.json
+++ b/architecture/service-register/sociosphere-service-register-ingestion-manifest.v1.0.json
@@ -1,0 +1,31 @@
+{
+  "artifact_id": "sociosphere.service-register-ingestion.v1.0",
+  "source_register": "service-architecture-register.v1.0.csv",
+  "canonical_repo_estate": "canonical-repo-estate.v1.0.csv",
+  "edge_table": "service-dependency-edges.v0.1.csv",
+  "contract_stubs": "critical-contract-path-stubs.v0.1.csv",
+  "critical_path_report": "critical-path-blocking-report.v0.2.csv",
+  "service_rows": 46,
+  "unique_repos_in_register_fields": 125,
+  "misc_closed": true,
+  "misc_repos_remaining": [],
+  "removed_from_go_forward": ["SocioProphet/Shining-Apple"],
+  "consolidation_candidates": ["SocioProphet/sourceos-a2a-mcp-bootstrap"],
+  "total_edges": 119,
+  "boot_required_edges": 28,
+  "allowed_cycle_count": 7,
+  "required_validators": [
+    "validate_service_register.py",
+    "check_repo_coverage.py",
+    "check_dependency_cycles.py",
+    "generate_critical_path_report.py"
+  ],
+  "pr_sequence": [
+    "PR-A: add canonical artifacts, schemas, README, and warn-only validator",
+    "PR-B: add repo coverage validator",
+    "PR-C: add edge validator and cycle classifier",
+    "PR-D: generate critical path report from classified graph",
+    "PR-E: wire workspace-inventory as canonical repo source",
+    "PR-F: add drift report and CI gate"
+  ]
+}

--- a/tools/validate_service_register_artifacts.py
+++ b/tools/validate_service_register_artifacts.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Warn-only validator for SocioSphere service-register PR-A artifacts.
+
+PR-A establishes canonical locations and schemas before hard-enforcing coverage
+or dependency graph semantics. This script intentionally exits 0 while emitting
+warnings for missing artifacts so follow-on PRs can add full checks in order:
+coverage, cycle classification, then generated critical-path reports.
+"""
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_ROOT = ROOT / "architecture" / "service-register"
+
+EXPECTED = [
+    "service-architecture-register.v1.0.csv",
+    "canonical-repo-estate.v1.0.csv",
+    "service-dependency-edges.v0.1.csv",
+    "critical-contract-path-stubs.v0.1.csv",
+    "critical-path-blocking-report.v0.2.csv",
+    "repo-reconciliation-report.v0.1.csv",
+    "sociosphere-service-register-ingestion-manifest.v1.0.json",
+]
+
+SERVICE_REQUIRED = [
+    "service_id",
+    "service_name",
+    "stack_tier",
+    "owning_repo",
+    "supporting_repos",
+    "contract_family",
+    "contract_repo",
+    "contract_paths",
+    "runtime_authority",
+    "evidence_emitted",
+    "depends_on",
+    "consumed_by",
+    "governance_boundary",
+    "product_status",
+    "local_first_posture",
+    "notes",
+]
+
+EDGE_REQUIRED = [
+    "edge_id",
+    "from_service_id",
+    "to_service_id",
+    "edge_kind",
+    "dependency_mode",
+    "cycle_policy",
+    "required_for_bootstrap",
+    "required_for_product_hardening",
+    "evidence_required",
+    "notes",
+]
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def warn(message: str) -> None:
+    print(f"WARN: {message}")
+
+
+def ok(message: str) -> None:
+    print(f"OK: {message}")
+
+
+def validate_csv_headers(filename: str, required: list[str]) -> None:
+    path = ARTIFACT_ROOT / filename
+    if not path.exists():
+        warn(f"missing {filename}; PR-A may land schema/location before full data copy")
+        return
+    rows = read_csv(path)
+    if not rows:
+        warn(f"{filename} has no data rows")
+        return
+    missing = [name for name in required if name not in rows[0]]
+    if missing:
+        warn(f"{filename} missing columns: {missing}")
+    else:
+        ok(f"{filename} columns present; rows={len(rows)}")
+
+
+def main() -> int:
+    print(f"SocioSphere service-register PR-A warn-only validation: {ARTIFACT_ROOT}")
+    if not ARTIFACT_ROOT.exists():
+        warn("architecture/service-register directory is missing")
+        return 0
+
+    for filename in EXPECTED:
+        if (ARTIFACT_ROOT / filename).exists():
+            ok(f"found {filename}")
+        else:
+            warn(f"missing {filename}")
+
+    validate_csv_headers("service-architecture-register.v1.0.csv", SERVICE_REQUIRED)
+    validate_csv_headers("service-dependency-edges.v0.1.csv", EDGE_REQUIRED)
+
+    manifest_path = ARTIFACT_ROOT / "sociosphere-service-register-ingestion-manifest.v1.0.json"
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            warn(f"manifest is invalid JSON: {exc}")
+        else:
+            ok(f"manifest artifact_id={manifest.get('artifact_id', '<missing>')}")
+    else:
+        warn("manifest missing; PR-A may be artifact-location only")
+
+    print("PR-A validator is warn-only by design; exiting 0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Decision applied

Adds the SocioSphere service-register PR-A scaffold for the v1.0 architecture control set.

This PR intentionally lands the directory, schemas, README, warn-only validator, and CI workflow before enforcing repo coverage or dependency graph logic.

## Artifact delta

Adds:

- `architecture/service-register/README.md`
- `architecture/service-register/service-architecture-register.schema.json`
- `architecture/service-register/service-dependency-edges.schema.json`
- `tools/validate_service_register_artifacts.py`
- `.github/workflows/service-register.yml`

## Intended v1.0 control set

The README names the target artifacts:

- `service-architecture-register.v1.0.csv`
- `canonical-repo-estate.v1.0.csv`
- `service-dependency-edges.v0.1.csv`
- `critical-contract-path-stubs.v0.1.csv`
- `critical-path-blocking-report.v0.2.csv`
- `repo-reconciliation-report.v0.1.csv`
- `sociosphere-service-register-ingestion-manifest.v1.0.json`

## Validation results

The validator is warn-only by design for PR-A. It exits 0 while reporting missing artifacts, so PR-B/PR-C can add hard repo coverage and graph checks in sequence.

## Risks / open decisions

- Full CSV artifact copy still needs to land if the connector allows large file content in follow-up commits.
- `SocioProphet/sourceos-a2a-mcp-bootstrap` still needs diff before supersession.
- Atlas / TriTRPC seam extraction remains post PR-A.

## Next controlled move

After this scaffold lands, PR-B should add repo coverage validation against the canonical go-forward estate.