### PR TITLE
Add service register repo coverage checker

### DIFF
--- a/.github/workflows/service-register.yml
+++ b/.github/workflows/service-register.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "architecture/service-register/**"
       - "tools/validate_service_register_artifacts.py"
+      - "tools/check_service_register_repo_coverage.py"
       - ".github/workflows/service-register.yml"
   push:
     branches: [main]
     paths:
       - "architecture/service-register/**"
       - "tools/validate_service_register_artifacts.py"
+      - "tools/check_service_register_repo_coverage.py"
       - ".github/workflows/service-register.yml"
 
 jobs:
@@ -23,3 +25,5 @@ jobs:
           python-version: "3.11"
       - name: Validate service register artifacts warn-only
         run: python3 tools/validate_service_register_artifacts.py
+      - name: Check service register repo coverage warn-only
+        run: python3 tools/check_service_register_repo_coverage.py

--- a/tools/check_service_register_repo_coverage.py
+++ b/tools/check_service_register_repo_coverage.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+print('repo coverage checker placeholder')

--- a/tools/check_service_register_repo_coverage.py
+++ b/tools/check_service_register_repo_coverage.py
@@ -1,2 +1,88 @@
 #!/usr/bin/env python3
-print('repo coverage checker placeholder')
+"""Warn-only repo coverage checker for the SocioSphere service register."""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_ROOT = ROOT / "architecture" / "service-register"
+REGISTER = ARTIFACT_ROOT / "service-architecture-register.v1.0.csv"
+CANONICAL_REPOS = ARTIFACT_ROOT / "canonical-repo-estate.v1.0.csv"
+EXPECTED_SERVICE_ROWS = 46
+EXPECTED_REPO_COUNT = 125
+REPO_FIELDS = ("owning_repo", "supporting_repos", "contract_repo")
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def split_values(value: str | None) -> list[str]:
+    if not value or value == "-":
+        return []
+    return [part.strip() for part in value.split(",") if part.strip() and part.strip() != "-"]
+
+
+def repo_key(row: dict[str, str]) -> str:
+    return row.get("repo") or row.get("repo_full_name") or row.get("repository") or ""
+
+
+def warn(message: str) -> None:
+    print(f"WARN: {message}")
+
+
+def ok(message: str) -> None:
+    print(f"OK: {message}")
+
+
+def main() -> int:
+    print("SocioSphere service-register repo coverage check")
+    if not REGISTER.exists():
+        warn(f"missing {REGISTER.relative_to(ROOT)}; coverage cannot run yet")
+        return 0
+
+    service_rows = read_csv(REGISTER)
+    if len(service_rows) == EXPECTED_SERVICE_ROWS:
+        ok(f"service rows={len(service_rows)}")
+    else:
+        warn(f"service row count {len(service_rows)} != expected {EXPECTED_SERVICE_ROWS}")
+
+    mapped_repos: set[str] = set()
+    for row in service_rows:
+        for field in REPO_FIELDS:
+            for value in split_values(row.get(field)):
+                if "/" in value and value != "TBD":
+                    mapped_repos.add(value)
+
+    if not CANONICAL_REPOS.exists():
+        warn(f"missing {CANONICAL_REPOS.relative_to(ROOT)}; mapped repo count={len(mapped_repos)}")
+        return 0
+
+    canonical_rows = read_csv(CANONICAL_REPOS)
+    canonical_repos = {repo_key(row).strip() for row in canonical_rows if repo_key(row).strip()}
+    missing = sorted(canonical_repos - mapped_repos)
+    extra = sorted(mapped_repos - canonical_repos)
+
+    if len(canonical_repos) == EXPECTED_REPO_COUNT:
+        ok(f"canonical repos={len(canonical_repos)}")
+    else:
+        warn(f"canonical repo count {len(canonical_repos)} != expected {EXPECTED_REPO_COUNT}")
+
+    if missing:
+        warn(f"missing coverage for {len(missing)} repos: {missing}")
+    else:
+        ok("no missing canonical repo coverage")
+
+    if extra:
+        warn(f"register references {len(extra)} noncanonical repos: {extra}")
+    else:
+        ok("no noncanonical repo references")
+
+    print("PR-B coverage checker is warn-only by design; exiting 0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Decision applied

Adds PR-B for the SocioSphere service-register lane: a warn-only repo coverage checker that verifies the canonical service register and repo estate once the CSV artifacts land.

This follows PR-A and remains scoped to `SocioProphet/sociosphere` only.

## Artifact delta

Adds:

- `tools/check_service_register_repo_coverage.py`

Updates:

- `.github/workflows/service-register.yml`

## Validation behavior

The checker is warn-only for this tranche. It expects:

- `service-architecture-register.v1.0.csv`
- `canonical-repo-estate.v1.0.csv`

It reports:

- service row count vs expected 46
- canonical repo count vs expected 125
- missing canonical repo coverage
- noncanonical repo references

If artifacts are not present, it reports warnings and exits 0. This keeps PR-B ordered before hard enforcement and before workspace-inventory becomes the source of truth.

## Risks / open decisions

- CSV artifacts are still absent from the repository because prior connector writes for large CSV artifacts were blocked.
- This PR intentionally prepares the coverage lane without enforcing it yet.

## Next controlled move

PR-C: add service dependency edge validator and cycle classifier after PR-B merges.