### PR TITLE
Bind service register to workspace inventory source

### DIFF
--- a/.github/workflows/service-register.yml
+++ b/.github/workflows/service-register.yml
@@ -8,6 +8,7 @@ on:
       - "tools/check_service_register_repo_coverage.py"
       - "tools/check_service_dependency_cycles.py"
       - "tools/generate_service_critical_path_report.py"
+      - "tools/check_workspace_inventory_binding.py"
       - ".github/workflows/service-register.yml"
   push:
     branches: [main]
@@ -17,6 +18,7 @@ on:
       - "tools/check_service_register_repo_coverage.py"
       - "tools/check_service_dependency_cycles.py"
       - "tools/generate_service_critical_path_report.py"
+      - "tools/check_workspace_inventory_binding.py"
       - ".github/workflows/service-register.yml"
 
 jobs:
@@ -35,3 +37,5 @@ jobs:
         run: python3 tools/check_service_dependency_cycles.py
       - name: Generate service critical path report warn-only
         run: python3 tools/generate_service_critical_path_report.py
+      - name: Check workspace-inventory binding warn-only
+        run: python3 tools/check_workspace_inventory_binding.py

--- a/architecture/service-register/workspace-inventory-source.v0.1.json
+++ b/architecture/service-register/workspace-inventory-source.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "artifact_id": "sociosphere.workspace-inventory-source.v0.1",
+  "status": "warn-only-binding",
+  "source_repository": "SocioProphet/workspace-inventory",
+  "source_artifact_candidates": [
+    "architecture/repo-estate/canonical-repo-estate.v1.0.csv",
+    "canonical-repo-estate.v1.0.csv",
+    "workspace-inventory/repositories.csv",
+    "inventory/repositories.csv"
+  ],
+  "consumer_repository": "SocioProphet/sociosphere",
+  "consumer_artifacts": [
+    "architecture/service-register/service-architecture-register.v1.0.csv",
+    "architecture/service-register/canonical-repo-estate.v1.0.csv"
+  ],
+  "expected_canonical_repo_count": 125,
+  "binding_mode": "external-source-pending",
+  "validator_mode": "warn-only",
+  "notes": "PR-E records workspace-inventory as the canonical repo-estate source for future coverage and drift checks. The validator remains warn-only until workspace-inventory exports a stable artifact path."
+}

--- a/tools/check_workspace_inventory_binding.py
+++ b/tools/check_workspace_inventory_binding.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Warn-only workspace-inventory binding checker.
+
+PR-E records `SocioProphet/workspace-inventory` as the future canonical repo
+estate source. This checker remains local and warn-only until the external repo
+exports a stable artifact path and CI is allowed to fetch it.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_ROOT = ROOT / "architecture" / "service-register"
+BINDING = ARTIFACT_ROOT / "workspace-inventory-source.v0.1.json"
+LOCAL_CANONICAL = ARTIFACT_ROOT / "canonical-repo-estate.v1.0.csv"
+EXPECTED_REPO_COUNT = 125
+
+
+def warn(message: str) -> None:
+    print(f"WARN: {message}")
+
+
+def ok(message: str) -> None:
+    print(f"OK: {message}")
+
+
+def count_csv_rows(path: Path) -> int:
+    with path.open(encoding="utf-8") as handle:
+        # Header minus blank lines.
+        lines = [line for line in handle.read().splitlines() if line.strip()]
+    return max(0, len(lines) - 1)
+
+
+def main() -> int:
+    print("SocioSphere workspace-inventory source binding check")
+    if not BINDING.exists():
+        warn(f"missing {BINDING.relative_to(ROOT)}")
+        return 0
+
+    try:
+        binding = json.loads(BINDING.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        warn(f"invalid binding JSON: {exc}")
+        return 0
+
+    source_repo = binding.get("source_repository")
+    if source_repo == "SocioProphet/workspace-inventory":
+        ok("workspace-inventory source repository declared")
+    else:
+        warn(f"unexpected source_repository={source_repo!r}")
+
+    if binding.get("validator_mode") == "warn-only":
+        ok("validator_mode=warn-only")
+    else:
+        warn(f"unexpected validator_mode={binding.get('validator_mode')!r}")
+
+    if not LOCAL_CANONICAL.exists():
+        warn(f"local canonical repo artifact absent: {LOCAL_CANONICAL.relative_to(ROOT)}")
+        print("PR-E binding checker is warn-only by design; exiting 0")
+        return 0
+
+    row_count = count_csv_rows(LOCAL_CANONICAL)
+    if row_count == EXPECTED_REPO_COUNT:
+        ok(f"local canonical repo rows={row_count}")
+    else:
+        warn(f"local canonical repo rows {row_count} != expected {EXPECTED_REPO_COUNT}")
+
+    print("PR-E binding checker is warn-only by design; exiting 0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Decision applied

Adds PR-E for the SocioSphere service-register lane: record `SocioProphet/workspace-inventory` as the canonical repo-estate source for future coverage and drift reporting.

This follows PR-D and remains scoped to `SocioProphet/sociosphere` only.

## Artifact delta

Adds:

- `architecture/service-register/workspace-inventory-source.v0.1.json`
- `tools/check_workspace_inventory_binding.py`

Updates:

- `.github/workflows/service-register.yml`

## Validation behavior

The checker is warn-only for this tranche. It validates:

- the binding manifest exists
- `source_repository` is `SocioProphet/workspace-inventory`
- `validator_mode` is `warn-only`
- local canonical repo artifact row count if present

This keeps the service architecture in SocioSphere while making `workspace-inventory` the future source of truth for repo estate coverage.

## Risks / open decisions

- The external `workspace-inventory` export path is not enforced yet.
- CSV artifacts are still absent from this repo because prior connector writes for large CSV artifacts were blocked.
- PR-F should add drift reporting and eventual CI gate behavior.

## Next controlled move

PR-F: add drift report scaffolding and CI gate policy, still warn-only until the artifact source path is stable.