### PR TITLE
Enforce service register artifact count validation

### DIFF
--- a/.github/workflows/service-register.yml
+++ b/.github/workflows/service-register.yml
@@ -26,8 +26,10 @@ on:
       - ".github/workflows/service-register.yml"
 
 jobs:
-  warn-only-validate:
+  validate:
     runs-on: ubuntu-latest
+    env:
+      SERVICE_REGISTER_STRICT: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -35,15 +37,15 @@ jobs:
           python-version: "3.11"
       - name: Rehydrate service register artifacts
         run: python3 tools/rehydrate_service_register_artifacts.py
-      - name: Validate service register artifacts warn-only
+      - name: Validate service register artifacts
         run: python3 tools/validate_service_register_artifacts.py
-      - name: Check service register repo coverage warn-only
+      - name: Check service register repo coverage
         run: python3 tools/check_service_register_repo_coverage.py
-      - name: Check service dependency cycles warn-only
+      - name: Check service dependency cycles
         run: python3 tools/check_service_dependency_cycles.py
-      - name: Generate service critical path report warn-only
+      - name: Generate service critical path report
         run: python3 tools/generate_service_critical_path_report.py
-      - name: Check workspace-inventory binding warn-only
+      - name: Check workspace inventory binding
         run: python3 tools/check_workspace_inventory_binding.py
-      - name: Generate service register drift report warn-only
+      - name: Generate service register drift report
         run: python3 tools/generate_service_register_drift_report.py

--- a/architecture/service-register/service-register-gate-policy.v0.1.json
+++ b/architecture/service-register/service-register-gate-policy.v0.1.json
@@ -1,8 +1,12 @@
 {
   "artifact_id": "sociosphere.service-register-gate-policy.v0.1",
-  "status": "warn-only",
-  "gate_mode": "warn-only",
-  "hard_gate_enabled": false,
+  "status": "artifact-count-gate-enabled",
+  "gate_mode": "artifact-count-strict",
+  "hard_gate_enabled": true,
+  "hard_gate_scope": [
+    "artifact_presence",
+    "artifact_row_counts"
+  ],
   "required_artifacts_before_hard_gate": [
     "service-architecture-register.v1.0.csv",
     "canonical-repo-estate.v1.0.csv",
@@ -14,15 +18,19 @@
     "artifact_path_status": "pending-stable-path"
   },
   "warn_only_checks": [
-    "artifact_presence",
     "repo_coverage",
     "dependency_cycles",
     "critical_path_generation",
-    "workspace_inventory_binding",
-    "drift_report"
+    "workspace_inventory_binding"
+  ],
+  "hard_gate_checks": [
+    "all_required_artifacts_present",
+    "service_row_count_is_46",
+    "canonical_repo_count_is_125",
+    "dependency_edge_count_is_119",
+    "critical_contract_stub_count_is_4"
   ],
   "future_hard_gate_checks": [
-    "all_required_artifacts_present",
     "canonical_repo_count_matches_workspace_inventory",
     "no_missing_repo_coverage",
     "no_noncanonical_repo_references",
@@ -30,5 +38,5 @@
     "critical_path_report_generated",
     "no_new_blocking_services_without_acknowledgement"
   ],
-  "notes": "PR-F captures drift report and CI gate policy in warn-only mode. Hard gates remain disabled until artifact CSVs are present and workspace-inventory exports a stable canonical repo-estate artifact."
+  "notes": "Artifact presence and row-count checks are now strict. Repo coverage, dependency cycles, critical-path semantics, and workspace-inventory drift remain warn-only until workspace-inventory exports a stable canonical repo-estate artifact."
 }

--- a/tools/generate_service_register_drift_report.py
+++ b/tools/generate_service_register_drift_report.py
@@ -1,14 +1,10 @@
 #!/usr/bin/env python3
-"""Generate a warn-only service-register drift report.
-
-PR-F adds drift-report scaffolding and CI gate policy. The script remains
-warn-only until the service register CSVs and workspace-inventory export path are
-stable.
-"""
+"""Generate and optionally enforce service-register drift checks."""
 from __future__ import annotations
 
 import csv
 import json
+import os
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -68,9 +64,11 @@ def main() -> int:
     print("SocioSphere service-register drift report")
     policy = load_policy()
     gate_mode = str(policy.get("gate_mode", "warn-only")) if policy else "warn-only"
+    strict_env = os.environ.get("SERVICE_REGISTER_STRICT", "0") == "1"
+    strict = strict_env or bool(policy.get("hard_gate_enabled"))
 
     rows: list[dict[str, str]] = []
-    add_row(rows, "gate_mode", "ok" if gate_mode == "warn-only" else "warn", "warn-only", gate_mode, "hard gates remain disabled in PR-F")
+    add_row(rows, "gate_mode", "ok" if gate_mode in {"warn-only", "artifact-count-strict"} else "warn", "warn-only|artifact-count-strict", gate_mode, "strict artifact-count gate may be enabled by policy or SERVICE_REGISTER_STRICT=1")
 
     artifacts = [
         ("service_rows", REGISTER, EXPECTED["service_rows"]),
@@ -81,11 +79,11 @@ def main() -> int:
     for check_id, path, expected in artifacts:
         actual_count = count_csv_rows(path)
         if actual_count is None:
-            add_row(rows, check_id, "warn", str(expected), "missing", f"{path.relative_to(ROOT)} is not present")
+            add_row(rows, check_id, "fail" if strict else "warn", str(expected), "missing", f"{path.relative_to(ROOT)} is not present")
         elif actual_count == expected:
             add_row(rows, check_id, "ok", str(expected), str(actual_count), "count matches expected")
         else:
-            add_row(rows, check_id, "warn", str(expected), str(actual_count), "count mismatch")
+            add_row(rows, check_id, "fail" if strict else "warn", str(expected), str(actual_count), "count mismatch")
 
     OUT.parent.mkdir(parents=True, exist_ok=True)
     with OUT.open("w", newline="", encoding="utf-8") as handle:
@@ -94,13 +92,18 @@ def main() -> int:
         writer.writeheader()
         writer.writerows(rows)
 
+    failures = sum(1 for row in rows if row["status"] == "fail")
     warnings = sum(1 for row in rows if row["status"] == "warn")
-    if warnings:
+    if failures:
+        warn(f"drift failures={failures}; output={OUT.relative_to(ROOT)}")
+    elif warnings:
         warn(f"drift warnings={warnings}; output={OUT.relative_to(ROOT)}")
     else:
         ok(f"no drift warnings; output={OUT.relative_to(ROOT)}")
 
-    print("PR-F drift checker is warn-only by design; exiting 0")
+    if failures:
+        return 1
+    print("service-register drift check complete")
     return 0
 
 


### PR DESCRIPTION
## Decision applied

Promotes the service-register drift lane from scaffold-only to artifact-count validation.

## Artifact delta

Updates:

- `architecture/service-register/service-register-gate-policy.v0.1.json`
- `tools/generate_service_register_drift_report.py`
- `.github/workflows/service-register.yml`

## Validation behavior

The drift report now fails when required service-register artifacts are missing or have incorrect row counts.

Strict checks:

- service register rows = 46
- canonical repo rows = 125
- dependency edge rows = 119
- critical contract stub rows = 4

Repo coverage, dependency-cycle semantics, critical-path semantics, and workspace-inventory drift remain warning-only until `workspace-inventory` exports a stable artifact path.

## Next controlled move

Inspect workflow results after merge and patch any rehydration/count defects.