### PR TITLE
docs: record TritFabric propagation ledger

### DIFF
--- a/docs/integration/tritfabric-propagation-ledger-2026-05-31.md
+++ b/docs/integration/tritfabric-propagation-ledger-2026-05-31.md
@@ -1,0 +1,103 @@
+# TritFabric downstream propagation ledger — 2026-05-31
+
+## Status
+
+Downstream propagation recorded for the first TritFabric recovered-work absorption package.
+
+This ledger supplements `docs/integration/tritfabric-recovered-work-ledger-2026-05-27.md`. It records where the stabilized TritFabric surfaces were propagated after the initial downstream implementation and estate admission work.
+
+## Source package
+
+- Implementation owner: `SocioProphet/tritfabric`
+- Estate registration owner: `SocioProphet/sociosphere`
+- Initial TritFabric absorption range: PR #9 through PR #23, excluding duplicate PR #13
+- Sociosphere registration: PR #395 through PR #402
+
+## Propagation map
+
+| Repo | PR(s) | Propagation surface | Status |
+|---|---:|---|---|
+| `SocioProphet/ontogenesis` | #110 | RDF/OWL/JSON-LD/SHACL vocabulary and supplemental registry | Merged |
+| `SocioProphet/prophet-platform` | #503 | Product-consumption planning contract | Merged |
+| `SocioProphet/prophet-platform` | #515 | Local-pre-infrastructure product API stubs | Merged |
+| `SocioProphet/prophet-platform` | #516 | Standalone API-stub runner | Merged |
+| `SocioProphet/prophet-platform` | #518 | Focused API-stub workflow | Merged |
+| `SocioProphet/superconscious` | #58 | Advisory-only consumption boundary | Merged |
+| `SocioProphet/superconscious` | #61 | Named advisory-boundary Makefile target | Merged |
+
+## Resulting ownership state
+
+### TritFabric
+
+`SocioProphet/tritfabric` remains the implementation and immediate contract owner for:
+
+- Community Learning workflow, API, and stream contracts;
+- Network Atlas framework catalog and capability descriptors;
+- model-card promotion evidence semantics;
+- Trit-visible promotion status semantics;
+- Serve router/autoscaler readiness and tests.
+
+### Sociosphere
+
+`SocioProphet/sociosphere` owns estate tracking and workspace routing:
+
+- recovered-work absorption ledger;
+- workspace admission decision;
+- workspace manifest entry;
+- workspace lock row;
+- staged/effective canonical registry admission.
+
+Sociosphere does not reimplement TritFabric contracts or product/runtime surfaces.
+
+### Ontogenesis
+
+`SocioProphet/ontogenesis` owns the semantic vocabulary layer:
+
+- TritFabric domain ontology;
+- SHACL gates for model-card, Community Learning, credit, framework catalog, and Serve readiness boundaries;
+- JSON-LD context;
+- conforming example;
+- supplemental registry entry.
+
+### Prophet Platform
+
+`SocioProphet/prophet-platform` owns governed product-consumption surfaces only:
+
+- consumption plan;
+- machine-readable consumption contract;
+- local-pre-infrastructure API stubs;
+- standalone API-stub runner;
+- focused workflow.
+
+Prophet Platform does not become the authority plane for TritFabric implementation, Ontogenesis vocabulary, or Sociosphere estate registration.
+
+### Superconscious
+
+`SocioProphet/superconscious` owns advisory/coordinator consumption only:
+
+- advisory-consumption boundary documentation;
+- JSON Schema;
+- valid and authority-drift invalid fixtures;
+- checker and pytest coverage;
+- named Makefile target.
+
+Superconscious must not perform model promotion, final Community Learning eligibility, adapter validation, economic credit creation, Serve deployment, contract override, or execution authorization.
+
+## Known validation caveats
+
+Prophet Platform broad `ci/build-web` and full `validate` lanes remained red during the TritFabric consumption PRs. The TritFabric-specific contract/stub/governance workflows passed, and the merged Prophet Platform changes were bounded to planning/contracts/API-stub/tooling/workflow files.
+
+Superconscious `Certificate Doctrine CI` remained red during advisory-boundary PRs. Trust Surface, SVF Validation, Superconscious CI, and lawful-learning checks passed. The certificate lane failure was not attributable to TritFabric advisory-boundary files based on available connector logs and artifacts.
+
+## Claim boundary
+
+This ledger records propagation and ownership routing only.
+
+It does not claim runtime production readiness, model promotion execution, adapter support, community-workflow execution, Serve deployment, economic-credit issuance, or authority-plane transfer.
+
+## Remaining work
+
+1. Rationalize Sociosphere canonical registry folding so staged/effective admissions can be safely folded into `registry/canonical-repos.yaml` without connector-driven full-file truncation risk.
+2. Decide whether TritFabric runtime packaging belongs in SociOS / SourceOS only after runtime deployment readiness advances beyond report-only mode.
+3. Expand Prophet Platform product UI/readiness labels only after the product API-stub surface stabilizes.
+4. Keep Superconscious advisory-only unless a separate authority review explicitly changes the estate boundary.


### PR DESCRIPTION
## Summary
- add a supplemental TritFabric propagation ledger
- record downstream propagation into Ontogenesis, Prophet Platform, and Superconscious
- keep this as documentation only

## Validation
- docs-only review
