### PR TITLE
Record SourceOS interaction registration validation note

### DIFF
--- a/registry/sourceos-interaction-substrate.validation-note.md
+++ b/registry/sourceos-interaction-substrate.validation-note.md
@@ -1,0 +1,15 @@
+# SourceOS interaction substrate registration note
+
+This note records the local SocioSphere registration artifacts for the SourceOS interaction substrate.
+
+Registry file:
+
+- `registry/sourceos-interaction-substrate.yaml`
+
+Validation tool:
+
+- `tools/validate_sourceos_interaction_substrate_registration.py`
+
+Workflow file:
+
+- `.github/workflows/sourceos-interaction-substrate-registration.yml`

--- a/registry/sourceos-interaction-substrate.yaml
+++ b/registry/sourceos-interaction-substrate.yaml
@@ -1,6 +1,7 @@
 version: "0.1.0"
 updated_at: "2026-05-31"
 status: "registered"
+registration_note: "SocioSphere workspace-level status and routing record for the SourceOS interaction substrate."
 
 canonical_contract:
   repo: "SourceOS-Linux/sourceos-spec"


### PR DESCRIPTION
## Summary

Adds a small registry note pointing to the SourceOS interaction substrate registration artifacts in SocioSphere.

This PR is documentation-only and exists to exercise the registration validation workflow after the workflow was added to the repository.

## Files

- `registry/sourceos-interaction-substrate.validation-note.md`

## Related

- `registry/sourceos-interaction-substrate.yaml`
- `tools/validate_sourceos_interaction_substrate_registration.py`
- `.github/workflows/sourceos-interaction-substrate-registration.yml`
- SocioProphet/sociosphere#425