### PR TITLE
Probe service register workflow

### DIFF
--- a/.github/workflows/service-register.yml
+++ b/.github/workflows/service-register.yml
@@ -1,5 +1,7 @@
 name: service-register
 
+# Observable CI probe: service-register
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Superseded by a fresh observable CI probe after fixing `tools/check_service_dependency_cycles.py` on main. This probe found the failure boundary: `service-register` failed at `Check service dependency cycles`; the fix is now on main at `50a034b30a7f7544a8120bd3f529ed38855b580b`. Closing this stale probe instead of merging it.