### PR TITLE
Probe service register workflow after cycle fix

### DIFF
--- a/.github/workflows/service-register.yml
+++ b/.github/workflows/service-register.yml
@@ -1,5 +1,7 @@
 name: service-register
 
+# Observable CI probe: service-register v2
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Superseded by #431 as the newer observable service-register probe.

Content inspected before closure:

- This PR only adds the workflow comment `# Observable CI probe: service-register v2`.
- Its purpose was to make the pull_request-triggered `service-register` workflow visible through the connector.
- Run inspection confirmed the useful result: `service-register` failed while the other visible checks were green.
- #431 repeats the same probe role for the newer report-only cycle update and is the active probe to retain.

No implementation content is being discarded.