### PR TITLE
Probe service register workflow after report-only cycle update

### DIFF
--- a/.github/workflows/service-register.yml
+++ b/.github/workflows/service-register.yml
@@ -1,5 +1,7 @@
 name: service-register
 
+# Observable CI probe: service-register v3
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Closed as probe-complete after inspection.

Content was not discarded: this PR intentionally changed only a workflow comment to make the pull_request-triggered `service-register` workflow visible through the connector.

Captured result from head `91abee42d0e40a3aa51433900039ba21286b6504`:

- `service-register` failed
- visible non-service-register checks were green, including `validate`, `ui-check`, `standards-validate`, `compliance`, `workspace-spine`, `SVF Validation`, and lattice/geospatial workflows

No implementation content exists to merge. The actionable remediation is to repair the underlying `service-register` workflow/lane, not merge this probe comment PR.