### PR TITLE
Add computational artifact registry validation and health report

### DIFF
--- a/docs/COMPUTATIONAL_ARTIFACT_REGISTRY.md
+++ b/docs/COMPUTATIONAL_ARTIFACT_REGISTRY.md
@@ -1,0 +1,65 @@
+# Computational Artifact Registry
+
+Sociosphere owns the registry and mesh-governance layer for Prophet Computational Knowledge Plane artifacts. It records governed computational artifacts, health states, change propagation, slash-topic bindings, and promotion guardrails.
+
+Sociosphere does not implement downstream runtime execution, model serving, search indexing, or policy enforcement. Those remain in their respective owner repositories.
+
+## Registry
+
+Registry path:
+
+```text
+registry/computational-artifacts.yaml
+```
+
+Key fields:
+
+| Field | Meaning |
+|---|---|
+| `spec.safetyClasses` | `advisory`, `bounded`, `privileged`, `prohibited` |
+| `spec.healthModel.freshnessStates` | `fresh`, `stale`, `drifted`, `blocked`, `deprecated` |
+| `spec.propagationRules` | Change-trigger to notification mapping |
+| `spec.governance.slashTopicBinding` | `/computational-artifacts` governance binding |
+| `spec.registryEntries` | Per-artifact registry entries |
+
+## Health states
+
+| State | Meaning |
+|---|---|
+| `fresh` | Required signals present, no drift detected |
+| `stale` | Required evidence is not yet produced |
+| `drifted` | Runtime profile or contract changed since attestation |
+| `blocked` | Artifact requires review or is prohibited |
+| `deprecated` | Artifact is retired and consumers must migrate |
+
+## Propagation triggers
+
+| Trigger | Meaning |
+|---|---|
+| `artifactContractChanged` | Artifact contract changed |
+| `runtimeProfileChanged` | Runtime profile changed |
+| `policyChanged` | Policy binding changed |
+| `evidenceChanged` | Required evidence changed |
+| `safetyClassPrivileged` | Auto-promotion blocked; human review required |
+| `safetyClassProhibited` | Auto-promotion blocked; human review required; rejected on ingest |
+
+## Slash-topic governance
+
+Computational artifact events are routed through `/computational-artifacts`, governed by `SocioProphet/slash-topics`.
+
+Subtopics:
+
+- `/computational-artifacts/registry`
+- `/computational-artifacts/health`
+- `/computational-artifacts/propagation`
+- `/computational-artifacts/governance`
+
+## Validation
+
+```bash
+python3 tools/validate_computational_artifacts.py
+python3 tools/runner/artifact_health_report.py
+python3 tools/runner/artifact_health_report.py --table
+```
+
+The report emits artifact id, owner repo, runtime profile, safety class, evidence status, downstream consumers, health state, and whether auto-promotion is blocked.

--- a/registry/computational-artifacts.yaml
+++ b/registry/computational-artifacts.yaml
@@ -74,9 +74,34 @@ spec:
         - SocioProphet/prophet-platform
         - SocioProphet/gaia-world-model
         - SocioProphet/delivery-excellence
+    - when: policyChanged
+      notifyRepos:
+        - SocioProphet/prophet-platform
+        - SocioProphet/policy-fabric
+        - SocioProphet/guardrail-fabric
+        - SocioProphet/agentplane
+    - when: evidenceChanged
+      notifyRepos:
+        - SocioProphet/prophet-platform
+        - SocioProphet/sherlock-search
+        - SocioProphet/delivery-excellence
     - when: safetyClassPrivileged
       requireHumanReview: true
       blockAutoPromotion: true
+    - when: safetyClassProhibited
+      requireHumanReview: true
+      blockAutoPromotion: true
+      rejectOnIngest: true
+  governance:
+    slashTopicBinding:
+      namespace: /computational-artifacts
+      topics:
+        - /computational-artifacts/registry
+        - /computational-artifacts/health
+        - /computational-artifacts/propagation
+        - /computational-artifacts/governance
+      governingRepo: SocioProphet/slash-topics
+      approvalRequired: true
   healthModel:
     freshnessStates:
       - fresh

--- a/tools/runner/artifact_health_report.py
+++ b/tools/runner/artifact_health_report.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Emit a deterministic health report for registry/computational-artifacts.yaml."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY = ROOT / "registry" / "computational-artifacts.yaml"
+
+
+def now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def _load_computational_artifacts() -> dict[str, Any]:
+    if yaml is None or not REGISTRY.exists():
+        return {}
+    try:
+        data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _artifact_health_state(entry: dict[str, Any]) -> str:
+    if entry.get("safetyClass") == "prohibited":
+        return "blocked"
+    status = entry.get("status", "")
+    if status == "deprecated":
+        return "deprecated"
+    if status == "seed":
+        return "stale"
+    if status == "drifted":
+        return "drifted"
+    if status == "blocked":
+        return "blocked"
+    if status in ("fresh", "active", "promoted"):
+        return "fresh"
+    return "stale"
+
+
+def artifact_health_report_payload(registry: dict[str, Any]) -> dict[str, Any]:
+    entries = ((registry.get("spec") or {}).get("registryEntries") or [])
+    rows: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        safety_cls = entry.get("safetyClass", "")
+        rows.append({
+            "id": entry.get("id"),
+            "ownerRepo": entry.get("ownerRepo"),
+            "runtimeProfile": entry.get("runtimeProfile"),
+            "safetyClass": safety_cls,
+            "evidenceStatus": entry.get("status", "unknown"),
+            "requiredEvidence": entry.get("requiredEvidence") or [],
+            "downstreamConsumers": entry.get("downstreamConsumers") or [],
+            "slashTopics": entry.get("slashTopics") or [],
+            "healthState": _artifact_health_state(entry),
+            "autoPromotionBlocked": safety_cls in {"privileged", "prohibited"},
+        })
+    return {
+        "kind": "ComputationalArtifactHealthReport",
+        "generatedAt": now_iso(),
+        "registryVersion": (registry.get("metadata") or {}).get("version", "unknown"),
+        "artifacts": rows,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="-", metavar="FILE")
+    parser.add_argument("--table", action="store_true")
+    args = parser.parse_args(argv)
+    registry = _load_computational_artifacts()
+    if not registry:
+        print("ERR: could not load registry/computational-artifacts.yaml (ensure PyYAML is installed)", file=sys.stderr)
+        return 2
+    payload = artifact_health_report_payload(registry)
+    if args.table:
+        header = f"{'id':32s} {'ownerRepo':36s} {'safetyClass':12s} {'healthState':10s} {'evidenceStatus':14s}"
+        print(header)
+        print("-" * len(header))
+        for artifact in payload["artifacts"]:
+            blocked = " [NO-AUTO-PROMOTE]" if artifact["autoPromotionBlocked"] else ""
+            print(
+                f"{str(artifact['id'] or '-'):32s} "
+                f"{str(artifact['ownerRepo'] or '-'):36s} "
+                f"{str(artifact['safetyClass'] or '-'):12s} "
+                f"{str(artifact['healthState'] or '-'):10s} "
+                f"{str(artifact['evidenceStatus'] or '-'):14s}{blocked}"
+            )
+        return 0
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output == "-":
+        print(text, end="")
+    else:
+        Path(args.output).write_text(text, encoding="utf-8")
+        print(f"[artifact-health-report] wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_computational_artifacts.py
+++ b/tools/tests/test_computational_artifacts.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY = ROOT / "registry" / "computational-artifacts.yaml"
+
+_runner_spec = importlib.util.spec_from_file_location(
+    "artifact_health_report",
+    ROOT / "tools" / "runner" / "artifact_health_report.py",
+)
+_runner = importlib.util.module_from_spec(_runner_spec)  # type: ignore[arg-type]
+if "artifact_health_report" not in sys.modules:
+    sys.modules["artifact_health_report"] = _runner
+_runner_spec.loader.exec_module(_runner)  # type: ignore[union-attr]
+
+try:
+    import yaml as _yaml
+    _REGISTRY_DATA = _yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+    _YAML_AVAILABLE = True
+except ImportError:
+    _REGISTRY_DATA = {}
+    _YAML_AVAILABLE = False
+
+
+def test_validate_computational_artifacts_passes() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "validate_computational_artifacts.py")],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "OK:" in result.stdout
+
+
+def test_registry_has_required_health_states() -> None:
+    if not _YAML_AVAILABLE:
+        return
+    states = set(_REGISTRY_DATA["spec"]["healthModel"]["freshnessStates"])
+    for expected in ("fresh", "stale", "drifted", "blocked", "deprecated"):
+        assert expected in states
+
+
+def test_registry_has_required_propagation_triggers() -> None:
+    if not _YAML_AVAILABLE:
+        return
+    triggers = {rule["when"] for rule in _REGISTRY_DATA["spec"]["propagationRules"]}
+    for expected in (
+        "artifactContractChanged",
+        "runtimeProfileChanged",
+        "policyChanged",
+        "evidenceChanged",
+        "safetyClassPrivileged",
+        "safetyClassProhibited",
+    ):
+        assert expected in triggers
+
+
+def test_registry_privileged_prohibited_block_auto_promotion() -> None:
+    if not _YAML_AVAILABLE:
+        return
+    for rule in _REGISTRY_DATA["spec"]["propagationRules"]:
+        if rule["when"] in ("safetyClassPrivileged", "safetyClassProhibited"):
+            assert rule.get("blockAutoPromotion") is True
+            assert rule.get("requireHumanReview") is True
+
+
+def test_registry_has_slash_topic_governance() -> None:
+    if not _YAML_AVAILABLE:
+        return
+    binding = _REGISTRY_DATA["spec"]["governance"]["slashTopicBinding"]
+    assert isinstance(binding["namespace"], str)
+    assert binding["topics"]
+    assert isinstance(binding["governingRepo"], str)
+
+
+def test_registry_entries_have_required_fields() -> None:
+    if not _YAML_AVAILABLE:
+        return
+    required = {"id", "ownerRepo", "runtimeProfile", "safetyClass", "downstreamConsumers", "requiredEvidence"}
+    for entry in _REGISTRY_DATA["spec"]["registryEntries"]:
+        for field in required:
+            assert field in entry
+
+
+def test_artifact_health_state_seed_is_stale() -> None:
+    assert _runner._artifact_health_state({"safetyClass": "bounded", "status": "seed"}) == "stale"
+
+
+def test_artifact_health_state_prohibited_is_blocked() -> None:
+    assert _runner._artifact_health_state({"safetyClass": "prohibited", "status": "fresh"}) == "blocked"
+
+
+def test_artifact_health_report_payload_structure() -> None:
+    if not _YAML_AVAILABLE:
+        return
+    payload = _runner.artifact_health_report_payload(_REGISTRY_DATA)
+    assert payload["kind"] == "ComputationalArtifactHealthReport"
+    assert payload["artifacts"]
+    first = payload["artifacts"][0]
+    for field in ("id", "ownerRepo", "runtimeProfile", "safetyClass", "evidenceStatus", "downstreamConsumers", "healthState", "autoPromotionBlocked"):
+        assert field in first
+
+
+def test_artifact_health_report_runner_command() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "runner" / "artifact_health_report.py")],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    report = json.loads(result.stdout)
+    assert report["kind"] == "ComputationalArtifactHealthReport"
+    assert report["artifacts"]

--- a/tools/validate_computational_artifacts.py
+++ b/tools/validate_computational_artifacts.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Validate registry/computational-artifacts.yaml."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "registry" / "computational-artifacts.yaml"
+
+REQUIRED_FRESHNESS_STATES = {"fresh", "stale", "drifted", "blocked", "deprecated"}
+REQUIRED_PROPAGATION_TRIGGERS = {
+    "artifactContractChanged",
+    "runtimeProfileChanged",
+    "policyChanged",
+    "evidenceChanged",
+    "safetyClassPrivileged",
+    "safetyClassProhibited",
+}
+REQUIRED_SAFETY_CLASSES = {"advisory", "bounded", "privileged", "prohibited"}
+REQUIRED_ENTRY_FIELDS = {"id", "ownerRepo", "runtimeProfile", "safetyClass", "downstreamConsumers", "requiredEvidence"}
+
+
+def fail(message: str) -> int:
+    print(f"ERR: {message}", file=sys.stderr)
+    return 1
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def require_dict(obj: Any, key: str, ctx: str) -> dict[str, Any]:
+    val = obj.get(key) if isinstance(obj, dict) else None
+    require(isinstance(val, dict), f"{ctx}.{key} must be a mapping")
+    return val  # type: ignore[return-value]
+
+
+def require_list(obj: Any, key: str, ctx: str) -> list[Any]:
+    val = obj.get(key) if isinstance(obj, dict) else None
+    require(isinstance(val, list), f"{ctx}.{key} must be a list")
+    return val  # type: ignore[return-value]
+
+
+def main() -> int:
+    if yaml is None:
+        return fail("PyYAML is required: pip install pyyaml")
+    try:
+        data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+        require(isinstance(data, dict), "registry must be a YAML mapping")
+        require(data.get("apiVersion") == "sociosphere.socioprophet.org/v1alpha1", "invalid apiVersion")
+        require(data.get("kind") == "ComputationalArtifactRegistry", "invalid kind")
+        metadata = require_dict(data, "metadata", "root")
+        require(isinstance(metadata.get("name"), str), "metadata.name must be a string")
+        require(isinstance(metadata.get("version"), str), "metadata.version must be a string")
+        spec = require_dict(data, "spec", "root")
+        safety_classes = require_dict(spec, "safetyClasses", "spec")
+        missing_safety = sorted(REQUIRED_SAFETY_CLASSES - set(safety_classes))
+        require(not missing_safety, f"spec.safetyClasses missing: {missing_safety}")
+        for safety_class in ("privileged", "prohibited"):
+            default_review = safety_classes[safety_class].get("defaultReview")
+            require(
+                default_review in ("human-required", "blocked"),
+                f"spec.safetyClasses.{safety_class}.defaultReview must be human-required or blocked",
+            )
+        health_model = require_dict(spec, "healthModel", "spec")
+        freshness = set(require_list(health_model, "freshnessStates", "spec.healthModel"))
+        missing_states = sorted(REQUIRED_FRESHNESS_STATES - freshness)
+        require(not missing_states, f"spec.healthModel.freshnessStates missing: {missing_states}")
+        require_list(health_model, "requiredSignals", "spec.healthModel")
+        prop_rules = require_list(spec, "propagationRules", "spec")
+        actual_triggers = {rule.get("when") for rule in prop_rules if isinstance(rule, dict)}
+        missing_triggers = sorted(REQUIRED_PROPAGATION_TRIGGERS - actual_triggers)
+        require(not missing_triggers, f"spec.propagationRules missing triggers: {missing_triggers}")
+        for rule in prop_rules:
+            if not isinstance(rule, dict):
+                continue
+            if rule.get("when") in ("safetyClassPrivileged", "safetyClassProhibited"):
+                require(rule.get("blockAutoPromotion") is True, f"{rule.get('when')} must block auto-promotion")
+                require(rule.get("requireHumanReview") is True, f"{rule.get('when')} must require human review")
+        governance = require_dict(spec, "governance", "spec")
+        slash_binding = require_dict(governance, "slashTopicBinding", "spec.governance")
+        require(isinstance(slash_binding.get("namespace"), str), "slashTopicBinding.namespace must be a string")
+        require_list(slash_binding, "topics", "spec.governance.slashTopicBinding")
+        require(isinstance(slash_binding.get("governingRepo"), str), "slashTopicBinding.governingRepo must be a string")
+        entries = require_list(spec, "registryEntries", "spec")
+        require(entries, "spec.registryEntries must not be empty")
+        seen_ids: set[str] = set()
+        for entry in entries:
+            require(isinstance(entry, dict), "each registryEntry must be a mapping")
+            entry_id = entry.get("id", "<unknown>")
+            require(entry_id not in seen_ids, f"duplicate registryEntry id: {entry_id}")
+            seen_ids.add(entry_id)
+            for field in REQUIRED_ENTRY_FIELDS:
+                require(field in entry, f"registryEntry '{entry_id}' missing required field: {field}")
+            require(entry.get("safetyClass") in safety_classes, f"registryEntry '{entry_id}' has unknown safetyClass")
+            require(isinstance(entry.get("downstreamConsumers"), list) and entry["downstreamConsumers"], f"registryEntry '{entry_id}' downstreamConsumers must be non-empty list")
+    except FileNotFoundError:
+        return fail(f"missing registry file: {REGISTRY}")
+    except ValueError as exc:
+        return fail(str(exc))
+
+    print(f"OK: validated computational-artifacts registry ({len(entries)} entries)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Clean replacement for stale, non-mergeable #308.

This preserves the intended computational artifact registry lane while avoiding stale Makefile or large-runner edits that could delete current-main content.

## Scope

- Adds `docs/COMPUTATIONAL_ARTIFACT_REGISTRY.md`.
- Adds `tools/validate_computational_artifacts.py`.
- Adds `tools/tests/test_computational_artifacts.py`.
- Adds standalone `tools/runner/artifact_health_report.py`.
- Updates `registry/computational-artifacts.yaml` with:
  - `policyChanged` propagation.
  - `evidenceChanged` propagation.
  - `safetyClassProhibited` guardrail.
  - `/computational-artifacts` slash-topic governance binding.

## Deliberate deviation from #308

The stale #308 branch added `artifact-health-report` as a subcommand inside `tools/runner/runner.py` and wired a Makefile target.

During cleanup, branch comparison caught that the stale replay path would delete current-main Makefile content. This replacement therefore preserves the health-report behavior as a standalone CLI:

```bash
python3 tools/runner/artifact_health_report.py
python3 tools/runner/artifact_health_report.py --table
```

Makefile wiring and canonical `tools/runner/runner.py` subcommand integration can be added later from a local checkout or patch-safe tool path.

## Validation expectation

```bash
python3 tools/validate_computational_artifacts.py
python3 tools/runner/artifact_health_report.py
python3 tools/runner/artifact_health_report.py --table
pytest tools/tests/test_computational_artifacts.py
```

## Supersedes

Supersedes #308 after this PR is reviewed and accepted.