### PR TITLE
Probe service register after edge-kind fix

### DIFF
--- a/.github/workflows/service-register.yml
+++ b/.github/workflows/service-register.yml
@@ -1,5 +1,7 @@
 name: service-register
 
+# Observable CI probe: service-register after edge-kind fix
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Closed as probe-complete.

This PR intentionally changed only a service-register workflow comment to force observable pull_request-triggered CI. It was not implementation content and should not be merged.

Outcome captured: after the edge_kind checker fix, the service-register lane advanced beyond dependency validation and exposed the next workspace-inventory binding issue.