### PR TITLE
docs: update TritFabric propagation ledger for UI labels

### DIFF
--- a/docs/integration/tritfabric-propagation-ledger-2026-05-31.md
+++ b/docs/integration/tritfabric-propagation-ledger-2026-05-31.md
@@ -22,6 +22,7 @@ This ledger supplements `docs/integration/tritfabric-recovered-work-ledger-2026-
 | `SocioProphet/prophet-platform` | #515 | Local-pre-infrastructure product API stubs | Merged |
 | `SocioProphet/prophet-platform` | #516 | Standalone API-stub runner | Merged |
 | `SocioProphet/prophet-platform` | #518 | Focused API-stub workflow | Merged |
+| `SocioProphet/prophet-platform` | #553 | UI/readiness label contract and validator | Merged |
 | `SocioProphet/superconscious` | #58 | Advisory-only consumption boundary | Merged |
 | `SocioProphet/superconscious` | #61 | Named advisory-boundary Makefile target | Merged |
 
@@ -67,7 +68,8 @@ Sociosphere does not reimplement TritFabric contracts or product/runtime surface
 - machine-readable consumption contract;
 - local-pre-infrastructure API stubs;
 - standalone API-stub runner;
-- focused workflow.
+- focused workflow;
+- UI/readiness label contract and validator.
 
 Prophet Platform does not become the authority plane for TritFabric implementation, Ontogenesis vocabulary, or Sociosphere estate registration.
 
@@ -85,7 +87,7 @@ Superconscious must not perform model promotion, final Community Learning eligib
 
 ## Known validation caveats
 
-Prophet Platform broad `ci/build-web` and full `validate` lanes remained red during the TritFabric consumption PRs. The TritFabric-specific contract/stub/governance workflows passed, and the merged Prophet Platform changes were bounded to planning/contracts/API-stub/tooling/workflow files.
+Prophet Platform broad validation lanes have had intermittent unrelated failures during the TritFabric consumption PRs. The TritFabric-specific contract, stub, workflow, UI-label, and governance checks passed, and the merged Prophet Platform changes were bounded to planning/contracts/API-stub/tooling/workflow/label-contract files.
 
 Superconscious `Certificate Doctrine CI` remained red during advisory-boundary PRs. Trust Surface, SVF Validation, Superconscious CI, and lawful-learning checks passed. The certificate lane failure was not attributable to TritFabric advisory-boundary files based on available connector logs and artifacts.
 
@@ -99,5 +101,5 @@ It does not claim runtime production readiness, model promotion execution, adapt
 
 1. Rationalize Sociosphere canonical registry folding so staged/effective admissions can be safely folded into `registry/canonical-repos.yaml` without connector-driven full-file truncation risk.
 2. Decide whether TritFabric runtime packaging belongs in SociOS / SourceOS only after runtime deployment readiness advances beyond report-only mode.
-3. Expand Prophet Platform product UI/readiness labels only after the product API-stub surface stabilizes.
+3. Expand Prophet Platform product UI components only after the readiness label contract stabilizes.
 4. Keep Superconscious advisory-only unless a separate authority review explicitly changes the estate boundary.


### PR DESCRIPTION
## Summary
- update the TritFabric propagation ledger with Prophet Platform #553
- record the UI/readiness label contract and validator as propagated product-consumption surface
- revise remaining work to point toward UI component implementation after label-contract stabilization

## Claim boundary
Docs/status only. No runtime, product API, registry, workspace, ontology, model-promotion, Serve, or authority-plane changes.

## Validation
- docs-only review
