### PR TITLE
Probe service register after MCP A2A checker fix

### DIFF
--- a/.github/workflows/service-register.yml
+++ b/.github/workflows/service-register.yml
@@ -1,5 +1,7 @@
 name: service-register
 
+# Observable CI probe: service-register after MCP/A2A checker fix
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Closed as probe-complete.

This PR intentionally changed only a service-register workflow comment to force observable pull_request-triggered CI. It was not implementation content and should not be merged.

Outcome captured: the MCP/A2A checker case-insensitivity patch alone was not sufficient; the artifact also needed explicit Ed25519 evidence in the canonical row.