### PR TITLE
Probe latest service register spine

### DIFF
--- a/.github/workflows/service-register.yml
+++ b/.github/workflows/service-register.yml
@@ -1,5 +1,7 @@
 name: service-register
 
+# Observable CI probe: latest service-register spine
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Closed as probe-complete.

This PR intentionally changed only a service-register workflow comment to force observable pull_request-triggered CI. It was not implementation content and should not be merged.

Outcome captured: full service-register lane passed on head 2e19f547a6573a956410cb4351293879c5d134d7 after dependency edge-kind, 122-repo workspace-inventory binding, and MCP/A2A evidence fixes.