### PR TITLE
Add workspace inventory disposition metadata

### DIFF
--- a/.github/workflows/workspace-dispositions.yml
+++ b/.github/workflows/workspace-dispositions.yml
@@ -1,0 +1,38 @@
+name: Workspace Dispositions
+
+on:
+  pull_request:
+    paths:
+      - 'manifest/workspace.dispositions.json'
+      - 'manifest/workspace.lock.json'
+      - 'tools/validate_workspace_dispositions.py'
+      - '.github/workflows/workspace-dispositions.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-workspace-dispositions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Validate workspace dispositions
+        run: |
+          mkdir -p reports
+          python3 tools/validate_workspace_dispositions.py > reports/workspace-dispositions-validation.json
+          python3 -m json.tool reports/workspace-dispositions-validation.json >/dev/null
+          cat reports/workspace-dispositions-validation.json
+
+      - name: Upload validation report
+        uses: actions/upload-artifact@v4
+        with:
+          name: workspace-dispositions-validation
+          path: reports/workspace-dispositions-validation.json

--- a/manifest/workspace.dispositions.json
+++ b/manifest/workspace.dispositions.json
@@ -1,0 +1,159 @@
+{
+  "schema_version": "sociosphere.workspace-dispositions.v0",
+  "source_issue": "SocioProphet/sociosphere#439",
+  "generated_at": "2026-06-02T18:25:00Z",
+  "policy": {
+    "purpose": "Track inventory disposition without changing manifest membership, refs, or pins.",
+    "allowed_first_pr_changes": [
+      "add disposition metadata",
+      "add validation",
+      "add reporting"
+    ],
+    "forbidden_first_pr_changes": [
+      "delete manifest entries",
+      "rename manifest entries",
+      "move pins",
+      "claim full-estate lock completion"
+    ],
+    "default_unresolved_action": "hold_for_confirmation"
+  },
+  "dispositions": [
+    {
+      "name": "tritfabric",
+      "status": "pin_drift_review_required",
+      "source_issue": 451,
+      "current_action": "preserve_pin",
+      "notes": "Pinned dependency drifts from current main; do not bump without explicit pin review."
+    },
+    {
+      "name": "tritrpc",
+      "status": "pin_drift_review_required",
+      "source_issue": 451,
+      "current_action": "preserve_pin",
+      "notes": "Pinned protocol dependency drifts from current main; do not bump without explicit pin review."
+    },
+    {
+      "name": "knowledge-graph",
+      "status": "ref_reconciliation_required",
+      "source_issue": 451,
+      "current_action": "verify_ref_before_manifest_change",
+      "notes": "Declared main ref did not resolve; verify default branch or intended ref before editing manifest."
+    },
+    {
+      "name": "hdt_app",
+      "status": "alias_or_stale_pending_confirmation",
+      "source_issue": 451,
+      "current_action": "hold_for_confirmation",
+      "candidate_successor": "human_digital_twin",
+      "notes": "Repository lookup returned 404; may be stale alias, planned/private repo, or retired surface."
+    },
+    {
+      "name": "human_digital_twin",
+      "status": "retain_candidate_canonical",
+      "source_issue": 451,
+      "current_action": "retain",
+      "notes": "Repository resolves and is candidate canonical HDT surface."
+    },
+    {
+      "name": "connector-github",
+      "status": "planned_or_stale_connector_stub_pending_confirmation",
+      "source_issue": 452,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "connector-gitlab",
+      "status": "planned_or_stale_connector_stub_pending_confirmation",
+      "source_issue": 452,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "connector-jira",
+      "status": "planned_or_stale_connector_stub_pending_confirmation",
+      "source_issue": 452,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "connector-kafka",
+      "status": "planned_or_stale_connector_stub_pending_confirmation",
+      "source_issue": 452,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "connector-slack",
+      "status": "planned_or_stale_connector_stub_pending_confirmation",
+      "source_issue": 452,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "configs",
+      "status": "planned_or_stale_adapter_pending_confirmation",
+      "source_issue": 452,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "dev_api",
+      "status": "planned_or_stale_service_stub_pending_confirmation",
+      "source_issue": 452,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "asr-service",
+      "status": "planned_or_stale_service_stub_pending_confirmation",
+      "source_issue": 452,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "embeddings-service",
+      "status": "planned_or_stale_service_stub_pending_confirmation",
+      "source_issue": 452,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "event-bus",
+      "status": "planned_or_stale_service_stub_pending_confirmation",
+      "source_issue": 452,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "data-pipeline",
+      "status": "candidate_successor_pending_confirmation",
+      "source_issue": 452,
+      "current_action": "hold_for_confirmation",
+      "candidate_successors": [
+        "datakit",
+        "argo-dataflow"
+      ],
+      "notes": "Candidate adjacent repositories are not confirmed semantic replacements."
+    },
+    {
+      "name": "socioprophet_integration",
+      "status": "stale_or_merged_pending_confirmation",
+      "source_issue": 453,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "runbooks",
+      "status": "stale_or_uncreated_pending_confirmation",
+      "source_issue": 453,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "onboarding-docs",
+      "status": "stale_or_uncreated_pending_confirmation",
+      "source_issue": 453,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "architecture-docs",
+      "status": "stale_or_uncreated_pending_confirmation",
+      "source_issue": 453,
+      "current_action": "hold_for_confirmation"
+    },
+    {
+      "name": "api-specs",
+      "status": "stale_or_uncreated_pending_confirmation",
+      "source_issue": 453,
+      "current_action": "hold_for_confirmation"
+    }
+  ]
+}

--- a/tools/validate_workspace_dispositions.py
+++ b/tools/validate_workspace_dispositions.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Validate workspace disposition metadata.
+
+This validator is intentionally offline. It does not resolve network refs and it
+must not mutate the workspace manifest. It only checks that disposition metadata
+is well-formed and refers to declared workspace repos.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DISPOSITIONS_PATH = ROOT / "manifest" / "workspace.dispositions.json"
+LOCK_PATH = ROOT / "manifest" / "workspace.lock.json"
+
+ALLOWED_STATUSES = {
+    "pin_drift_review_required",
+    "ref_reconciliation_required",
+    "alias_or_stale_pending_confirmation",
+    "retain_candidate_canonical",
+    "planned_or_stale_connector_stub_pending_confirmation",
+    "planned_or_stale_adapter_pending_confirmation",
+    "planned_or_stale_service_stub_pending_confirmation",
+    "candidate_successor_pending_confirmation",
+    "stale_or_merged_pending_confirmation",
+    "stale_or_uncreated_pending_confirmation",
+}
+
+ALLOWED_ACTIONS = {
+    "preserve_pin",
+    "retain",
+    "verify_ref_before_manifest_change",
+    "hold_for_confirmation",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} root must be a JSON object")
+    return data
+
+
+def declared_names() -> set[str]:
+    lock = load_json(LOCK_PATH)
+    repos = lock.get("repos")
+    if not isinstance(repos, list):
+        raise ValueError("workspace lock repos must be a list")
+    names: set[str] = set()
+    for repo in repos:
+        if not isinstance(repo, dict):
+            raise ValueError("workspace lock repo entries must be objects")
+        name = repo.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("workspace lock repo entry missing non-empty name")
+        if name in names:
+            raise ValueError(f"duplicate workspace lock repo name: {name}")
+        names.add(name)
+    return names
+
+
+def validate() -> dict[str, Any]:
+    declared = declared_names()
+    data = load_json(DISPOSITIONS_PATH)
+
+    schema_version = data.get("schema_version")
+    if schema_version != "sociosphere.workspace-dispositions.v0":
+        raise ValueError(f"unexpected schema_version: {schema_version!r}")
+
+    dispositions = data.get("dispositions")
+    if not isinstance(dispositions, list):
+        raise ValueError("dispositions must be a list")
+
+    seen: set[str] = set()
+    status_counts: dict[str, int] = {}
+    for index, entry in enumerate(dispositions):
+        if not isinstance(entry, dict):
+            raise ValueError(f"disposition entry {index} must be an object")
+
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"disposition entry {index} missing non-empty name")
+        if name in seen:
+            raise ValueError(f"duplicate disposition name: {name}")
+        if name not in declared:
+            raise ValueError(f"disposition name not present in workspace lock: {name}")
+        seen.add(name)
+
+        status = entry.get("status")
+        if status not in ALLOWED_STATUSES:
+            raise ValueError(f"{name}: unsupported status {status!r}")
+        status_counts[str(status)] = status_counts.get(str(status), 0) + 1
+
+        action = entry.get("current_action")
+        if action not in ALLOWED_ACTIONS:
+            raise ValueError(f"{name}: unsupported current_action {action!r}")
+
+        source_issue = entry.get("source_issue")
+        if not isinstance(source_issue, int) or source_issue <= 0:
+            raise ValueError(f"{name}: source_issue must be positive integer")
+
+    return {
+        "schema_version": "sociosphere.workspace-dispositions-validation.v0",
+        "declared_repo_count": len(declared),
+        "disposition_count": len(seen),
+        "status_counts": dict(sorted(status_counts.items())),
+        "validation_status": "valid",
+    }
+
+
+def main() -> int:
+    try:
+        report = validate()
+    except Exception as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements PR 1 from reports/workspace-manifest-cleanup.readiness-v0.md.

Scope:

- add machine-readable inventory disposition metadata
- add offline disposition validator
- add disposition validation workflow

Non-goals:

- no manifest entry deletions
- no manifest entry renames
- no pin movement
- no resolved-lock regeneration
- no full-estate completion claim

Artifacts added:

- manifest/workspace.dispositions.json
- tools/validate_workspace_dispositions.py
- .github/workflows/workspace-dispositions.yml

Related issues:

- #439
- #451
- #452
- #453

Validation:

- disposition entries must be unique
- disposition entries must refer to declared workspace repos
- status values are constrained
- action values are constrained

This PR intentionally establishes governance metadata before any inventory cleanup or manifest reconciliation.