### PR TITLE
Probe service register after bootstrap archive-ready disposition

### DIFF
--- a/architecture/service-register/probe-run.txt
+++ b/architecture/service-register/probe-run.txt
@@ -1,0 +1,1 @@
+Observable CI probe. Do not merge.


### PR DESCRIPTION
Closed as probe-complete.

This PR intentionally added only a temporary marker under `architecture/service-register/` to force observable PR-triggered CI. It was not implementation content and should not be merged.

Outcome captured: `service-register` passed on head `02d16d67ced75688389b03d9f500e64b59765944` after marking `sourceos-a2a-mcp-bootstrap` archive-ready in the MCP/A2A disposition artifact.