### PR TITLE
Add PFK stack integration membrane for proof apparatus

### DIFF
--- a/.github/workflows/proof-apparatus.yml
+++ b/.github/workflows/proof-apparatus.yml
@@ -24,6 +24,7 @@ on:
       - 'protocol/proof-apparatus-workspace/**'
       - 'standards/proof-apparatus/**'
       - 'registry/proof-adjacency-ranking.v0.yaml'
+      - 'catalog/proof-repo-roles.yaml'
       - 'templates/proof-research/**'
       - 'tools/validate_proof_apparatus.py'
       - 'tools/test_proof_adapter_negative_cases.py'
@@ -40,6 +41,7 @@ on:
       - 'protocol/proof-apparatus-workspace/**'
       - 'standards/proof-apparatus/**'
       - 'registry/proof-adjacency-ranking.v0.yaml'
+      - 'catalog/proof-repo-roles.yaml'
       - 'templates/proof-research/**'
       - 'tools/validate_proof_apparatus.py'
       - 'tools/test_proof_adapter_negative_cases.py'
@@ -163,7 +165,7 @@ jobs:
 
           ## Failure evidence
 
-          See \`strict-adapter-validation.log\` for the adapter validation output. See \`materialized-domain-proof-adapter.json\` for the adapter content checked at the triggering SHA when available.
+          See `strict-adapter-validation.log` for the adapter validation output. See `materialized-domain-proof-adapter.json` for the adapter content checked at the triggering SHA when available.
           EOF
         env:
           DOMAIN_REPO: ${{ inputs.domain_repo || github.event.client_payload.repository || github.repository }}

--- a/catalog/proof-repo-roles.yaml
+++ b/catalog/proof-repo-roles.yaml
@@ -1,0 +1,93 @@
+version: 0.1
+status: draft
+controller: SocioProphet/sociosphere
+
+roles:
+  proof_fabric_authority:
+    repositories:
+      - SocioProphet/Heller-Godel
+    responsibility: PFK schemas, framework identifiers, claim grammar, anti-seed discipline, dependency pins.
+
+  proof_workspace_controller:
+    repositories:
+      - SocioProphet/sociosphere
+    responsibility: Cross-repo proof workspace manifests, adapter validation, gate routing, promotion decisions, and snapshots.
+
+  workroom_and_platform_surfaces:
+    repositories:
+      - SocioProphet/prophet-workspace
+      - SocioProphet/prophet-platform
+    responsibility: Human proof workroom UX, platform contracts, APIs, dashboards, and runtime deployment surfaces.
+
+  execution_and_runtime_evidence:
+    repositories:
+      - SocioProphet/agentplane
+      - SocioProphet/lattice-forge
+      - SocioProphet/tritfabric
+      - SocioProphet/TriTRPC
+    responsibility: Bounded execution, replay, validation artifacts, runtime evidence, deterministic transport, and orchestration gates.
+
+  reasoning_search_and_memory:
+    repositories:
+      - SocioProphet/superconscious
+      - SocioProphet/holmes
+      - SocioProphet/sherlock-search
+      - SocioProphet/memory-mesh
+    responsibility: Claim proposal, explanation, contradiction reporting, evidence search, and review-only context proposals.
+
+  policy_authority:
+    repositories:
+      - SocioProphet/ProCybernetica
+      - SocioProphet/policy-fabric
+      - SocioProphet/guardrail-fabric
+      - SocioProphet/mcp-a2a-zero-trust
+      - SocioProphet/agent-registry
+    responsibility: Cybernetic control doctrine, policy packaging, claim/action admission, provider/tool/agent grants, and revocation posture.
+
+  semantic_authority:
+    repositories:
+      - SocioProphet/semantic-serdes
+      - SocioProphet/ontogenesis
+    responsibility: Semantic serialization, truth-class preservation, ontology lifecycle, JSON-LD/RDF/OWL governance, and SHACL gates.
+
+  model_governance:
+    repositories:
+      - SocioProphet/model-governance-ledger
+      - SocioProphet/model-router
+    responsibility: Model lifecycle records, eval receipts, route decisions, runtime/model Trust Chain bindings, and model-use boundaries.
+
+  graph_world_and_identity_evidence:
+    repositories:
+      - SocioProphet/meshrush
+      - SocioProphet/gaia-world-model
+      - SocioProphet/orion-field-intelligence
+      - SocioProphet/regis-entity-graph
+      - SocioProphet/HolographMe
+      - SocioProphet/human-digital-twin
+    responsibility: Graph traversal, world claims, field observations, identity graph edges, and consent-scoped projection records.
+
+  proof_domain_engines:
+    repositories:
+      - SocioProphet/Heller-Winters-Theorem
+      - SocioProphet/Heller-Einstein
+      - SocioProphet/Heller-Dirac
+      - SocioProphet/bsd-proof-program
+      - SocioProphet/np-program
+      - SocioProphet/ns-program
+      - SocioProphet/hodge-program-proof
+      - SocioProphet/identity-is-prime-reference
+    responsibility: Domain definitions, proof claims, non-claims, obstruction registers, fixtures, computations, papers, and repo-local gates.
+
+  learning_and_publication:
+    repositories:
+      - SocioProphet/systems-learning-loops
+      - SocioProphet/alexandrian-academy
+      - SocioProphet/slash-topics
+      - SocioProphet/new-hope
+    responsibility: Institutional learning loops, curriculum objects, teaching records, scoped topic surfaces, and publication membranes.
+
+invariants:
+  - PFK authority remains SocioProphet/Heller-Godel/proof_fabric_kernel.
+  - Sociosphere may orchestrate, but domain repositories keep mathematical interpretation and claim boundaries.
+  - Search, memory, model, and cognition systems produce proposals or evidence envelopes, not theorem conclusions.
+  - Promotion requires a named gate, artifact digest, prior state, new state, severity delta, claim-boundary update, and controller-visible decision.

--- a/protocol/proof-apparatus-workspace/v0/pfk-stack-integration-map.md
+++ b/protocol/proof-apparatus-workspace/v0/pfk-stack-integration-map.md
@@ -1,0 +1,139 @@
+# PFK Stack Integration Map
+
+Status: draft control-plane integration map.  
+Authority surface: `SocioProphet/sociosphere` proof-apparatus workspace.  
+PFK authority: `SocioProphet/Heller-Godel/proof_fabric_kernel/`.
+
+## Purpose
+
+This document defines the initial estate-level integration map for making the Heller-Godel Proof Fabric Kernel (PFK) usable across the SocioProphet proof, platform, memory, policy, execution, and workroom stack without promoting operational receipts into mathematical truth.
+
+The goal is a thin integration membrane, not a new proof authority. Heller-Godel owns PFK. Sociosphere orchestrates the proof workspace. Domain repositories own their mathematics, tests, fixtures, notebooks, papers, and claim boundaries.
+
+## Non-negotiable boundaries
+
+1. PFK schemas are consumed from `SocioProphet/Heller-Godel/proof_fabric_kernel/` at a pinned merged commit SHA.
+2. Consumer repositories must not create local authoritative forks of PFK schemas.
+3. Schema validity is envelope validity, not theorem evidence.
+4. Event-IR traces, ProofArtifact envelopes, claim-ledger rows, calibration bundles, CI status, model summaries, search packets, and memory proposals are not mathematical proof by themselves.
+5. Sociosphere may register, route, test, compare, promote, demote, quarantine, archive, and snapshot claims only from emitted evidence and declared domain boundaries.
+6. Sociosphere must not silently upgrade a domain claim.
+7. Memory and search systems may propose context; they must not promote context into durable truth or theorem-grade evidence without governance.
+8. Agent execution must be policy-mediated, evidence-producing, replayable, and bounded by declared authority.
+
+## Authority map
+
+| Layer | Primary repo | Responsibility |
+| --- | --- | --- |
+| PFK authority | `SocioProphet/Heller-Godel` | Canonical PFK schemas, framework identifiers, claim grammar, anti-seed discipline, dependency pins. |
+| Proof workspace controller | `SocioProphet/sociosphere` | Workspace manifest, proof-slice routing, proof adapter validation, gate orchestration, evidence-event normalization, promotion/quarantine/archive decisions, snapshots. |
+| Human workroom surface | `SocioProphet/prophet-workspace` | Proof Workroom product semantics, claim/gate/source/artifact views, review UX, attachment of office artifacts and workroom context. |
+| Runtime deployment surface | `SocioProphet/prophet-platform` | Production service composition, platform contracts, trust-chain admission composition, dashboards, APIs. |
+| Execution control plane | `SocioProphet/agentplane` | Validated bundle execution, placement, run evidence, replay artifacts, proof-gate runs. |
+| Governed cognition | `SocioProphet/superconscious` | Recursive planning loop, safe operational traces, memory decision requests, model route requests, AgentPlane evidence handoff. |
+| Discovery and reasoning | `SocioProphet/sherlock-search`, `SocioProphet/holmes` | Evidence search packets, claim candidates, explanation traces, contradiction reports, bounded verification artifacts. |
+| Memory context | `SocioProphet/memory-mesh` | Review-only learning/context proposals, channel-provenance write gates, scoped context packs. |
+| Authority and policy | `SocioProphet/ProCybernetica`, `SocioProphet/policy-fabric`, `SocioProphet/guardrail-fabric`, `SocioProphet/mcp-a2a-zero-trust`, `SocioProphet/agent-registry` | Cybernetic control law, policy packaging, claim/action admission, provider/tool/agent grant decisions, identity/capability/revocation posture. |
+| Semantics | `SocioProphet/semantic-serdes`, `SocioProphet/ontogenesis` | Semantic object encoding, truth classes, RDF/OWL/JSON-LD governance, SHACL promotion gates. |
+| Runtime/model supply chain | `SocioProphet/lattice-forge`, `SocioProphet/model-governance-ledger`, `SocioProphet/model-router` | Runtime assets, model lifecycle evidence, route decisions, local/hosted model posture, Trust Chain evidence. |
+| Transport and graph runtime | `SocioProphet/TriTRPC`, `SocioProphet/tritfabric`, `SocioProphet/meshrush` | Deterministic transport, orchestration/gates, graph-native agent traversal and evidence surfaces. |
+| Domain proof engines | `SocioProphet/Heller-Winters-Theorem`, `SocioProphet/Heller-Einstein`, `SocioProphet/Heller-Dirac`, `SocioProphet/bsd-proof-program`, `SocioProphet/np-program`, `SocioProphet/ns-program`, `SocioProphet/hodge-program-proof` | Domain definitions, proof claims, non-claims, obstruction registers, fixtures, notebooks, computations, repo-local gates. |
+
+## Canonical loop
+
+```text
+Observe
+  -> Anchor
+  -> Normalize
+  -> Propose
+  -> Explain
+  -> Verify
+  -> Govern
+  -> Act
+  -> Receipt
+  -> Learn
+  -> Promote | Quarantine | Archive
+```
+
+### Observe
+
+Sources include domain repo fixtures, manuscripts, notebooks, source imports, Lampstand local file evidence, Sherlock search packets, GAIA source records, Orion field events, Regis graph edges, and runtime observations.
+
+### Anchor
+
+Every source-backed item should carry source refs, hashes where available, citation anchors, evidence refs, freshness posture, and sensitivity/handling constraints.
+
+### Normalize
+
+Semantic SerDes, Ontogenesis, and PFK adapters normalize candidate objects into typed envelopes without changing their claim grade.
+
+### Propose
+
+Holmes, domain proof repos, Superconscious, or human operators may propose claims, gates, non-claims, proof artifacts, calibration bundles, and memory context. Proposed objects remain proposed until admitted.
+
+### Explain
+
+Explanation traces should describe evidence used, transformations performed, assumptions, non-claims, contradiction candidates, and next obstruction walls.
+
+### Verify
+
+Verification includes repo-local tests, proof gates, fixture checks, deterministic computations, PFK validators, AgentPlane execution, and calibration runs. Passing verification may support state movement; it does not imply theorem truth by itself.
+
+### Govern
+
+Guardrail Fabric, Policy Fabric, MCP/A2A Zero Trust, Agent Registry, and ProCybernetica authority rules decide whether an action, promotion, route, memory writeback, or public surface is allowed, denied, provisional, or review-required.
+
+### Act
+
+Effectful work is performed by bounded, validated execution surfaces, primarily AgentPlane. Proof work should prefer no-network, deterministic, replayable gates whenever feasible.
+
+### Receipt
+
+Receipts include PFK Event-IR traces, ProofArtifact envelopes, calibration bundles, AgentPlane run/replay artifacts, policy decisions, guardrail decisions, and promotion decisions.
+
+### Learn
+
+Memory Mesh receives review-only proposals. Durable writeback requires explicit approval and must preserve provenance, scope, redaction posture, and writeback posture.
+
+### Promote, quarantine, archive
+
+Sociosphere emits the controller-visible state transition. Promotion by prose alone is forbidden.
+
+## Minimum consumer maturity
+
+| Level | Meaning | Allowed statement | Forbidden statement |
+| --- | --- | --- | --- |
+| M0 | Citation-only dependency | PFK compatibility target identified. | Native PFK integration complete. |
+| M1 | Pinned PFK dependency | Heller-Godel PFK commit SHA and consumed schema identifiers are declared. | Receipts are PFK-native without examples. |
+| M2 | Example compatibility | Repo examples validate against one or more PFK schemas. | Full pipeline integration. |
+| M3 | Native receipt emission | Normal workflow emits PFK-compatible Event-IR, ProofArtifact, claim-ledger, or calibration outputs. | Theorem-grade evidence. |
+| M4 | Migration-disciplined consumer | Dependency pinning, CI validation, migration notes, anti-seed compliance, and replay behavior exist. | PFK validates mathematical correctness. |
+
+## Target repository file set
+
+Each proof-facing domain repository should eventually expose:
+
+```text
+PFK_ADAPTER.json
+DEPENDENCIES.md
+claims/<repo>.claims.jsonl
+gates/<repo>.gates.jsonl
+nonclaims/<repo>.nonclaims.jsonl
+obstructions/<repo>.walls.jsonl
+```
+
+The exact schema for `PFK_ADAPTER.json` is owned by Sociosphere under `standards/proof-apparatus/proof-adapter.schema.json`.
+
+## Immediate implementation sequence
+
+1. Land this integration map in Sociosphere.
+2. Add PFK authority fields to the Sociosphere proof-adapter schema for PFK consumers.
+3. Add a proof repo role catalog to classify proof authority, controller, runtime, memory, policy, semantic, and domain-engine roles.
+4. Validate adapter examples before requiring all domain repos to implement the adapter.
+5. Add repo-local adapter files to Heller-Winters, BSD, NP, NS, Hodge, Heller-Einstein, and Heller-Dirac in separate domain-owned PRs.
+6. Add AgentPlane proof-gate runner support only after adapter examples stabilize.
+7. Add Prophet Workspace Proof Workroom UI only after the controller object model is stable.
+
+## Anti-overclaim clause
+
+This map does not add mathematical content. It does not assert progress on any Clay problem. It does not convert Heller-Godel methodology into a proof-transfer theorem. It only defines how proof-facing artifacts can be routed, checked, governed, and reviewed across the estate.

--- a/standards/proof-apparatus/proof-adapter.schema.json
+++ b/standards/proof-apparatus/proof-adapter.schema.json
@@ -30,6 +30,70 @@
       "type": "string",
       "const": "protocol/proof-apparatus-workspace/v0"
     },
+    "pfk_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_repo",
+        "authority_path",
+        "pinned_commit",
+        "consumed_schemas",
+        "schema_validity_is_content_validity"
+      ],
+      "properties": {
+        "authority_repo": {
+          "type": "string",
+          "const": "SocioProphet/Heller-Godel"
+        },
+        "authority_path": {
+          "type": "string",
+          "const": "proof_fabric_kernel/"
+        },
+        "pinned_commit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "consumed_schemas": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "PFK-SCHEMA-001",
+              "PFK-SCHEMA-002",
+              "PFK-SCHEMA-003",
+              "PFK-SCHEMA-004"
+            ]
+          }
+        },
+        "consumer_maturity": {
+          "type": "string",
+          "enum": [
+            "M0-citation-only",
+            "M1-pinned-schema-dependency",
+            "M2-example-compatibility",
+            "M3-native-receipt-emission",
+            "M4-migration-disciplined-consumer"
+          ],
+          "default": "M1-pinned-schema-dependency"
+        },
+        "local_schema_authority": {
+          "type": "boolean",
+          "const": false,
+          "default": false
+        },
+        "schema_validity_is_content_validity": {
+          "type": "boolean",
+          "const": false
+        },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        }
+      }
+    },
     "claims": {
       "type": "array",
       "items": {

--- a/tools/test_proof_adapter_negative_cases.py
+++ b/tools/test_proof_adapter_negative_cases.py
@@ -23,6 +23,21 @@ VALID_ADAPTER: dict[str, Any] = {
     "repo": "SocioProphet/example-math-repo",
     "domain": "example-mathematical-physics-domain",
     "controller_protocol": "protocol/proof-apparatus-workspace/v0",
+    "pfk_authority": {
+        "authority_repo": "SocioProphet/Heller-Godel",
+        "authority_path": "proof_fabric_kernel/",
+        "pinned_commit": "988307215ad38ccb16514311222184a1b757752b",
+        "consumed_schemas": [
+            "PFK-SCHEMA-001",
+            "PFK-SCHEMA-002",
+            "PFK-SCHEMA-003",
+            "PFK-SCHEMA-004",
+        ],
+        "consumer_maturity": "M1-pinned-schema-dependency",
+        "local_schema_authority": False,
+        "schema_validity_is_content_validity": False,
+        "notes": ["PFK envelope validity is not theorem evidence."],
+    },
     "claims": [
         {
             "claim_id": "EXAMPLE-CLAIM-001",
@@ -171,6 +186,30 @@ def main() -> int:
     passed_gate_missing_digests = clone_adapter()
     passed_gate_missing_digests["gates"][0]["status"] = "pass"
     expect_fail("passed gate missing digests", lambda: validate_adapter_case(passed_gate_missing_digests))
+
+    invalid_pfk_repo = clone_adapter()
+    invalid_pfk_repo["pfk_authority"]["authority_repo"] = "SocioProphet/not-heller-godel"
+    expect_fail("invalid PFK authority repo", lambda: validate_adapter_case(invalid_pfk_repo))
+
+    floating_pfk_commit = clone_adapter()
+    floating_pfk_commit["pfk_authority"]["pinned_commit"] = "main"
+    expect_fail("PFK authority cannot float main", lambda: validate_adapter_case(floating_pfk_commit))
+
+    unknown_pfk_schema = clone_adapter()
+    unknown_pfk_schema["pfk_authority"]["consumed_schemas"] = ["PFK-SCHEMA-999"]
+    expect_fail("unknown PFK schema identifier", lambda: validate_adapter_case(unknown_pfk_schema))
+
+    duplicate_pfk_schema = clone_adapter()
+    duplicate_pfk_schema["pfk_authority"]["consumed_schemas"] = ["PFK-SCHEMA-001", "PFK-SCHEMA-001"]
+    expect_fail("duplicate PFK schema identifiers", lambda: validate_adapter_case(duplicate_pfk_schema))
+
+    local_schema_authority = clone_adapter()
+    local_schema_authority["pfk_authority"]["local_schema_authority"] = True
+    expect_fail("local PFK schema authority forbidden", lambda: validate_adapter_case(local_schema_authority))
+
+    schema_as_truth = clone_adapter()
+    schema_as_truth["pfk_authority"]["schema_validity_is_content_validity"] = True
+    expect_fail("schema validity cannot mean content validity", lambda: validate_adapter_case(schema_as_truth))
 
     invalid_manifest_role = clone_manifest()
     invalid_manifest_role["repos"][0]["role"] = "not-a-valid-role"

--- a/tools/validate_proof_apparatus.py
+++ b/tools/validate_proof_apparatus.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,8 @@ PROOF_MANIFEST = ROOT / "manifest" / "proof-workspace.toml"
 CLAIM_SCHEMA = ROOT / "standards" / "proof-apparatus" / "claim-ledger.schema.json"
 ADAPTER_SCHEMA = ROOT / "standards" / "proof-apparatus" / "proof-adapter.schema.json"
 ADJACENCY_REGISTRY = ROOT / "registry" / "proof-adjacency-ranking.v0.yaml"
+PROOF_ROLE_CATALOG = ROOT / "catalog" / "proof-repo-roles.yaml"
+PFK_INTEGRATION_MAP = ROOT / "protocol" / "proof-apparatus-workspace" / "v0" / "pfk-stack-integration-map.md"
 
 SEVERITY = {"E0", "E1", "E2", "E3", "E4", "E5", "E6", "E7"}
 CLAIM_STATES = {
@@ -76,6 +79,15 @@ VALID_WALLS = {
     "set_theoretic_wall",
     "combinatorial_extremal_wall",
 }
+VALID_PFK_SCHEMAS = {"PFK-SCHEMA-001", "PFK-SCHEMA-002", "PFK-SCHEMA-003", "PFK-SCHEMA-004"}
+VALID_PFK_MATURITY = {
+    "M0-citation-only",
+    "M1-pinned-schema-dependency",
+    "M2-example-compatibility",
+    "M3-native-receipt-emission",
+    "M4-migration-disciplined-consumer",
+}
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
 def load_json(path: Path) -> Any:
@@ -127,6 +139,29 @@ def validate_registry() -> None:
         require(term in content, f"proof adjacency registry missing required term: {term}")
 
 
+def validate_pfk_control_files() -> None:
+    require(PFK_INTEGRATION_MAP.exists(), f"missing PFK integration map: {PFK_INTEGRATION_MAP}")
+    map_content = PFK_INTEGRATION_MAP.read_text(encoding="utf-8")
+    for term in (
+        "PFK authority: `SocioProphet/Heller-Godel/proof_fabric_kernel/`",
+        "Schema validity is envelope validity, not theorem evidence.",
+        "Sociosphere must not silently upgrade a domain claim.",
+        "Promotion by prose alone is forbidden.",
+    ):
+        require(term in map_content, f"PFK integration map missing required term: {term}")
+
+    require(PROOF_ROLE_CATALOG.exists(), f"missing proof role catalog: {PROOF_ROLE_CATALOG}")
+    role_content = PROOF_ROLE_CATALOG.read_text(encoding="utf-8")
+    for term in (
+        "proof_fabric_authority:",
+        "proof_workspace_controller:",
+        "proof_domain_engines:",
+        "SocioProphet/Heller-Godel",
+        "SocioProphet/sociosphere",
+    ):
+        require(term in role_content, f"proof role catalog missing required term: {term}")
+
+
 def validate_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     proof_workspace = manifest.get("proof_workspace")
     require(isinstance(proof_workspace, dict), "manifest missing [proof_workspace]")
@@ -172,6 +207,55 @@ def validate_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     return repos
 
 
+def validate_pfk_authority(path: Path, pfk_authority: dict[str, Any]) -> None:
+    for field in (
+        "authority_repo",
+        "authority_path",
+        "pinned_commit",
+        "consumed_schemas",
+        "schema_validity_is_content_validity",
+    ):
+        require(field in pfk_authority, f"{path} pfk_authority missing required field {field}")
+
+    require(
+        pfk_authority["authority_repo"] == "SocioProphet/Heller-Godel",
+        f"{path} pfk_authority.authority_repo must be SocioProphet/Heller-Godel",
+    )
+    require(
+        pfk_authority["authority_path"] == "proof_fabric_kernel/",
+        f"{path} pfk_authority.authority_path must be proof_fabric_kernel/",
+    )
+    require(
+        isinstance(pfk_authority["pinned_commit"], str) and SHA_RE.match(pfk_authority["pinned_commit"]) is not None,
+        f"{path} pfk_authority.pinned_commit must be a 40-character lowercase hex SHA",
+    )
+    consumed_schemas = pfk_authority["consumed_schemas"]
+    require(
+        isinstance(consumed_schemas, list) and consumed_schemas,
+        f"{path} pfk_authority.consumed_schemas must be a nonempty list",
+    )
+    require(
+        len(set(consumed_schemas)) == len(consumed_schemas),
+        f"{path} pfk_authority.consumed_schemas must not contain duplicates",
+    )
+    require(
+        set(consumed_schemas).issubset(VALID_PFK_SCHEMAS),
+        f"{path} pfk_authority.consumed_schemas contains unknown schema identifiers",
+    )
+    require(
+        pfk_authority.get("consumer_maturity", "M1-pinned-schema-dependency") in VALID_PFK_MATURITY,
+        f"{path} pfk_authority.consumer_maturity is invalid",
+    )
+    require(
+        pfk_authority.get("local_schema_authority", False) is False,
+        f"{path} pfk_authority.local_schema_authority must be false",
+    )
+    require(
+        pfk_authority["schema_validity_is_content_validity"] is False,
+        f"{path} pfk_authority.schema_validity_is_content_validity must be false",
+    )
+
+
 def validate_adapter(path: Path, adapter: dict[str, Any]) -> None:
     for field in ("adapter_version", "repo", "domain", "claims", "gates", "non_claims"):
         require(field in adapter, f"{path} missing required field {field}")
@@ -183,6 +267,11 @@ def validate_adapter(path: Path, adapter: dict[str, Any]) -> None:
     require(isinstance(adapter["claims"], list), f"{path} claims must be a list")
     require(isinstance(adapter["gates"], list), f"{path} gates must be a list")
     require(isinstance(adapter["non_claims"], list), f"{path} non_claims must be a list")
+
+    pfk_authority = adapter.get("pfk_authority")
+    if pfk_authority is not None:
+        require(isinstance(pfk_authority, dict), f"{path} pfk_authority must be an object")
+        validate_pfk_authority(path, pfk_authority)
 
     gate_ids = set()
     for gate in adapter["gates"]:
@@ -239,6 +328,7 @@ def main() -> int:
     load_json(CLAIM_SCHEMA)
     load_json(ADAPTER_SCHEMA)
     validate_registry()
+    validate_pfk_control_files()
 
     manifest = load_toml(PROOF_MANIFEST)
     repos = validate_manifest(manifest)
@@ -261,7 +351,7 @@ def main() -> int:
 
     print(
         "proof-apparatus validation passed: "
-        f"schemas=2 registry=1 manifest_repos={len(repos)} "
+        f"schemas=2 registry=1 pfk_controls=2 manifest_repos={len(repos)} "
         f"adapters_checked={checked_adapters} strict_adapters={args.strict_adapters}"
     )
     return 0


### PR DESCRIPTION
## Summary

Adds the first Sociosphere-side integration membrane for making the Heller-Godel Proof Fabric Kernel (PFK) usable across the proof apparatus workspace without promoting operational receipts into theorem evidence.

This PR:

- adds `protocol/proof-apparatus-workspace/v0/pfk-stack-integration-map.md`;
- adds `catalog/proof-repo-roles.yaml` for estate-level proof-fabric role classification;
- extends `standards/proof-apparatus/proof-adapter.schema.json` with an optional `pfk_authority` block;
- updates `tools/validate_proof_apparatus.py` to validate the PFK integration map, role catalog, and PFK authority declarations when present;
- extends negative tests so adapters fail closed on floating PFK refs, local PFK schema authority, duplicate/unknown PFK schema IDs, and schema-validity-as-truth claims;
- updates `.github/workflows/proof-apparatus.yml` so proof apparatus validation runs when the new role catalog changes.

## Boundary

This PR does not add mathematical content. It does not assert progress on any Clay problem. It does not convert PFK receipts, validators, model outputs, memory proposals, or CI status into theorem evidence.

## Validation intent

Expected local/CI gates:

```bash
python3 tools/validate_proof_apparatus.py
python3 tools/test_proof_adapter_negative_cases.py
```

Strict materialized adapter validation remains workflow-owned because it depends on materializing declared proof repos.