### PR TITLE
Mark socioprophet-old archive-retire

### DIFF
--- a/docs/governance/repo-governance-matrix-v0.md
+++ b/docs/governance/repo-governance-matrix-v0.md
@@ -11,6 +11,7 @@ This matrix classifies current SocioProphet estate repositories by governance ro
 - `canonical`: authoritative repositories allowed to define current platform contracts, runtime behavior, release gates, transport semantics, execution semantics, ontology terms, public surface behavior, or governance state.
 - `promotion-candidate`: active repositories that need scope hardening, canonical consumers, validation, or ADR/Sociosphere registration before becoming authority sources.
 - `provenance-only`: historical, archival, salvage, mirror, or experimental material. Evidence, not authority.
+- `archive-retire`: superseded repository that should be archived rather than mined, promoted, or reactivated. Evidence only; no active extraction backlog.
 
 ## Canonical repositories
 
@@ -36,11 +37,16 @@ This matrix classifies current SocioProphet estate repositories by governance ro
 | `SocioProphet/gaia-world-model` | Auditable world-model scaffolding | Promote when GAIA domain model is explicitly imported by platform or ontology spine. | Domain scope outpaces validation. |
 | `SocioProphet/slash-topics` | Governed topic packs and semantic BI outputs | Promote when outputs feed live surface ontology, search, or analytics. | Topic taxonomy drift from `config/surfaces.json`. |
 
+## Archive-retire repositories
+
+| Repository | Use | Restriction |
+|---|---|---|
+| `mdheller/socioprophet-old` | Superseded historical implementation | Archive. Do not mine for current doctrine, do not promote, and do not treat as a salvage backlog source. |
+
 ## Provenance-only by default
 
 | Repository/pattern | Use | Restriction |
 |---|---|---|
-| `mdheller/socioprophet-old` | Historical implementation reference | Must not define current contracts. |
 | `SocioProphet/socioprophet-web-medium` | Historical web material | Must not define current public surface behavior. |
 | `SocioProphet/tritrpc-notes-archive` | TriTRPC notes archive | Must not supersede `TriTRPC`. |
 | WIP salvage or mirror branches/repos | Recovery and audit continuity | Must be explicitly promoted before use as authority. |
@@ -56,3 +62,4 @@ This matrix classifies current SocioProphet estate repositories by governance ro
 6. Ontology terms and SHACL validation belong in `ontogenesis`.
 7. Standards repos require explicit import, ADR, or registration to be authoritative.
 8. Provenance repos are evidence, not authority.
+9. Archive-retire repos are not extraction backlogs; they should be archived unless a later explicit governance reversal is recorded.

--- a/registry/repo-governance-matrix-v0.yaml
+++ b/registry/repo-governance-matrix-v0.yaml
@@ -10,6 +10,8 @@ classes:
     description: Active repositories that require promotion before becoming authoritative.
   provenance_only:
     description: Historical or experimental evidence sources, not current authority.
+  archive_retire:
+    description: Superseded repositories that should be archived rather than mined, promoted, or reactivated.
 repositories:
   - name: SocioProphet/socioprophet
     class: canonical
@@ -100,9 +102,9 @@ repositories:
     promotion_condition: Outputs feed live surface ontology search or analytics.
     risk: topic_taxonomy_drift_from_config_surfaces_json
   - name: mdheller/socioprophet-old
-    class: provenance_only
-    function: historical_implementation_reference
-    restriction: must_not_define_current_contracts
+    class: archive_retire
+    function: superseded_historical_implementation
+    restriction: archive_do_not_mine_promote_or_salvage
   - name: SocioProphet/socioprophet-web-medium
     class: provenance_only
     function: historical_web_material
@@ -120,6 +122,7 @@ authority_boundaries:
   - ontology_terms_and_SHACL_validation_belong_in_ontogenesis
   - standards_repos_require_explicit_import_ADR_or_registration_to_be_authoritative
   - provenance_repos_are_evidence_not_authority
+  - archive_retire_repos_are_not_extraction_backlogs_and_should_be_archived
 promotion_checklist:
   - declared_scope_boundary
   - canonical_repo_consumer

--- a/status/build-intelligence/sociosphere-repo-governance-matrix-2026-04-26.yaml
+++ b/status/build-intelligence/sociosphere-repo-governance-matrix-2026-04-26.yaml
@@ -7,9 +7,9 @@ subject: repo-governance-matrix
 status: proposed
 summary: >-
   Registers the SocioProphet repository governance matrix tranche. The tranche
-  classifies repositories as canonical, promotion-candidate, or provenance-only
-  and adds a zero-dependency validator plus CI gate for the machine-readable
-  matrix.
+  classifies repositories as canonical, promotion-candidate, provenance-only, or
+  archive-retire and adds a zero-dependency validator plus CI gate for the
+  machine-readable matrix.
 artifacts:
   - docs/governance/repo-governance-matrix-v0.md
   - registry/repo-governance-matrix-v0.yaml
@@ -32,8 +32,9 @@ governance_classes:
     - SocioProphet/socioprophet-standards-knowledge
     - SocioProphet/gaia-world-model
     - SocioProphet/slash-topics
-  provenance_only:
+  archive_retire:
     - mdheller/socioprophet-old
+  provenance_only:
     - SocioProphet/socioprophet-web-medium
     - SocioProphet/tritrpc-notes-archive
 validation:
@@ -43,6 +44,7 @@ risk: low
 limitations:
   - Matrix is draft v0 and should be reviewed against current org inventory before canonical promotion.
   - Validator is structural and intentionally does not yet query GitHub for repo existence or branch state.
+  - mdheller/socioprophet-old is superseded and should be archived rather than mined, promoted, or used as a salvage backlog source.
 next_steps:
   - Add repo-existence and archived-state checks.
   - Add ownership/RACI fields.

--- a/tools/validate_repo_governance_matrix.py
+++ b/tools/validate_repo_governance_matrix.py
@@ -4,8 +4,9 @@ import re
 import sys
 
 MATRIX = Path("registry/repo-governance-matrix-v0.yaml")
-VALID_CLASSES = {"canonical", "promotion_candidate", "provenance_only"}
+VALID_CLASSES = {"canonical", "promotion_candidate", "provenance_only", "archive_retire"}
 REQUIRED_AUTHORITY_FIELDS = {"contracts", "runtime_behavior", "standards", "evidence_state"}
+REQUIRES_RESTRICTION = {"provenance_only", "archive_retire"}
 
 
 def fail(message: str) -> int:
@@ -74,7 +75,7 @@ def main() -> int:
                 return fail(f"{name} missing promotion_condition")
             if not str(repo.get("risk", "")).strip():
                 return fail(f"{name} missing risk")
-        if klass == "provenance_only" and not str(repo.get("restriction", "")).strip():
+        if klass in REQUIRES_RESTRICTION and not str(repo.get("restriction", "")).strip():
             return fail(f"{name} missing restriction")
     missing_classes = VALID_CLASSES - classes
     if missing_classes:


### PR DESCRIPTION
## Summary

- Marks `mdheller/socioprophet-old` as `archive_retire` rather than generic provenance-only.
- States explicitly that it should be archived and must not be mined, promoted, reactivated, or treated as a salvage backlog source.
- Updates the Markdown governance matrix, machine-readable YAML registry, and build-intelligence snapshot.
- Updates the validator to recognize `archive_retire` as a first-class governance class requiring a restriction.

## Rationale

The user clarified that `socioprophet-old` is old and should be archived. This removes it from the active extraction/mining backlog and records a stronger disposition than provenance-only.

## Validation

Expected validation: `tools/validate_repo_governance_matrix.py` should continue to pass with the new class.