### PR TITLE
Add governance action schema stubs

### DIFF
--- a/schemas/governance/README.md
+++ b/schemas/governance/README.md
@@ -1,0 +1,28 @@
+# Governance schema stubs
+
+Status: v0.1 schema stubs
+Owner: Sociosphere governance layer
+
+This directory defines the first machine-readable object contracts for the regulated-domain institutional-action doctrine.
+
+## Schemas
+
+| Schema | Purpose |
+|---|---|
+| `institutional-action.v0.1.schema.json` | Complete governed action object binding actor, role, authority, context, evidence, policy, procedure, capability, approval, and execution receipt. |
+| `procedure-template.v0.1.schema.json` | Governed workflow template with required inputs, policy basis, evidence requirements, output schema, approval gate, and replay test. |
+| `evidence-bundle.v0.1.schema.json` | Versioned source/evidence bundle supporting a governed decision or execution. |
+| `execution-receipt.v0.1.schema.json` | Hashable record proving what executed a governed action and which artifacts/replay refs support it. |
+
+## Boundary
+
+These files are schema stubs only. They do not imply runtime middleware, storage implementation, HellGraph ingestion, AgentPlane receipt emission, or Prophet Platform API readiness. Runtime adoption requires downstream fixtures, validators, graph queries, and admission tests.
+
+## Ownership alignment
+
+- SocioProphet records institutional actions.
+- Sociosphere owns the governance topology and schema registration posture.
+- HellGraph serves graph-backed governance state and query fixtures.
+- AgentPlane emits execution and replay evidence.
+- Prophet Platform exposes release/admission validator surfaces.
+- Ontogenesis owns ontology and shape authority when these schemas are lifted into semantic vocabularies.

--- a/schemas/governance/evidence-bundle.v0.1.schema.json
+++ b/schemas/governance/evidence-bundle.v0.1.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/sociosphere/governance/evidence-bundle.v0.1.schema.json",
+  "title": "EvidenceBundle v0.1",
+  "description": "Versioned set of sources, citations, retrieved context, artifacts, logs, graph snapshots, and validation outputs supporting a governed decision or execution.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "recordType", "evidenceBundleId", "subjectRef", "sourceRefs", "policyBasisRefs", "provenance", "integrity"],
+  "properties": {
+    "schemaVersion": { "const": "governance.evidence-bundle.v0.1" },
+    "recordType": { "const": "EvidenceBundle" },
+    "evidenceBundleId": { "type": "string", "minLength": 1 },
+    "subjectRef": { "type": "string", "minLength": 1 },
+    "summary": { "type": "string", "minLength": 1 },
+    "sourceRefs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["ref", "kind", "authorityClass"],
+        "properties": {
+          "ref": { "type": "string", "minLength": 1 },
+          "kind": {
+            "type": "string",
+            "enum": ["repo_file", "document", "artifact", "log", "graph_snapshot", "citation", "human_statement", "system_observation", "external_evidence"]
+          },
+          "authorityClass": {
+            "type": "string",
+            "enum": ["canonical", "policy", "procedure", "evidence", "context", "external", "advisory"]
+          },
+          "contentDigest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+          "observedAt": { "type": "string", "format": "date-time" },
+          "excerptRef": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "policyBasisRefs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "qualitySignals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["signal", "status"],
+        "properties": {
+          "signal": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "enum": ["pass", "warn", "fail", "unknown"] },
+          "evidenceRef": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "contradictionRefs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["createdBy", "createdAt", "sourceRepo", "nonSecret"],
+      "properties": {
+        "createdBy": { "type": "string", "minLength": 1 },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "sourceRepo": { "type": "string", "minLength": 1 },
+        "sourceCommit": { "type": "string", "minLength": 1 },
+        "nonSecret": { "type": "boolean" }
+      }
+    },
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contentDigest"],
+      "properties": {
+        "contentDigest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "signatureRef": { "type": "string", "minLength": 1 },
+        "hashAlgorithm": { "type": "string", "enum": ["sha256"] }
+      }
+    }
+  }
+}

--- a/schemas/governance/execution-receipt.v0.1.schema.json
+++ b/schemas/governance/execution-receipt.v0.1.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/sociosphere/governance/execution-receipt.v0.1.schema.json",
+  "title": "ExecutionReceipt v0.1",
+  "description": "Hashable record proving what actor, capability, workflow, tool, agent, or infrastructure path executed a governed action.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "recordType", "receiptId", "actionRef", "executor", "execution", "artifactRefs", "replay", "provenance", "integrity"],
+  "properties": {
+    "schemaVersion": { "const": "governance.execution-receipt.v0.1" },
+    "recordType": { "const": "ExecutionReceipt" },
+    "receiptId": { "type": "string", "minLength": 1 },
+    "actionRef": { "type": "string", "minLength": 1 },
+    "executor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["executorId", "executorKind", "capabilityRef"],
+      "properties": {
+        "executorId": { "type": "string", "minLength": 1 },
+        "executorKind": { "type": "string", "enum": ["human", "agent", "service", "workflow", "ci", "runtime"] },
+        "capabilityRef": { "type": "string", "minLength": 1 },
+        "runtimeRef": { "type": "string", "minLength": 1 }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "startedAt"],
+      "properties": {
+        "status": { "type": "string", "enum": ["succeeded", "failed", "denied", "cancelled", "review_required"] },
+        "startedAt": { "type": "string", "format": "date-time" },
+        "completedAt": { "type": "string", "format": "date-time" },
+        "decisionRef": { "type": "string", "minLength": 1 },
+        "policyDecisionRef": { "type": "string", "minLength": 1 },
+        "environmentRef": { "type": "string", "minLength": 1 }
+      }
+    },
+    "artifactRefs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "evidenceBundleRef": { "type": "string", "minLength": 1 },
+    "replay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["replayable"],
+      "properties": {
+        "replayable": { "type": "boolean" },
+        "replayArtifactRef": { "type": "string", "minLength": 1 },
+        "graphSnapshotRef": { "type": "string", "minLength": 1 },
+        "determinismClass": { "type": "string", "enum": ["deterministic", "bounded_nondeterministic", "synthetic", "not_replayable"] }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["createdBy", "createdAt", "sourceRepo", "nonSecret"],
+      "properties": {
+        "createdBy": { "type": "string", "minLength": 1 },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "sourceRepo": { "type": "string", "minLength": 1 },
+        "sourceCommit": { "type": "string", "minLength": 1 },
+        "nonSecret": { "type": "boolean" }
+      }
+    },
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contentDigest"],
+      "properties": {
+        "contentDigest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "signatureRef": { "type": "string", "minLength": 1 },
+        "hashAlgorithm": { "type": "string", "enum": ["sha256"] }
+      }
+    }
+  }
+}

--- a/schemas/governance/institutional-action.v0.1.schema.json
+++ b/schemas/governance/institutional-action.v0.1.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/sociosphere/governance/institutional-action.v0.1.schema.json",
+  "title": "InstitutionalAction v0.1",
+  "description": "Complete governed action object binding actor, role, authority, context, evidence, policy, procedure, capability, approval, and execution receipt.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "recordType", "actionId", "actor", "roleRef", "authorityBoundaryRef", "contextRefs", "evidenceBundleRef", "policyBasisRefs", "procedureTemplateRef", "capabilityRef", "approval", "executionReceiptRef", "provenance"],
+  "properties": {
+    "schemaVersion": { "const": "governance.institutional-action.v0.1" },
+    "recordType": { "const": "InstitutionalAction" },
+    "actionId": { "type": "string", "minLength": 1 },
+    "actionKind": { "type": "string", "enum": ["recommendation", "draft", "approval", "override", "execution", "admission", "release_gate", "review"] },
+    "status": { "type": "string", "enum": ["proposed", "approved", "denied", "executed", "failed", "superseded"] },
+    "actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actorRef", "actorKind"],
+      "properties": {
+        "actorRef": { "type": "string", "minLength": 1 },
+        "actorKind": { "type": "string", "enum": ["human", "agent", "service_account", "organization", "delegated_process"] }
+      }
+    },
+    "roleRef": { "type": "string", "minLength": 1 },
+    "authorityBoundaryRef": { "type": "string", "minLength": 1 },
+    "contextRefs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "evidenceBundleRef": { "type": "string", "minLength": 1 },
+    "policyBasisRefs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "procedureTemplateRef": { "type": "string", "minLength": 1 },
+    "capabilityRef": { "type": "string", "minLength": 1 },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "status"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "status": { "type": "string", "enum": ["not_required", "pending", "approved", "denied", "overridden"] },
+        "approvalEventRef": { "type": "string", "minLength": 1 },
+        "overrideEventRef": { "type": "string", "minLength": 1 },
+        "approverRoleRef": { "type": "string", "minLength": 1 }
+      }
+    },
+    "executionReceiptRef": { "type": "string", "minLength": 1 },
+    "graphSnapshotRef": { "type": "string", "minLength": 1 },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["createdBy", "createdAt", "sourceRepo", "nonSecret"],
+      "properties": {
+        "createdBy": { "type": "string", "minLength": 1 },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "sourceRepo": { "type": "string", "minLength": 1 },
+        "sourceCommit": { "type": "string", "minLength": 1 },
+        "nonSecret": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/schemas/governance/procedure-template.v0.1.schema.json
+++ b/schemas/governance/procedure-template.v0.1.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/sociosphere/governance/procedure-template.v0.1.schema.json",
+  "title": "ProcedureTemplate v0.1",
+  "description": "Governed workflow template with required inputs, policy basis, evidence requirements, output schema, approval gate, and replay test.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "recordType", "templateId", "title", "version", "ownerRepo", "policyBasisRefs", "requiredInputs", "evidenceRequirements", "outputContract", "approvalGate", "replayTest", "provenance"],
+  "properties": {
+    "schemaVersion": { "const": "governance.procedure-template.v0.1" },
+    "recordType": { "const": "ProcedureTemplate" },
+    "templateId": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "ownerRepo": { "type": "string", "minLength": 1 },
+    "status": { "type": "string", "enum": ["draft", "active", "deprecated", "retired"] },
+    "authorityBoundaryRef": { "type": "string", "minLength": 1 },
+    "policyBasisRefs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "requiredInputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "kind", "required"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "kind": { "type": "string", "enum": ["actor", "role", "context", "evidence", "policy", "asset", "freeform", "artifact_ref"] },
+          "required": { "type": "boolean" },
+          "schemaRef": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "evidenceRequirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["requirementId", "description", "minAuthorityClass"],
+        "properties": {
+          "requirementId": { "type": "string", "minLength": 1 },
+          "description": { "type": "string", "minLength": 1 },
+          "minAuthorityClass": { "type": "string", "enum": ["canonical", "policy", "procedure", "evidence", "context", "external", "advisory"] },
+          "acceptedKinds": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+        }
+      }
+    },
+    "outputContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaRef", "permittedOutputs"],
+      "properties": {
+        "schemaRef": { "type": "string", "minLength": 1 },
+        "permittedOutputs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "approvalGate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "mode"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "mode": { "type": "string", "enum": ["none", "single_human", "domain_owner", "quorum", "external_authority"] },
+        "approverRoleRefs": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "replayTest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "fixtureRef"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "fixtureRef": { "type": "string", "minLength": 1 },
+        "expectedReceiptKind": { "type": "string", "minLength": 1 }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["createdBy", "createdAt", "sourceRepo", "nonSecret"],
+      "properties": {
+        "createdBy": { "type": "string", "minLength": 1 },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "sourceRepo": { "type": "string", "minLength": 1 },
+        "sourceCommit": { "type": "string", "minLength": 1 },
+        "nonSecret": { "type": "boolean" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds first v0.1 JSON Schema stubs for the regulated-domain institutional-action doctrine:
  - `InstitutionalAction`
  - `ProcedureTemplate`
  - `EvidenceBundle`
  - `ExecutionReceipt`
- Adds `schemas/governance/README.md` documenting ownership boundaries and non-runtime claims.

## Rationale

The previous documentation PRs established SocioProphet as the institutional-action surface, Sociosphere as the governance graph authority, HellGraph as the governance-query substrate, and Prophet Platform as the release/admission validator surface. This PR starts the machine-readable contract layer for those objects.

## Validation

- JSON syntax for the four schema stubs was checked locally before commit.
- The schemas are self-contained draft 2020-12 stubs and intentionally do not require cross-schema resolver wiring yet.