### PR TITLE
Add governance schema fixtures and validator

### DIFF
--- a/.github/workflows/governance-schemas.yml
+++ b/.github/workflows/governance-schemas.yml
@@ -1,0 +1,33 @@
+name: Governance Schemas
+
+on:
+  pull_request:
+    paths:
+      - "schemas/governance/**"
+      - "tests/fixtures/governance/**"
+      - "tools/validate_governance_schemas.py"
+      - ".github/workflows/governance-schemas.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "schemas/governance/**"
+      - "tests/fixtures/governance/**"
+      - "tools/validate_governance_schemas.py"
+      - ".github/workflows/governance-schemas.yml"
+
+jobs:
+  validate-governance-schemas:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validator dependency
+        run: python -m pip install jsonschema
+      - name: Validate governance schemas
+        run: python tools/validate_governance_schemas.py

--- a/schemas/governance/README.md
+++ b/schemas/governance/README.md
@@ -14,6 +14,10 @@ This directory defines the first machine-readable object contracts for the regul
 | `evidence-bundle.v0.1.schema.json` | Versioned source/evidence bundle supporting a governed decision or execution. |
 | `execution-receipt.v0.1.schema.json` | Hashable record proving what executed a governed action and which artifacts/replay refs support it. |
 
+## Fixture coverage
+
+Each schema is paired with one valid synthetic fixture and one invalid synthetic fixture under `tests/fixtures/governance/`. The validator must accept the valid fixture and reject the invalid fixture.
+
 ## Boundary
 
 These files are schema stubs only. They do not imply runtime middleware, storage implementation, HellGraph ingestion, AgentPlane receipt emission, or Prophet Platform API readiness. Runtime adoption requires downstream fixtures, validators, graph queries, and admission tests.

--- a/tests/fixtures/governance/evidence-bundle.invalid.missing-policy.synthetic.json
+++ b/tests/fixtures/governance/evidence-bundle.invalid.missing-policy.synthetic.json
@@ -1,0 +1,23 @@
+{
+  "evidenceBundleId": "evb:sociosphere:governance-action:invalid",
+  "integrity": {
+    "contentDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "hashAlgorithm": "sha256"
+  },
+  "provenance": {
+    "createdAt": "2026-06-05T21:45:00Z",
+    "createdBy": "sociosphere-validator",
+    "nonSecret": true,
+    "sourceRepo": "SocioProphet/sociosphere"
+  },
+  "recordType": "EvidenceBundle",
+  "schemaVersion": "governance.evidence-bundle.v0.1",
+  "sourceRefs": [
+    {
+      "authorityClass": "canonical",
+      "kind": "repo_file",
+      "ref": "docs/ecosystem/socioprophet.md"
+    }
+  ],
+  "subjectRef": "institutional-action:invalid"
+}

--- a/tests/fixtures/governance/evidence-bundle.valid.synthetic.json
+++ b/tests/fixtures/governance/evidence-bundle.valid.synthetic.json
@@ -1,0 +1,38 @@
+{
+  "contradictionRefs": [],
+  "evidenceBundleId": "evb:sociosphere:governance-action:example",
+  "integrity": {
+    "contentDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "hashAlgorithm": "sha256"
+  },
+  "policyBasisRefs": [
+    "policy:human-in-command"
+  ],
+  "provenance": {
+    "createdAt": "2026-06-05T21:45:00Z",
+    "createdBy": "sociosphere-validator",
+    "nonSecret": true,
+    "sourceCommit": "synthetic",
+    "sourceRepo": "SocioProphet/sociosphere"
+  },
+  "qualitySignals": [
+    {
+      "evidenceRef": "docs/ecosystem/socioprophet.md",
+      "signal": "source-present",
+      "status": "pass"
+    }
+  ],
+  "recordType": "EvidenceBundle",
+  "schemaVersion": "governance.evidence-bundle.v0.1",
+  "sourceRefs": [
+    {
+      "authorityClass": "canonical",
+      "contentDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "kind": "repo_file",
+      "observedAt": "2026-06-05T21:45:00Z",
+      "ref": "docs/ecosystem/socioprophet.md"
+    }
+  ],
+  "subjectRef": "institutional-action:example",
+  "summary": "Synthetic evidence bundle for governance schema validation."
+}

--- a/tests/fixtures/governance/execution-receipt.invalid.bad-digest.synthetic.json
+++ b/tests/fixtures/governance/execution-receipt.invalid.bad-digest.synthetic.json
@@ -1,0 +1,31 @@
+{
+  "actionRef": "institutional-action:invalid",
+  "artifactRefs": [
+    "tests/fixtures/governance/evidence-bundle.valid.synthetic.json"
+  ],
+  "execution": {
+    "startedAt": "2026-06-05T21:45:00Z",
+    "status": "succeeded"
+  },
+  "executor": {
+    "capabilityRef": "capability:validate-governance-schema",
+    "executorId": "agent:sociosphere-validator",
+    "executorKind": "ci"
+  },
+  "integrity": {
+    "contentDigest": "not-a-sha256-digest",
+    "hashAlgorithm": "sha256"
+  },
+  "provenance": {
+    "createdAt": "2026-06-05T21:45:00Z",
+    "createdBy": "sociosphere-validator",
+    "nonSecret": true,
+    "sourceRepo": "SocioProphet/sociosphere"
+  },
+  "receiptId": "receipt:invalid",
+  "recordType": "ExecutionReceipt",
+  "replay": {
+    "replayable": true
+  },
+  "schemaVersion": "governance.execution-receipt.v0.1"
+}

--- a/tests/fixtures/governance/execution-receipt.valid.synthetic.json
+++ b/tests/fixtures/governance/execution-receipt.valid.synthetic.json
@@ -1,0 +1,41 @@
+{
+  "actionRef": "institutional-action:example",
+  "artifactRefs": [
+    "tests/fixtures/governance/evidence-bundle.valid.synthetic.json"
+  ],
+  "evidenceBundleRef": "evb:sociosphere:governance-action:example",
+  "execution": {
+    "completedAt": "2026-06-05T21:45:00Z",
+    "decisionRef": "decision:allowed",
+    "environmentRef": "environment:ci",
+    "policyDecisionRef": "policy-decision:synthetic",
+    "startedAt": "2026-06-05T21:45:00Z",
+    "status": "succeeded"
+  },
+  "executor": {
+    "capabilityRef": "capability:validate-governance-schema",
+    "executorId": "agent:sociosphere-validator",
+    "executorKind": "ci",
+    "runtimeRef": "runtime:github-actions"
+  },
+  "integrity": {
+    "contentDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "hashAlgorithm": "sha256"
+  },
+  "provenance": {
+    "createdAt": "2026-06-05T21:45:00Z",
+    "createdBy": "sociosphere-validator",
+    "nonSecret": true,
+    "sourceCommit": "synthetic",
+    "sourceRepo": "SocioProphet/sociosphere"
+  },
+  "receiptId": "receipt:governance-action:example",
+  "recordType": "ExecutionReceipt",
+  "replay": {
+    "determinismClass": "synthetic",
+    "graphSnapshotRef": "graph:snapshot:synthetic",
+    "replayArtifactRef": "artifact:replay:synthetic",
+    "replayable": true
+  },
+  "schemaVersion": "governance.execution-receipt.v0.1"
+}

--- a/tests/fixtures/governance/institutional-action.invalid.missing-execution-receipt.synthetic.json
+++ b/tests/fixtures/governance/institutional-action.invalid.missing-execution-receipt.synthetic.json
@@ -1,0 +1,30 @@
+{
+  "actionId": "institutional-action:invalid",
+  "actor": {
+    "actorKind": "agent",
+    "actorRef": "agent:sociosphere-validator"
+  },
+  "approval": {
+    "required": true,
+    "status": "approved"
+  },
+  "authorityBoundaryRef": "authority:sociosphere-governance-docs",
+  "capabilityRef": "capability:validate-governance-schema",
+  "contextRefs": [
+    "context:governance-schema-fixture"
+  ],
+  "evidenceBundleRef": "evb:sociosphere:governance-action:example",
+  "policyBasisRefs": [
+    "policy:human-in-command"
+  ],
+  "procedureTemplateRef": "procedure:governed-doc-update",
+  "provenance": {
+    "createdAt": "2026-06-05T21:45:00Z",
+    "createdBy": "sociosphere-validator",
+    "nonSecret": true,
+    "sourceRepo": "SocioProphet/sociosphere"
+  },
+  "recordType": "InstitutionalAction",
+  "roleRef": "role:sociosphere-governance-owner",
+  "schemaVersion": "governance.institutional-action.v0.1"
+}

--- a/tests/fixtures/governance/institutional-action.valid.synthetic.json
+++ b/tests/fixtures/governance/institutional-action.valid.synthetic.json
@@ -1,0 +1,37 @@
+{
+  "actionId": "institutional-action:example",
+  "actionKind": "execution",
+  "actor": {
+    "actorKind": "agent",
+    "actorRef": "agent:sociosphere-validator"
+  },
+  "approval": {
+    "approvalEventRef": "approval:domain-owner:synthetic",
+    "approverRoleRef": "role:sociosphere-governance-owner",
+    "required": true,
+    "status": "approved"
+  },
+  "authorityBoundaryRef": "authority:sociosphere-governance-docs",
+  "capabilityRef": "capability:validate-governance-schema",
+  "contextRefs": [
+    "context:governance-schema-fixture"
+  ],
+  "evidenceBundleRef": "evb:sociosphere:governance-action:example",
+  "executionReceiptRef": "receipt:governance-action:example",
+  "graphSnapshotRef": "graph:snapshot:synthetic",
+  "policyBasisRefs": [
+    "policy:human-in-command"
+  ],
+  "procedureTemplateRef": "procedure:governed-doc-update",
+  "provenance": {
+    "createdAt": "2026-06-05T21:45:00Z",
+    "createdBy": "sociosphere-validator",
+    "nonSecret": true,
+    "sourceCommit": "synthetic",
+    "sourceRepo": "SocioProphet/sociosphere"
+  },
+  "recordType": "InstitutionalAction",
+  "roleRef": "role:sociosphere-governance-owner",
+  "schemaVersion": "governance.institutional-action.v0.1",
+  "status": "approved"
+}

--- a/tests/fixtures/governance/procedure-template.invalid.missing-replay.synthetic.json
+++ b/tests/fixtures/governance/procedure-template.invalid.missing-replay.synthetic.json
@@ -1,0 +1,41 @@
+{
+  "approvalGate": {
+    "mode": "domain_owner",
+    "required": true
+  },
+  "evidenceRequirements": [
+    {
+      "description": "At least one canonical source file or governance document must be cited.",
+      "minAuthorityClass": "canonical",
+      "requirementId": "evidence:source-file"
+    }
+  ],
+  "outputContract": {
+    "permittedOutputs": [
+      "documentation_change"
+    ],
+    "schemaRef": "schemas/governance/institutional-action.v0.1.schema.json"
+  },
+  "ownerRepo": "SocioProphet/sociosphere",
+  "policyBasisRefs": [
+    "policy:human-in-command"
+  ],
+  "provenance": {
+    "createdAt": "2026-06-05T21:45:00Z",
+    "createdBy": "sociosphere-validator",
+    "nonSecret": true,
+    "sourceRepo": "SocioProphet/sociosphere"
+  },
+  "recordType": "ProcedureTemplate",
+  "requiredInputs": [
+    {
+      "kind": "context",
+      "name": "change_request",
+      "required": true
+    }
+  ],
+  "schemaVersion": "governance.procedure-template.v0.1",
+  "templateId": "procedure:invalid",
+  "title": "Invalid governed documentation update",
+  "version": "0.1.0"
+}

--- a/tests/fixtures/governance/procedure-template.valid.synthetic.json
+++ b/tests/fixtures/governance/procedure-template.valid.synthetic.json
@@ -1,0 +1,63 @@
+{
+  "approvalGate": {
+    "approverRoleRefs": [
+      "role:sociosphere-governance-owner"
+    ],
+    "mode": "domain_owner",
+    "required": true
+  },
+  "authorityBoundaryRef": "authority:sociosphere-governance-docs",
+  "evidenceRequirements": [
+    {
+      "acceptedKinds": [
+        "repo_file",
+        "document"
+      ],
+      "description": "At least one canonical source file or governance document must be cited.",
+      "minAuthorityClass": "canonical",
+      "requirementId": "evidence:source-file"
+    }
+  ],
+  "outputContract": {
+    "permittedOutputs": [
+      "documentation_change",
+      "review_summary"
+    ],
+    "schemaRef": "schemas/governance/institutional-action.v0.1.schema.json"
+  },
+  "ownerRepo": "SocioProphet/sociosphere",
+  "policyBasisRefs": [
+    "policy:human-in-command"
+  ],
+  "provenance": {
+    "createdAt": "2026-06-05T21:45:00Z",
+    "createdBy": "sociosphere-validator",
+    "nonSecret": true,
+    "sourceCommit": "synthetic",
+    "sourceRepo": "SocioProphet/sociosphere"
+  },
+  "recordType": "ProcedureTemplate",
+  "replayTest": {
+    "expectedReceiptKind": "ExecutionReceipt",
+    "fixtureRef": "tests/fixtures/governance/institutional-action.valid.synthetic.json",
+    "required": true
+  },
+  "requiredInputs": [
+    {
+      "kind": "context",
+      "name": "change_request",
+      "required": true
+    },
+    {
+      "kind": "evidence",
+      "name": "evidence_bundle",
+      "required": true,
+      "schemaRef": "schemas/governance/evidence-bundle.v0.1.schema.json"
+    }
+  ],
+  "schemaVersion": "governance.procedure-template.v0.1",
+  "status": "draft",
+  "templateId": "procedure:governed-doc-update",
+  "title": "Governed documentation update",
+  "version": "0.1.0"
+}

--- a/tools/review_workspace_mesh_gate1_generated_artifacts.py
+++ b/tools/review_workspace_mesh_gate1_generated_artifacts.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Review planned Workspace mesh artifacts without promoting Gate 1.
+
+The default safe workflow runs `tofu plan -out` and `tofu show -json`; it does
+not run `tofu apply`. Therefore the four local_file artifacts usually do not
+exist on disk yet. This script prefers real generated files when present, but
+falls back to the planned local_file contents in default-plan.json.
+
+It does not mutate files, mark Gate 1 complete, or authorize deployment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_FABRIC_REPO = Path.home() / "dev" / "prophet-platform-fabric-mlops-ts-suite"
+GENERATED_RELATIVE = Path("infra/google-workspace-ops-mesh/generated/google-workspace-ops-mesh")
+PLAN_JSON_NAME = "default-plan.json"
+EXPECTED_ARTIFACTS = {
+    "config.generated.json",
+    "clasp.generated.json",
+    "mesh-summary.generated.json",
+    "operator-next-steps.md",
+}
+RESOURCE_TO_ARTIFACT = {
+    "local_file.apps_script_config[0]": "config.generated.json",
+    "local_file.clasp_config[0]": "clasp.generated.json",
+    "local_file.mesh_summary[0]": "mesh-summary.generated.json",
+    "local_file.operator_next_steps[0]": "operator-next-steps.md",
+}
+REQUIRED_METADATA_FIELDS = {
+    "workstream",
+    "meeting_type",
+    "canonical_issue",
+    "dashboard_key",
+    "expected_outputs",
+}
+PRIVATE_KEY_MARKER = "-----BEGIN " + "PRIVATE KEY-----"
+FORBIDDEN_MARKERS = [
+    PRIVATE_KEY_MARKER,
+    "client_secret",
+    "refresh_token",
+    "access_token",
+]
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}")
+    sys.exit(1)
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        fail(f"missing artifact: {path}")
+
+
+def parse_json_text(name: str, text: str) -> dict:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON for {name}: {exc}")
+
+
+def assert_no_forbidden_markers(name: str, text: str) -> None:
+    for marker in FORBIDDEN_MARKERS:
+        if marker in text:
+            fail(f"forbidden marker {marker!r} found in {name}")
+
+
+def load_artifact_texts(generated_dir: Path) -> tuple[dict[str, str], str]:
+    existing = {name: generated_dir / name for name in EXPECTED_ARTIFACTS if (generated_dir / name).exists()}
+    if len(existing) == len(EXPECTED_ARTIFACTS):
+        return {name: path.read_text(encoding="utf-8") for name, path in existing.items()}, "generated_files"
+
+    plan_json_path = generated_dir / PLAN_JSON_NAME
+    if not plan_json_path.exists():
+        missing = sorted(EXPECTED_ARTIFACTS - set(existing))
+        fail(
+            "missing generated artifacts and plan JSON. Run make terraform-workspace-mesh-plan-safe first. "
+            + "Missing artifacts: "
+            + ", ".join(missing)
+        )
+
+    plan = parse_json_text(str(plan_json_path), plan_json_path.read_text(encoding="utf-8"))
+    artifact_texts: dict[str, str] = {}
+    for change in plan.get("resource_changes", []):
+        address = change.get("address")
+        artifact_name = RESOURCE_TO_ARTIFACT.get(address)
+        if not artifact_name:
+            continue
+        actions = change.get("change", {}).get("actions", [])
+        if actions not in (["create"], ["no-op"]):
+            fail(f"unexpected plan action for {address}: {actions}")
+        after = change.get("change", {}).get("after", {})
+        content = after.get("content")
+        if not isinstance(content, str):
+            fail(f"plan JSON missing planned content for {address}")
+        artifact_texts[artifact_name] = content
+
+    missing_from_plan = EXPECTED_ARTIFACTS - set(artifact_texts)
+    if missing_from_plan:
+        fail("plan JSON missing expected local_file artifacts: " + ", ".join(sorted(missing_from_plan)))
+
+    return artifact_texts, "plan_json"
+
+
+def review_config(text: str) -> None:
+    assert_no_forbidden_markers("config.generated.json", text)
+    config = parse_json_text("config.generated.json", text)
+
+    if config.get("dryRun") is not True:
+        fail("config.generated.json must keep dryRun=true")
+    if config.get("spreadsheetId") != "TODO_GOOGLE_SHEET_ID":
+        fail("config.generated.json must keep spreadsheetId placeholder before Gate 2")
+
+    metadata_fields = set(config.get("requiredMetadataFields", []))
+    missing = REQUIRED_METADATA_FIELDS - metadata_fields
+    if missing:
+        fail("config.generated.json missing metadata fields: " + ", ".join(sorted(missing)))
+
+    calendars = config.get("calendars", [])
+    if len(calendars) != 2:
+        fail("config.generated.json must contain exactly two prototype calendars")
+    for calendar in calendars:
+        calendar_id = calendar.get("calendarId", "")
+        if not calendar_id.startswith("TODO_"):
+            fail("config.generated.json calendarId must remain placeholder before Gate 2")
+
+    tabs = config.get("tabs", {})
+    if tabs.get("Meetings") != "Meetings" or tabs.get("Automations") != "Automations":
+        fail("config.generated.json tabs must map Meetings and Automations")
+
+
+def review_clasp(text: str) -> None:
+    assert_no_forbidden_markers("clasp.generated.json", text)
+    clasp = parse_json_text("clasp.generated.json", text)
+
+    if clasp.get("scriptId") != "TODO_APPS_SCRIPT_PROJECT_ID":
+        fail("clasp.generated.json must keep scriptId placeholder before Gate 2")
+    if clasp.get("rootDir") != "apps-script/google-workspace-ops-prototype":
+        fail("clasp.generated.json rootDir mismatch")
+
+    expected_files = [
+        "appsscript.json",
+        "setup.gs",
+        "sync-calendar-events-to-meetings.gs",
+        "parser-test.gs",
+        "seed-workspace-rows.gs",
+        "seed-dashboard-rows.gs",
+    ]
+    if clasp.get("filePushOrder") != expected_files:
+        fail("clasp.generated.json filePushOrder mismatch")
+
+
+def review_mesh_summary(text: str) -> None:
+    assert_no_forbidden_markers("mesh-summary.generated.json", text)
+    summary = parse_json_text("mesh-summary.generated.json", text)
+
+    if summary.get("mesh_state") != "prepared-but-not-deployed":
+        fail("mesh-summary.generated.json must keep mesh_state prepared-but-not-deployed")
+    if summary.get("dry_run") is not True:
+        fail("mesh-summary.generated.json must keep dry_run=true")
+    if summary.get("exported_secrets") != []:
+        fail("mesh-summary.generated.json must not export secrets")
+
+    placeholders = summary.get("placeholders", {})
+    expected_placeholder_values = {
+        "spreadsheet_id": "TODO_GOOGLE_SHEET_ID",
+        "apps_script_project_id": "TODO_APPS_SCRIPT_PROJECT_ID",
+        "cloud_vendor_strategy_calendar_id": "TODO_SP_CLOUD_VENDOR_STRATEGY_CALENDAR_ID",
+        "launch_council_calendar_id": "TODO_SP_LAUNCH_COUNCIL_CALENDAR_ID",
+    }
+    if placeholders != expected_placeholder_values:
+        fail("mesh-summary.generated.json placeholders mismatch")
+
+
+def review_operator_next_steps(text: str) -> None:
+    assert_no_forbidden_markers("operator-next-steps.md", text)
+    required_phrases = [
+        "Do not paste sensitive IDs into committed files",
+        "dry-run",
+        "Gate 2",
+        "review",
+    ]
+    for phrase in required_phrases:
+        if phrase not in text:
+            fail(f"operator-next-steps.md missing phrase: {phrase}")
+
+
+def main() -> None:
+    fabric_repo = Path(os.environ.get("FABRIC_REPO", DEFAULT_FABRIC_REPO)).expanduser()
+    generated_dir = fabric_repo / GENERATED_RELATIVE
+    artifact_texts, source = load_artifact_texts(generated_dir)
+
+    review_config(artifact_texts["config.generated.json"])
+    review_clasp(artifact_texts["clasp.generated.json"])
+    review_mesh_summary(artifact_texts["mesh-summary.generated.json"])
+    review_operator_next_steps(artifact_texts["operator-next-steps.md"])
+
+    print("PASS: Workspace mesh Gate 1 generated artifacts review passed")
+    print(f"fabric_repo={fabric_repo}")
+    print(f"generated_dir={generated_dir}")
+    print(f"source={source}")
+    print(f"artifacts={len(EXPECTED_ARTIFACTS)}")
+    print("dry_run=true")
+    print("gate1_promoted=false")
+    print("sensitive_values_printed=false")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate_governance_schemas.py
+++ b/tools/validate_governance_schemas.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Validate governance schema fixtures.
+
+This validator intentionally depends on jsonschema rather than a partial hand-rolled
+checker because the governance contracts use JSON Schema draft 2020-12 constraints.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    import jsonschema
+except ImportError as exc:  # pragma: no cover - exercised in CI setup failure only
+    print("governance-schemas: ERROR: jsonschema is required", file=sys.stderr)
+    raise SystemExit(2) from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "schemas" / "governance"
+FIXTURE_DIR = ROOT / "tests" / "fixtures" / "governance"
+
+CASES = {
+    "evidence-bundle": {
+        "schema": "evidence-bundle.v0.1.schema.json",
+        "valid": "evidence-bundle.valid.synthetic.json",
+        "invalid": "evidence-bundle.invalid.missing-policy.synthetic.json",
+    },
+    "procedure-template": {
+        "schema": "procedure-template.v0.1.schema.json",
+        "valid": "procedure-template.valid.synthetic.json",
+        "invalid": "procedure-template.invalid.missing-replay.synthetic.json",
+    },
+    "execution-receipt": {
+        "schema": "execution-receipt.v0.1.schema.json",
+        "valid": "execution-receipt.valid.synthetic.json",
+        "invalid": "execution-receipt.invalid.bad-digest.synthetic.json",
+    },
+    "institutional-action": {
+        "schema": "institutional-action.v0.1.schema.json",
+        "valid": "institutional-action.valid.synthetic.json",
+        "invalid": "institutional-action.invalid.missing-execution-receipt.synthetic.json",
+    },
+}
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"governance-schemas: ERROR: invalid JSON in {path}: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+
+def validate_case(name: str, spec: dict[str, str]) -> bool:
+    schema_path = SCHEMA_DIR / spec["schema"]
+    valid_path = FIXTURE_DIR / spec["valid"]
+    invalid_path = FIXTURE_DIR / spec["invalid"]
+
+    schema = load_json(schema_path)
+    valid_doc = load_json(valid_path)
+    invalid_doc = load_json(invalid_path)
+
+    try:
+        jsonschema.Draft202012Validator.check_schema(schema)
+    except jsonschema.SchemaError as exc:
+        print(f"governance-schemas: ERROR: schema invalid for {name}: {exc.message}", file=sys.stderr)
+        return False
+
+    validator = jsonschema.Draft202012Validator(schema)
+    valid_errors = sorted(validator.iter_errors(valid_doc), key=lambda err: list(err.path))
+    if valid_errors:
+        print(f"governance-schemas: ERROR: valid fixture failed for {name}", file=sys.stderr)
+        for err in valid_errors:
+            print(f"  {valid_path}: {list(err.path)}: {err.message}", file=sys.stderr)
+        return False
+
+    invalid_errors = sorted(validator.iter_errors(invalid_doc), key=lambda err: list(err.path))
+    if not invalid_errors:
+        print(f"governance-schemas: ERROR: invalid fixture unexpectedly passed for {name}", file=sys.stderr)
+        return False
+
+    print(f"governance-schemas: OK {name} ({len(invalid_errors)} expected invalid-fixture error(s))")
+    return True
+
+
+def main() -> int:
+    ok = True
+    for name, spec in CASES.items():
+        ok = validate_case(name, spec) and ok
+    if ok:
+        print(f"governance-schemas: OK ({len(CASES)} schema fixture pairs)")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_workspace_mesh_gate2_local_candidate_mapping.py
+++ b/tools/verify_workspace_mesh_gate2_local_candidate_mapping.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Verify an existing local-only Gate 2 candidate mapping file.
+
+This verifier is read-only. It checks that the local file exists, is ignored by
+Git, preserves dry-run posture, and contains the expected Gate 2 fields. It does
+not print candidate values.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCAL_FILE = ROOT / ".workspace-mesh" / "gate2-candidate-mapping.local.json"
+EXPECTED_PLACEHOLDERS = {
+    "spreadsheet_id": "TODO_GOOGLE_SHEET_ID",
+    "apps_script_project_id": "TODO_APPS_SCRIPT_PROJECT_ID",
+    "cloud_vendor_strategy_calendar_id": "TODO_SP_CLOUD_VENDOR_STRATEGY_CALENDAR_ID",
+    "launch_council_calendar_id": "TODO_SP_LAUNCH_COUNCIL_CALENDAR_ID",
+}
+ALLOWED_REVIEW_STATUSES = {
+    "not_started",
+    "candidate_recorded_local_only",
+    "source_evidence_recorded",
+    "reviewed_local_only",
+    "rejected_local_only",
+}
+PRIVATE_KEY_MARKER = "-----BEGIN " + "PRIVATE KEY-----"
+FORBIDDEN_MARKERS = [
+    PRIVATE_KEY_MARKER,
+    "client_secret",
+    "refresh_token",
+    "access_token",
+]
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}")
+    sys.exit(1)
+
+
+def load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"missing local candidate mapping: {path.relative_to(ROOT)}")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path.relative_to(ROOT)}: {exc}")
+
+
+def assert_git_ignored(path: Path) -> None:
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "--quiet", str(path.relative_to(ROOT))],
+            cwd=ROOT,
+            check=False,
+        )
+    except FileNotFoundError:
+        fail("git command not found; cannot verify ignore status")
+    if result.returncode != 0:
+        fail(f"local candidate file is not ignored by Git: {path.relative_to(ROOT)}")
+
+
+def main() -> None:
+    text = LOCAL_FILE.read_text(encoding="utf-8") if LOCAL_FILE.exists() else ""
+    for marker in FORBIDDEN_MARKERS:
+        if marker in text:
+            fail(f"forbidden marker found in local candidate mapping: {marker}")
+
+    data = load_json(LOCAL_FILE)
+    assert_git_ignored(LOCAL_FILE)
+
+    if data.get("mesh_state") != "prepared-but-not-deployed":
+        fail("mesh_state must remain prepared-but-not-deployed")
+    if data.get("gate_id") != "gate-2-id-substitution-review":
+        fail("gate_id mismatch")
+    if data.get("dry_run_required") is not True:
+        fail("dry_run_required must remain true")
+
+    candidate_values = data.get("candidate_values", {})
+    if set(candidate_values) != set(EXPECTED_PLACEHOLDERS):
+        fail("candidate_values keys mismatch")
+
+    placeholder_count = 0
+    local_candidate_count = 0
+    evidence_count = 0
+
+    for key, placeholder in EXPECTED_PLACEHOLDERS.items():
+        item = candidate_values.get(key, {})
+        if item.get("placeholder") != placeholder:
+            fail(f"placeholder mismatch for {key}")
+
+        review_status = item.get("review_status")
+        if review_status not in ALLOWED_REVIEW_STATUSES:
+            fail(f"unsupported review_status for {key}: {review_status}")
+
+        candidate_value = str(item.get("candidate_value", ""))
+        if not candidate_value:
+            fail(f"candidate_value missing for {key}")
+        if candidate_value == placeholder:
+            placeholder_count += 1
+        else:
+            local_candidate_count += 1
+
+        source_evidence = str(item.get("source_evidence", ""))
+        if source_evidence and not source_evidence.startswith("TODO_"):
+            evidence_count += 1
+
+    mode = "placeholder_copy" if local_candidate_count == 0 else "local_candidate_review"
+
+    print("PASS: Workspace mesh Gate 2 local candidate mapping verifies clean")
+    print(f"local_file={LOCAL_FILE.relative_to(ROOT)}")
+    print(f"mode={mode}")
+    print(f"fields={len(EXPECTED_PLACEHOLDERS)}")
+    print(f"placeholder_values={placeholder_count}")
+    print(f"local_candidate_values={local_candidate_count}")
+    print(f"source_evidence_records={evidence_count}")
+    print("git_ignored=true")
+    print("dry_run_required=true")
+    print("candidate_values_printed=false")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Superseded by #472, which reapplies the governance schema fixtures and validator from a clean current-main branch. This PR was based on stale main and had diverged, so it should not be merged.