### PR TITLE
Add regulated AI control-plane benchmark

### DIFF
--- a/docs/competitive/regulated-ai-control-plane-benchmark-v0.md
+++ b/docs/competitive/regulated-ai-control-plane-benchmark-v0.md
@@ -1,0 +1,108 @@
+# Regulated AI control-plane benchmark v0
+
+Status: draft
+Owner: Sociosphere governance layer
+Date: 2026-06-05
+
+## Purpose
+
+This benchmark captures visible product patterns from regulated AI systems and maps them into SocioProphet's open governance model. The goal is capability coverage with stronger transparency, provenance, replayability, authority boundaries, and validator-backed claims.
+
+This document is a design benchmark. It is not a claim that SocioProphet implements every runtime capability listed here.
+
+## Source set
+
+| Source | URL | Use |
+|---|---|---|
+| OpenAI Business | https://openai.com/business/ | Enterprise/product/security capability baseline |
+| ChatGPT Enterprise | https://chatgpt.com/business/enterprise/ | Enterprise agents, app/data connectors, security, deployment support |
+| Harvey platform | https://www.harvey.ai/ | Legal/professional-services product surface baseline |
+| Harvey security | https://www.harvey.ai/security | Legal AI security and enterprise-control baseline |
+| Ambience Healthcare | https://www.ambiencehealthcare.com/ | Healthcare documentation/coding/productivity baseline |
+| HealthBench paper | https://arxiv.org/abs/2505.08775 | Open rubric-driven medical evaluation baseline |
+| HealthBench Professional paper | https://arxiv.org/abs/2604.27470 | Clinician-task evaluation baseline |
+
+## Competitor/product patterns captured
+
+### OpenAI enterprise pattern
+
+OpenAI's business page presents ChatGPT for Business/Enterprise as a workforce AI layer with advanced models, tools, specialized agents, app integrations, enterprise security, admin controls, SAML SSO, and compliance claims. It explicitly mentions workspace agents that can run shared workflows, handle recurring tasks, and work across team tools. It also identifies integrations with company data sources such as Google Drive, SharePoint, GitHub, Dropbox, Box, and related apps, plus Codex and ChatGPT agent usage.
+
+SocioProphet mapping:
+
+- Workspace agents become governed `ProcedureTemplate` plus `InstitutionalAction` records.
+- App integrations become `ConnectorContract`, `SourcePermission`, and `AppActionPolicy` objects.
+- Enterprise admin controls become `Actor`, `Role`, `AuthorityBoundary`, and `CapabilityGrant` graph state.
+- Data privacy/security claims become `SecurityProfile`, `RetentionPolicy`, `ComplianceLogEvent`, and `ExecutionReceipt` objects.
+- Agent outputs require `EvidenceBundle`, approval posture, graph snapshot, and replay references before high-stakes use.
+
+### Harvey legal/professional-services pattern
+
+Harvey presents a unified legal/professional-services platform with Assistant, Vault, Knowledge, Agents, Ecosystem, Contract Intelligence, Command Center, and Shared Spaces surfaces. Its platform language includes asking questions, analyzing documents, drafting, securely storing and bulk-analyzing legal documents, legal/regulatory/tax research, end-to-end purpose-built agents, ecosystem access, source grounding, analytics, benchmarking, and secure shared collaboration.
+
+Harvey's security page identifies no-model-training commitments, SAML SSO, audit logs, IP allow-listing, data lifecycle management, contractual controls aligned with SOC 2, ISO, GDPR and other standards, independent testing, encryption in transit and at rest, role-based access controls, logical workspace separation, and regional processing options.
+
+SocioProphet mapping:
+
+- Legal assistant capabilities become human-in-command synthesis workflows with citation-first `EvidenceBundle` objects.
+- Vault/document review becomes evidence-vault workflow: `ExtractionReceipt`, `ReviewTable`, `RedactionPolicy`, `GraphSnapshot`.
+- Legal knowledge grounding becomes a source-authority and jurisdiction-aware knowledge registry.
+- Workflow agents become versioned `ProcedureTemplate` objects with approval gates and replay tests.
+- Security controls become machine-readable policies and receipts, not only vendor assertions.
+
+### Ambience healthcare pattern
+
+Ambience presents a healthcare AI platform for clinical documentation and coding, with published product claims around utilization, charting-time reduction, documentation quality, revenue integrity, compliance, real-time code suggestions, risk reduction, and specialty adaptation. The site states that the product adapts to workflows, documentation, and coding across 200+ specialties.
+
+SocioProphet mapping:
+
+- Clinical documentation becomes domain-specific `ProcedureTemplate` workflows with clinician approval gates.
+- Coding/revenue integrity becomes `PolicyBasis`, coding-rule evidence, and execution receipts.
+- Specialty adaptation becomes domain packs with explicit source authority, policy basis, and benchmark coverage.
+- Utilization/time-saved claims become `WorkflowBench` metrics with transparent adoption, correction, override, and quality dimensions.
+- Compliance/risk claims become retained evidence, graph snapshots, and release/admission validators.
+
+### HealthBench evaluation pattern
+
+HealthBench defines an open health-model benchmark using 5,000 multi-turn conversations and physician-created rubrics. HealthBench Professional extends this evaluation posture to real clinician ChatGPT tasks, organized around care consult, writing/documentation, and medical research, with physician-written conversations and rubric adjudication.
+
+SocioProphet mapping:
+
+- Domain evaluations become `DomainBench` objects.
+- Workflow evaluations become `WorkflowBench` objects.
+- Governance and authority checks become `GovernanceBench` objects.
+- Replay and evidence retention checks become `ReplayBench` objects.
+- Rubrics must carry source lineage, domain owner, adjudication method, fixture coverage, and versioned result records.
+
+## Parity-plus governance bar
+
+Every captured capability must be upgraded into a governed SocioProphet primitive before it becomes a product claim:
+
+1. Actor, role, authority boundary, policy basis, and capability grant are explicit.
+2. Evidence bundle includes provenance, source authority class, content digest, and contradiction hooks.
+3. Human-in-command separation exists between synthesis, recommendation, approval, override, and execution.
+4. Execution receipt includes artifact refs, graph snapshot refs, replay posture, and determinism class.
+5. Connector actions are classified by read/write/action risk and retain source-system permission posture.
+6. Benchmarks expose rubric lineage, task coverage, pass/fail thresholds, failure classes, and replayable scoring.
+7. Runtime claims require schemas, fixtures, validators, graph queries, and release-readiness admission.
+
+## Immediate schema backlog
+
+| Object | Reason |
+|---|---|
+| `GovernanceBench` | Test authority, policy, approval, override, and audit behavior. |
+| `WorkflowBench` | Test operational workflow quality, adoption, timing, correction, and override metrics. |
+| `DomainBench` | Test domain-specific rubrics, task coverage, and expert adjudication. |
+| `ReplayBench` | Test replayability, graph snapshot availability, and evidence retention. |
+| `ConnectorContract` | Represent external data/tool connectors, scopes, and permission inheritance. |
+| `CapabilityGrant` | Bind actors/roles to allowed tool, app, or agent capabilities. |
+| `AppActionPolicy` | Classify app/plugin actions and enforce confirmation/approval rules. |
+| `SecurityProfile` | Capture identity, region, retention, encryption, audit, and contractual controls. |
+| `ExtractionReceipt` | Prove document/data extraction lineage and review-table provenance. |
+| `GraphSnapshot` | Pin graph state used by action, benchmark, release, or review decisions. |
+| `ComplianceLogEvent` | Represent retained compliance/audit events and export posture. |
+| `RetentionPolicy` | Represent retention, deletion, export, and legal-hold posture. |
+
+## Boundary
+
+This benchmark records product-pattern requirements. It does not claim implementation completeness, medical/legal fitness, production certification, or competitive equivalence. Downstream work must add schema stubs, fixtures, validators, HellGraph query fixtures, AgentPlane receipts, and Prophet Platform admission tests before product-readiness claims are allowed.

--- a/registry/competitive-capability-map-v0.yaml
+++ b/registry/competitive-capability-map-v0.yaml
@@ -1,0 +1,112 @@
+version: 0.1.0
+status: draft
+date: 2026-06-05
+owner: sociosphere-governance
+subject: regulated-ai-control-plane-capability-map
+purpose: Map visible regulated AI product patterns into SocioProphet governed primitives.
+sources:
+  - id: openai-business
+    name: OpenAI Business
+    url: https://openai.com/business/
+    pattern: enterprise_ai_workspace
+  - id: openai-enterprise
+    name: ChatGPT Enterprise
+    url: https://chatgpt.com/business/enterprise/
+    pattern: enterprise_agents_connectors_security
+  - id: harvey-platform
+    name: Harvey platform
+    url: https://www.harvey.ai/
+    pattern: legal_professional_services_ai_platform
+  - id: harvey-security
+    name: Harvey security
+    url: https://www.harvey.ai/security
+    pattern: enterprise_security_controls
+  - id: ambience-healthcare
+    name: Ambience Healthcare
+    url: https://www.ambiencehealthcare.com/
+    pattern: healthcare_documentation_coding_workflow
+  - id: healthbench
+    name: HealthBench
+    url: https://arxiv.org/abs/2505.08775
+    pattern: physician_rubric_health_evaluation
+  - id: healthbench-professional
+    name: HealthBench Professional
+    url: https://arxiv.org/abs/2604.27470
+    pattern: clinician_task_evaluation
+capabilities:
+  - id: workspace-agents
+    source_patterns: [openai-business, openai-enterprise]
+    observed_capability: Shared agents for recurring workflows and team-tool usage.
+    governed_analogue: Governed agents represented as ProcedureTemplate and InstitutionalAction records.
+    required_objects: [ProcedureTemplate, InstitutionalAction, CapabilityGrant, ExecutionReceipt, WorkflowBench]
+    governance_delta: approval_gates_replay_receipts_graph_snapshots
+  - id: app-connectors
+    source_patterns: [openai-business, openai-enterprise, harvey-platform]
+    observed_capability: Connectors to enterprise apps, data sources, and embedded workflow tools.
+    governed_analogue: Connector registry with source permissions, action controls, and inherited permission posture.
+    required_objects: [ConnectorContract, SourcePermission, AppActionPolicy, ExecutionReceipt]
+    governance_delta: default_deny_scope_attestation_action_receipts
+  - id: legal-assistant
+    source_patterns: [harvey-platform]
+    observed_capability: Question answering, analysis, drafting, and source-grounded legal work.
+    governed_analogue: Human-in-command assistant with citation-first EvidenceBundle and authority checks.
+    required_objects: [InstitutionalAction, EvidenceBundle, PolicyBasis, AuthorityBoundary]
+    governance_delta: citation_provenance_jurisdiction_contradiction_tracking
+  - id: evidence-vault
+    source_patterns: [harvey-platform]
+    observed_capability: Secure document vault, review, extraction, and report generation.
+    governed_analogue: Evidence vault with extraction receipts, review-table lineage, graph snapshots, and redaction posture.
+    required_objects: [EvidenceBundle, ExtractionReceipt, ReviewTable, RedactionPolicy, GraphSnapshot]
+    governance_delta: extraction_lineage_redaction_policy_replay
+  - id: workflow-agents
+    source_patterns: [harvey-platform, openai-business]
+    observed_capability: Custom workflow agents, templates, conditionals, permissions, and sharing.
+    governed_analogue: Procedure-template-to-agent lane with role gates, capability grants, approval checkpoints, and replay tests.
+    required_objects: [ProcedureTemplate, CapabilityGrant, ApprovalEvent, ExecutionReceipt, WorkflowBench]
+    governance_delta: versioned_template_diff_human_approval_replay_test
+  - id: enterprise-security
+    source_patterns: [openai-business, harvey-security]
+    observed_capability: SSO, audit logs, role controls, data region posture, encryption, no-training statements, and security certifications.
+    governed_analogue: Machine-readable SecurityProfile, RetentionPolicy, ComplianceLogEvent, and audit receipts.
+    required_objects: [SecurityProfile, RetentionPolicy, ComplianceLogEvent, ExecutionReceipt]
+    governance_delta: enforceable_policy_objects_receipts_exports_retention
+  - id: clinical-documentation-coding
+    source_patterns: [ambience-healthcare]
+    observed_capability: Clinical documentation, coding support, workflow adaptation, documentation quality, and revenue-integrity support.
+    governed_analogue: Domain-specific procedure templates with clinician approval, coding-policy evidence, and workflow metrics.
+    required_objects: [ProcedureTemplate, EvidenceBundle, PolicyBasis, ExecutionReceipt, DomainBench, WorkflowBench]
+    governance_delta: clinician_approval_policy_trace_replay_quality_metrics
+  - id: domain-benchmarks
+    source_patterns: [healthbench, healthbench-professional]
+    observed_capability: Expert-rubric multi-turn health evaluation and clinician-task evaluation.
+    governed_analogue: DomainBench, WorkflowBench, GovernanceBench, and ReplayBench with rubric lineage and replayable scoring.
+    required_objects: [DomainBench, WorkflowBench, GovernanceBench, ReplayBench]
+    governance_delta: open_rubric_lineage_fixture_coverage_replayable_scores
+parity_plus_requirements:
+  - explicit_actor_role_authority_policy_capability
+  - evidence_bundle_with_provenance_digest_authority_class
+  - human_in_command_synthesis_recommendation_approval_execution_split
+  - execution_receipt_with_artifacts_graph_snapshot_replay_posture
+  - connector_actions_classified_by_read_write_action_risk
+  - benchmarks_with_rubric_lineage_failure_classes_thresholds
+  - runtime_claims_require_schema_fixture_validator_graph_query_admission
+next_schema_backlog:
+  - GovernanceBench
+  - WorkflowBench
+  - DomainBench
+  - ReplayBench
+  - ConnectorContract
+  - CapabilityGrant
+  - AppActionPolicy
+  - SecurityProfile
+  - ExtractionReceipt
+  - ReviewTable
+  - RedactionPolicy
+  - GraphSnapshot
+  - ComplianceLogEvent
+  - RetentionPolicy
+limitations:
+  - Capability map records product patterns, not runtime implementation claims.
+  - Source review should be refreshed before customer-facing use.
+  - Registry does not yet include per-capability acceptance tests.
+  - Registry does not yet include market scoring or pricing comparisons.


### PR DESCRIPTION
## Summary

- Adds `docs/competitive/regulated-ai-control-plane-benchmark-v0.md`.
- Adds `registry/competitive-capability-map-v0.yaml`.
- Maps visible regulated AI product patterns from OpenAI enterprise surfaces, Harvey legal/professional-services AI, Ambience healthcare AI, and HealthBench-style evaluation into SocioProphet governed primitives.
- Captures the parity-plus bar: evidence bundles, authority boundaries, human-in-command separation, execution receipts, graph snapshots, connector policies, and validator-backed runtime claims.

## Rationale

The user asked to evaluate competition and ensure SocioProphet captures competitor capability patterns while aligning them to a stronger governance and transparency model. This PR records that as a bounded benchmark and machine-readable capability map.

## Validation

Documentation/registry-only change. No runtime code changed.