### PR TITLE
Probe Prophet Cloud execution artifacts

### DIFF
--- a/architecture/service-register/probe-prophet-cloud-artifacts.txt
+++ b/architecture/service-register/probe-prophet-cloud-artifacts.txt
@@ -1,0 +1,1 @@
+Observable CI probe for Prophet Cloud execution artifacts. Do not merge.


### PR DESCRIPTION
Closed as probe-complete.

This PR intentionally added only a temporary marker under `architecture/service-register/` to force observable PR-triggered CI. It was not implementation content and should not be merged.

Outcome captured: `service-register` passed on head `511a087db3804e988a0f9441c203b5b5117f7bb8`; the new `Check Prophet Cloud execution artifacts` step passed as part of the full service-register validation chain.