### PR TITLE
Add Health-AI Evaluation Readiness Fixture

### DIFF
--- a/registry/health-ai/health-ai-eval-readiness.v0.json
+++ b/registry/health-ai/health-ai-eval-readiness.v0.json
@@ -1,0 +1,13 @@
+{
+  "capability_id": "health_ai_eval_and_clinical_value_v0",
+  "state": "planning_only",
+  "production_ready": false,
+  "patient_care_action": false,
+  "autonomous_clinical_action": false,
+  "customer_facing_healthcare_claim": false,
+  "evidence": [
+    "SocioProphet/prophet-core-contracts#18",
+    "SocioProphet/sherlock-search#64"
+  ],
+  "next_allowed_action": "planning_record_only"
+}

--- a/tests/fixtures/health-ai/health-ai-eval-readiness.planning.json
+++ b/tests/fixtures/health-ai/health-ai-eval-readiness.planning.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "0.1.0",
+  "capability_id": "health_ai_eval_and_clinical_value_v0",
+  "readiness_state": "planning_only",
+  "production_ready": false,
+  "patient_care_action": false,
+  "autonomous_clinical_action": false,
+  "customer_facing_healthcare_claim": false,
+  "source_repos": [
+    "SocioProphet/prophet-core-contracts",
+    "SocioProphet/sherlock-search",
+    "SocioProphet/sociosphere"
+  ],
+  "validated_inputs": [
+    "prophet-core-contracts:schemas/health-eval-rubric.schema.json",
+    "prophet-core-contracts:schemas/clinical-value-claim.schema.json",
+    "sherlock-search:schemas/health-ai-search-packet.schema.json"
+  ],
+  "blocked_from": [
+    "production_ready",
+    "patient_care_action",
+    "autonomous_clinical_action",
+    "customer_facing_healthcare_claim",
+    "real_clinical_data_processing",
+    "protected_benchmark_reproduction"
+  ],
+  "next_allowed_action": "planning_record_only",
+  "notes": "Healthcare AI evaluation and clinical value work is registered as planning-only. Ambience-derived claims remain external source claims. HealthBench-derived content remains benchmark-design guidance without protected examples, answer keys, or canary content."
+}

--- a/tools/validate_health_ai_readiness.py
+++ b/tools/validate_health_ai_readiness.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tests" / "fixtures" / "health-ai" / "health-ai-eval-readiness.planning.json"
+REGISTRY = ROOT / "registry" / "health-ai" / "health-ai-eval-readiness.v0.json"
+
+REQUIRED_BLOCKS = {
+    "production_ready",
+    "patient_care_action",
+    "autonomous_clinical_action",
+    "customer_facing_healthcare_claim",
+    "real_clinical_data_processing",
+    "protected_benchmark_reproduction"
+}
+
+def load(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+def main() -> int:
+    errors: list[str] = []
+
+    try:
+        fixture = load(FIXTURE)
+        registry = load(REGISTRY)
+    except Exception as exc:
+        print(f"ERR: failed to load readiness artifacts: {exc}", file=sys.stderr)
+        return 2
+
+    for name, record in (("fixture", fixture), ("registry", registry)):
+        if record.get("production_ready") is not False:
+            errors.append(f"{name}: production_ready must be false")
+        if record.get("patient_care_action") is not False:
+            errors.append(f"{name}: patient_care_action must be false")
+        if record.get("autonomous_clinical_action") is not False:
+            errors.append(f"{name}: autonomous_clinical_action must be false")
+        if record.get("customer_facing_healthcare_claim") is not False:
+            errors.append(f"{name}: customer_facing_healthcare_claim must be false")
+        if record.get("next_allowed_action") != "planning_record_only":
+            errors.append(f"{name}: next_allowed_action must be planning_record_only")
+
+    if fixture.get("readiness_state") != "planning_only":
+        errors.append("fixture readiness_state must be planning_only")
+    if registry.get("state") != "planning_only":
+        errors.append("registry state must be planning_only")
+
+    missing = REQUIRED_BLOCKS - set(fixture.get("blocked_from", []))
+    if missing:
+        errors.append(f"fixture missing blocked_from entries: {sorted(missing)}")
+
+    required_inputs = [
+        "health-eval-rubric.schema.json",
+        "clinical-value-claim.schema.json",
+        "health-ai-search-packet.schema.json"
+    ]
+    inputs = fixture.get("validated_inputs", [])
+    for fragment in required_inputs:
+        if not any(fragment in item for item in inputs):
+            errors.append(f"fixture missing validated input containing {fragment}")
+
+    if errors:
+        print("ERR: Health AI readiness validation failed", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 2
+
+    print("Health AI readiness validates as planning_only.")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Registers the healthcare AI evaluation tranche in Sociosphere with planning-only posture.

Validation:
- python3 tools/validate_health_ai_readiness.py

Safety posture:
- readiness_state=planning_only
- production_ready=false
- patient_care_action=false
- autonomous_clinical_action=false
- customer_facing_healthcare_claim=false

References prior green tranches:
- SocioProphet/prophet-core-contracts#18
- SocioProphet/sherlock-search#64