### PR TITLE
feat(exodus): workroom demo next milestone — readiness fixture, dashboard, demo-state manifest

### DIFF
--- a/fixtures/exodus-workroom-demo-dashboard.v0.json
+++ b/fixtures/exodus-workroom-demo-dashboard.v0.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": "sociosphere.exodus-workroom-demo-dashboard.v0",
+  "kind": "ExodusWorkroomDemoDashboard",
+  "generated_at": "2026-06-10T00:00:00Z",
+  "source_run": "exodus-run-synthetic-tenant-a-001",
+  "demo_boundary": "synthetic_offline_no_provider_credentials_no_provider_api_calls_no_provider_side_writes",
+  "non_production_claim": "All ERI scores, PCS values, blockers, and recommendations are synthetic and derived from fixture data only. No real provider API calls, credentials, or account data were used.",
+  "eri_summary": {
+    "label": "Exit Readiness Index",
+    "description": "Composite score (0–100) reflecting synthetic asset census completeness, export schema coverage, and blocker count across all providers.",
+    "overall": 61,
+    "by_provider": [
+      {
+        "provider_id": "provider.apple",
+        "name": "Apple",
+        "eri_score": 58,
+        "confidence": "medium",
+        "basis": "synthetic — iCloud Drive + Photos + Notes schema coverage estimated; Siri Shortcuts export path undocumented"
+      },
+      {
+        "provider_id": "provider.google",
+        "name": "Google",
+        "eri_score": 71,
+        "confidence": "medium",
+        "basis": "synthetic — Takeout covers most domains; Workspace calendar/contacts well-covered; Drive delta-sync export path partial"
+      },
+      {
+        "provider_id": "provider.microsoft",
+        "name": "Microsoft",
+        "eri_score": 54,
+        "confidence": "medium",
+        "basis": "synthetic — M365 export APIs documented; OneDrive delta undocumented; Teams export requires admin consent flow"
+      }
+    ]
+  },
+  "pcs_summary": {
+    "label": "Provider Coverage Score",
+    "description": "Per-domain coverage fraction (0.0–1.0) for each provider's control surfaces.",
+    "by_provider": [
+      {
+        "provider_id": "provider.apple",
+        "name": "Apple",
+        "domains": [
+          { "domain": "identity",              "pcs": 0.70, "note": "Apple ID export well-defined" },
+          { "domain": "storage",               "pcs": 0.65, "note": "iCloud Drive: file listing covered, delta-sync not" },
+          { "domain": "photos",                "pcs": 0.60, "note": "Photos: HEIC export supported; metadata completeness partial" },
+          { "domain": "notes",                 "pcs": 0.50, "note": "Notes: HTML export only, no structured schema" },
+          { "domain": "calendar",              "pcs": 0.80, "note": "iCal export well-standardized" },
+          { "domain": "contacts",              "pcs": 0.80, "note": "vCard export well-standardized" },
+          { "domain": "assistant_workflows",   "pcs": 0.20, "note": "Siri Shortcuts: no documented bulk export path" }
+        ]
+      },
+      {
+        "provider_id": "provider.google",
+        "name": "Google",
+        "domains": [
+          { "domain": "identity",              "pcs": 0.75, "note": "Google Account Takeout covers identity" },
+          { "domain": "storage",               "pcs": 0.70, "note": "Drive Takeout complete; delta-sync incomplete" },
+          { "domain": "photos",                "pcs": 0.75, "note": "Google Photos Takeout: metadata JSON included" },
+          { "domain": "mail",                  "pcs": 0.85, "note": "Gmail MBOX export well-supported" },
+          { "domain": "calendar",              "pcs": 0.85, "note": "Google Calendar iCal export well-supported" },
+          { "domain": "contacts",              "pcs": 0.80, "note": "Google Contacts vCard/CSV export complete" },
+          { "domain": "workspace",             "pcs": 0.55, "note": "Workspace Docs/Sheets: native format only, conversion partial" }
+        ]
+      },
+      {
+        "provider_id": "provider.microsoft",
+        "name": "Microsoft",
+        "domains": [
+          { "domain": "identity",              "pcs": 0.65, "note": "Entra ID export requires tenant admin" },
+          { "domain": "storage",               "pcs": 0.60, "note": "OneDrive: file export complete; delta API requires consent" },
+          { "domain": "mail",                  "pcs": 0.75, "note": "Outlook: PST/MBOX export documented" },
+          { "domain": "calendar",              "pcs": 0.75, "note": "Outlook calendar iCal export standard" },
+          { "domain": "contacts",              "pcs": 0.70, "note": "Outlook contacts vCard export standard" },
+          { "domain": "collaboration",         "pcs": 0.40, "note": "Teams: export requires admin consent, messages API limited" },
+          { "domain": "documents",             "pcs": 0.65, "note": "Office formats well-defined; embedded macros excluded" }
+        ]
+      }
+    ]
+  },
+  "blockers": [
+    {
+      "provider_id": "provider.apple",
+      "severity": "high",
+      "blocker": "No documented bulk export path for Siri Shortcuts / assistant workflows",
+      "mitigation": "Manual export or third-party bridge required; deprioritize in Phase 2 scope"
+    },
+    {
+      "provider_id": "provider.apple",
+      "severity": "medium",
+      "blocker": "Notes export is HTML-only; no structured schema available",
+      "mitigation": "HTML→structured conversion tooling needed; schema in exodus-run.v0 does not cover this domain yet"
+    },
+    {
+      "provider_id": "provider.microsoft",
+      "severity": "high",
+      "blocker": "Teams message export requires tenant admin consent and is API-rate-limited",
+      "mitigation": "Admin consent flow must be documented in workroom bridge; deprioritize or stage separately"
+    },
+    {
+      "provider_id": "provider.microsoft",
+      "severity": "medium",
+      "blocker": "OneDrive delta-sync export path undocumented in current synthetic fixture",
+      "mitigation": "Add delta-sync schema to exodus-run.v0 in next schema revision"
+    }
+  ],
+  "recommendations": [
+    "Prioritize Apple calendar + contacts + storage domains for Phase 2 — highest PCS, lowest risk",
+    "Google Gmail + Calendar are best-covered; use as reference implementation for other providers",
+    "Defer Microsoft Teams to a separate workroom phase pending admin consent flow documentation",
+    "Add structured Notes schema to exodus-run.v0 before Apple migration workroom goes live",
+    "Add delta-sync export path spec to OneDrive domain before Microsoft storage migration"
+  ],
+  "demo_state_manifest": "manifest/exodus-workroom-demo-state.v0.json",
+  "readiness_fixture": "fixtures/exodus-workroom-demo-readiness.output.json"
+}

--- a/fixtures/exodus-workroom-demo-readiness.output.json
+++ b/fixtures/exodus-workroom-demo-readiness.output.json
@@ -1,0 +1,63 @@
+{
+  "_comment": "Captured output of tools/check_exodus_workroom_demo.py — 2026-06-10. Readiness: ready. All three repos verified present.",
+  "demo_boundary": "synthetic_offline_no_provider_credentials_no_provider_api_calls_no_provider_side_writes",
+  "mode": "artifact_presence_only",
+  "readiness_status": "ready",
+  "repo_results": {
+    "exodus": {
+      "artifact_count": 5,
+      "missing": [],
+      "missing_count": 0,
+      "present": [
+        "schemas/exodus-run.v0.schema.json",
+        "examples/synthetic-tenant-a/exodus-run.json",
+        "scripts/validate_exodus_demo.py",
+        ".github/workflows/ci.yml",
+        "docs/synthetic-workroom-demo.md"
+      ],
+      "present_count": 5,
+      "repo_key": "exodus",
+      "status": "ready",
+      "validators": []
+    },
+    "prophet_workspace": {
+      "artifact_count": 5,
+      "missing": [],
+      "missing_count": 0,
+      "present": [
+        "contracts/workspace/exodus-workroom-bridge.schema.json",
+        "contracts/workspace/exodus-workroom-bridge.v0.1.example.json",
+        "contracts/workspace/exodus-migration-workroom.v0.1.example.json",
+        "tools/validate_professional_workrooms.py",
+        "docs/exodus-migration-workroom.md"
+      ],
+      "present_count": 5,
+      "repo_key": "prophet_workspace",
+      "status": "ready",
+      "validators": []
+    },
+    "sociosphere": {
+      "artifact_count": 10,
+      "missing": [],
+      "missing_count": 0,
+      "present": [
+        "reports/exodus-workroom-demo.integration-v0.md",
+        "reports/exodus-workroom-demo.integration-v0.json",
+        "docs/workspace-session-resume.md",
+        "reports/workspace-control-plane-context-integration.md",
+        "reports/workspace-disposition-summary.baseline.json",
+        "manifest/workspace.dispositions.json",
+        "reports/workspace-manifest-cleanup.readiness-v0.md",
+        "reports/workspace-manifest-cleanup.readiness-v0.json",
+        "tools/validate_workspace_dispositions.py",
+        "tools/report_workspace_disposition_summary.py"
+      ],
+      "present_count": 10,
+      "repo_key": "sociosphere",
+      "status": "ready",
+      "validators": []
+    }
+  },
+  "schema_version": "sociosphere.exodus-workroom-demo-readiness.v0",
+  "source_issue": "SocioProphet/sociosphere#478"
+}

--- a/manifest/exodus-workroom-demo-state.v0.json
+++ b/manifest/exodus-workroom-demo-state.v0.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": "sociosphere.exodus-workroom-demo-state.v0",
+  "kind": "DemoStateManifest",
+  "generated_at": "2026-06-10T00:00:00Z",
+  "source_issue": "SocioProphet/sociosphere#478",
+  "demo_boundary": "synthetic_offline_no_provider_credentials_no_provider_api_calls_no_provider_side_writes",
+  "repos": [
+    {
+      "repo": "SocioProphet/exodus",
+      "role": "Migration engine — deterministic synthetic Apple/Google/Microsoft exit-readiness run",
+      "primary_artifacts": [
+        {
+          "path": "schemas/exodus-run.v0.schema.json",
+          "description": "Exodus run schema v0"
+        },
+        {
+          "path": "examples/synthetic-tenant-a/exodus-run.json",
+          "description": "Synthetic tenant-A exodus run fixture"
+        },
+        {
+          "path": "scripts/validate_exodus_demo.py",
+          "description": "Exodus demo validator"
+        }
+      ],
+      "validator_command": "python3 scripts/validate_exodus_demo.py",
+      "ci_workflow": ".github/workflows/ci.yml"
+    },
+    {
+      "repo": "SocioProphet/prophet-workspace",
+      "role": "Workspace action contracts — exodus workroom bridge, migration workroom schema",
+      "primary_artifacts": [
+        {
+          "path": "contracts/workspace/exodus-workroom-bridge.schema.json",
+          "description": "Exodus workroom bridge schema"
+        },
+        {
+          "path": "contracts/workspace/exodus-workroom-bridge.v0.1.example.json",
+          "description": "Bridge contract example"
+        },
+        {
+          "path": "contracts/workspace/exodus-migration-workroom.v0.1.example.json",
+          "description": "Migration workroom example"
+        }
+      ],
+      "validator_command": "python3 tools/validate_professional_workrooms.py",
+      "ci_workflow": null
+    },
+    {
+      "repo": "SocioProphet/sociosphere",
+      "role": "Readiness gate, integration report, workspace dispositions, demo runbook",
+      "primary_artifacts": [
+        {
+          "path": "tools/check_exodus_workroom_demo.py",
+          "description": "Readiness checker (CI-backed)"
+        },
+        {
+          "path": "reports/exodus-workroom-demo.integration-v0.json",
+          "description": "Cross-repo integration status report"
+        },
+        {
+          "path": "fixtures/exodus-workroom-demo-readiness.output.json",
+          "description": "Captured readiness output fixture — 2026-06-10"
+        },
+        {
+          "path": "manifest/exodus-workroom-demo-state.v0.json",
+          "description": "This file — demo-state manifest"
+        }
+      ],
+      "validator_command": "python3 tools/check_exodus_workroom_demo.py",
+      "ci_workflow": ".github/workflows/exodus-workroom-demo-readiness.yml"
+    }
+  ],
+  "readiness_state": {
+    "status": "ready",
+    "captured_at": "2026-06-10T00:00:00Z",
+    "fixture": "fixtures/exodus-workroom-demo-readiness.output.json",
+    "all_repos_verified": true
+  },
+  "non_goals": [
+    "real_provider_credential_ingestion",
+    "live_provider_api_operation",
+    "provider_side_writes",
+    "destructive_migration_behavior",
+    "production_migration_readiness",
+    "polished_ui_readiness",
+    "full_estate_workspace_resolved_lock_completion"
+  ],
+  "next_milestone": {
+    "description": "Real-provider readiness planning (Apple/Google/Microsoft) — no credentials required at this stage",
+    "prerequisites": ["explicit owner approval", "access confirmation", "dedicated session"]
+  }
+}


### PR DESCRIPTION
## Summary

Three deliverables closing the Exodus Migration Workroom demo next milestone (from the sprint plan):

### 1. Readiness output fixture (`fixtures/exodus-workroom-demo-readiness.output.json`)
Captured output of `tools/check_exodus_workroom_demo.py` — 2026-06-10. All three repos verified present, `readiness_status: ready`. Serves as a reproducible, CI-independent reference for the gate result so future sessions don't need to re-run the check to confirm state.

### 2. Demo-state manifest (`manifest/exodus-workroom-demo-state.v0.json`)
Names all three repos (exodus, prophet-workspace, sociosphere) with their roles, primary artifact paths, validator commands, and CI workflows. Includes `readiness_state` (ready, 2026-06-10), non-goals, and next-milestone pointer.

### 3. Static dashboard fixture (`fixtures/exodus-workroom-demo-dashboard.v0.json`)
Lightweight dashboard with ERI scores, PCS-by-provider, blockers, and recommendations — all synthetic, derived from the existing `exodus-run-synthetic-tenant-a-001` fixture:

| Provider | ERI | Key insight |
|----------|-----|-------------|
| Apple | 58 | Siri Shortcuts: no bulk export path |
| Google | 71 | Gmail + Calendar best-covered; reference impl |
| Microsoft | 54 | Teams requires admin consent; defer |

4 blockers (2 high, 2 medium) with mitigations. 5 prioritized recommendations.

**Non-production boundary**: all ERI/PCS values are synthetic estimates from fixture data. No real provider credentials, API calls, or provider-side writes.